### PR TITLE
Use the misc device for the Linux driver

### DIFF
--- a/source/drivers/linux/run.sh
+++ b/source/drivers/linux/run.sh
@@ -6,20 +6,10 @@ if [ "$a1" == "0x" ]; then
 	exit;
 fi
 
-# note: these may not be found, due to lack of CONFIG_PCI...
-a2="0x"`cat /proc/kallsyms | grep ' raw_pci_read' | head -1 |cut -d ' ' -f 1`
-if [ "$a2" == "0x" ]; then
-	a2="0"
-fi
-a3="0x"`cat /proc/kallsyms | grep ' raw_pci_write' | head -1 |cut -d ' ' -f 1`
-if [ "$a3" == "0x" ]; then
-	a3="0"
-fi
-
 cat WARNING.txt
 
-echo -n "Module: insmod chipsec.ko a1=$a1 a2=$a2 a3=$a3 : ";
-insmod chipsec.ko a1="$a1" a2="$a2" a3="$a3" || exit;
+echo -n "Module: insmod chipsec.ko a1=$a1 : ";
+insmod chipsec.ko a1="$a1" || exit;
 chown root:root /dev/chipsec
 chmod 600 /dev/chipsec
 ##############echo -n "Module: insmod chipsec.ko a1=$a1 : ";


### PR DESCRIPTION
Use the misc device for the Linux driver to avoid allocating a major number. Remove the need for raw_pci_read and raw_pci_write (as not used).