### PR TITLE
Change sys.exit to re-raise

### DIFF
--- a/source/tool/chipsec/helper/oshelper.py
+++ b/source/tool/chipsec/helper/oshelper.py
@@ -32,7 +32,6 @@
 Abstracts support for various OS/environments, wrapper around platform specific code that invokes kernel driver
 """
 
-import sys
 import os
 import fnmatch
 import re
@@ -341,5 +340,5 @@ def helper():
         except BaseException, msg:
             logger().error( str(msg) )
             if logger().VERBOSE: logger().log_bad(traceback.format_exc())
-            sys.exit()
+            raise
     return _helper


### PR DESCRIPTION
This request re-raises the exception in case an error happened when trying to load the helper. This gives a chance to the caller to handle gracefully the error.