### PR TITLE
Fix Linux driver build on i386

### DIFF
--- a/source/drivers/linux/Makefile
+++ b/source/drivers/linux/Makefile
@@ -6,11 +6,9 @@ VERSION=
 
 #obj-m += chipsec.o
 
-
-#ifeq ($(shell uname -m),x86_64)
 ifeq ($(ARCH),i386)
 obj-m += chipsec.o
-chipsec-objs := chipsec_ko.o i386/cpu.o
+chipsec-objs := chipsec_km.o i386/cpu.o
 all:	clean chipsec32
 else
 obj-m += chipsec.o
@@ -18,17 +16,13 @@ chipsec-objs := chipsec_km.o amd64/cpu.o
 all:	clean chipsec64
 endif
 
-chipsec64 : clean 
-	echo $(ARCH)
-	echo $(obj-m)
-	echo $(chipsec-objs)
+chipsec64: clean
 	nasm -f elf64 -o amd64/cpu.o amd64/cpu.asm;
 	make -C $(KERNEL_SRC_DIR) SUBDIRS=`pwd` modules
-	cd ../../tool/chipsec/helper/linux; make
-chipsec32 : clean
+
+chipsec32: clean
 	nasm -f elf32 -o i386/cpu.o i386/cpu.asm;
 	make -C $(KERNEL_SRC_DIR) SUBDIRS=`pwd` modules
-	cd ../../tool/chipsec/helper/linux; make
 
 install:
 	./run.sh
@@ -36,9 +30,8 @@ install:
 uninstall:
 	rmmod chipsec
 
-clean : 
+clean:
 	rm -f *.o *.ko *.mod.c Module.symvers Module.markers modules.order \.*.o.cmd \.*.ko.cmd \.*.o.d
 	rm -rf \.tmp_versions
 	rm -rf amd64/cpu.o i386/cpu.o
-	cd ../../tool/chipsec/helper/linux; make clean
 


### PR DESCRIPTION
This request fixes the building of the Linux driver on i386. It also removes the need to clean/rebuild the Linux helper.