### PR TITLE
Check that hardware sequencing is enabled before interacting with the flash

### DIFF
--- a/source/tool/chipsec/hal/spi.py
+++ b/source/tool/chipsec/hal/spi.py
@@ -525,6 +525,13 @@ class SPI:
 
         return cycle_done
 
+    def check_hardware_sequencing(self):
+        # Test if the flash decriptor is valid (and hardware sequencing enabled)
+        hsfsts = self.spi_reg_read( self.hsfs_off, 2 )
+        if not (hsfsts & Cfg.PCH_RCBA_SPI_HSFSTS_FDV):
+            logger().error("HSFS.FDV is 0, hardware sequencing is disabled")
+            raise SpiRuntimeError("Chipset does not support hardware sequencing")
+
     #
     # SPI Flash operations
     #
@@ -545,6 +552,9 @@ class SPI:
         #return self.write_spi( spi_fla, struct.unpack('B'*len(buf), buf) )
 
     def read_spi(self, spi_fla, data_byte_count ):
+
+        self.check_hardware_sequencing()
+
         buf = []
         dbc = SPI_READ_WRITE_DEF_DBC
         if (data_byte_count >= SPI_READ_WRITE_MAX_DBC):
@@ -595,6 +605,9 @@ class SPI:
         return buf
 
     def write_spi(self, spi_fla, buf ):
+
+        self.check_hardware_sequencing()
+
         write_ok = True
         data_byte_count = len(buf)
         dbc = 4
@@ -635,6 +648,9 @@ class SPI:
         return write_ok
 
     def erase_spi_block(self, spi_fla ):
+
+        self.check_hardware_sequencing()
+
         if logger().UTIL_TRACE or logger().VERBOSE:
             logger().log( "[spi] Erasing SPI Flash block @ 0x%X" % spi_fla )
 


### PR DESCRIPTION
Currently, no check is performed to detect that hardware sequencing is enabled (HSFS.FDV). When such configuration is encountered, although the base and limit values are meaningless, Chipsec still interpret them and try to read/write to the flash.

This patch add a method to the SPI HAL to detect such configuration. A call to this method is added to the beginning of each SPI operation.

By doing so, it is still possible to run 'chipsec_utils.py spi info' to get some information on the flash.