### PR TITLE
Move the util functions to classes

### DIFF
--- a/source/tool/chipsec/command.py
+++ b/source/tool/chipsec/command.py
@@ -1,0 +1,33 @@
+#!/usr/local/bin/python
+#CHIPSEC: Platform Security Assessment Framework
+#Copyright (c) 2016, Google
+#
+#This program is free software; you can redistribute it and/or
+#modify it under the terms of the GNU General Public License
+#as published by the Free Software Foundation; Version 2.
+#
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program; if not, write to the Free Software
+#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+
+import chipsec.logger
+
+class BaseCommand:
+
+    def __init__(self, argv, cs=None):
+        self.argv = argv
+        self.logger = chipsec.logger.logger()
+        self.cs = cs
+
+    def run(self):
+        raise NotImplementedError('sub class should overwrite the run() method')
+
+    def requires_driver(self):
+        raise NotImplementedError('sub class should overwrite the requires_driver() method')

--- a/source/tool/chipsec/utilcmd/chipset_cmd.py
+++ b/source/tool/chipsec/utilcmd/chipset_cmd.py
@@ -28,16 +28,7 @@ usage as a standalone utility:
 
 __version__ = '1.0'
 
-import os
-import sys
-import time
-
-import chipsec_util
-
-
-from chipsec.logger     import *
-from chipsec.file       import *
-
+from chipsec.command    import BaseCommand
 from chipsec.chipset    import UnknownChipsetError, print_supported_chipsets
 
 # ###################################################################
@@ -45,15 +36,20 @@ from chipsec.chipset    import UnknownChipsetError, print_supported_chipsets
 # Chipset/CPU Detection
 #
 # ###################################################################
-def platform(argv):
+class PlatformCommand(BaseCommand):
     """
     chipsec_util platform
     """
-    try:
-        print_supported_chipsets()
-        logger().log("")
-        chipsec_util._cs.print_chipset()
-    except UnknownChipsetError, msg:
-        logger().error( msg )
 
-chipsec_util.commands['platform'] = {'func' : platform, 'start_driver' : True , 'help' : platform.__doc__ }
+    def requires_driver(self):
+        return True
+
+    def run(self):
+        try:
+            print_supported_chipsets()
+            self.logger.log("")
+            self.cs.print_chipset()
+        except UnknownChipsetError, msg:
+            self.logger.error( msg )
+
+commands = { 'platform': PlatformCommand }

--- a/source/tool/chipsec/utilcmd/cmos_cmd.py
+++ b/source/tool/chipsec/utilcmd/cmos_cmd.py
@@ -24,19 +24,12 @@
 
 __version__ = '1.0'
 
-import os
-import sys
 import time
 
-import chipsec_util
-
-
-from chipsec.logger     import *
-from chipsec.file       import *
-
+from chipsec.command    import BaseCommand
 from chipsec.hal.cmos   import CMOS, CmosRuntimeError
 
-def cmos(argv):
+class CMOSCommand(BaseCommand):
     """
     >>> chipsec_util cmos dump
     >>> chipsec_util cmos readl|writel|readh|writeh <byte_offset> [byte_val]
@@ -47,46 +40,53 @@ def cmos(argv):
     >>> chipsec_util cmos rl 0x0
     >>> chipsec_util cmos wh 0x0 0xCC
     """
-    if 3 > len(argv):
-        print cmos.__doc__
-        return
 
-    try:
-        _cmos = CMOS(  )
-    except CmosRuntimeError, msg:
-        print msg
-        return
+    def requires_driver(self):
+        # No driver required when printing the util documentation
+        if len(self.argv) < 3:
+            return False
+        return True
 
-    op = argv[2]
-    t = time.time()
+    def run(self):
+        if len(self.argv) < 3:
+            print CMOSCommand.__doc__
+            return
 
-    if ( 'dump' == op ):
-        logger().log( "[CHIPSEC] Dumping CMOS memory.." )
-        _cmos.dump()
-    elif ( 'readl' == op ):
-        off = int(argv[3],16)
-        val = _cmos.read_cmos_low( off )
-        logger().log( "[CHIPSEC] CMOS low byte 0x%X = 0x%X" % (off, val) )
-    elif ( 'writel' == op ):
-        off = int(argv[3],16)
-        val = int(argv[4],16)
-        logger().log( "[CHIPSEC] Writing CMOS low byte 0x%X <- 0x%X " % (off, val) )
-        _cmos.write_cmos_low( off, val )
-    elif ( 'readh' == op ):
-        off = int(argv[3],16)
-        val = _cmos.read_cmos_high( off )
-        logger().log( "[CHIPSEC] CMOS high byte 0x%X = 0x%X" % (off, val) )
-    elif ( 'writeh' == op ):
-        off = int(argv[3],16)
-        val = int(argv[4],16)
-        logger().log( "[CHIPSEC] Writing CMOS high byte 0x%X <- 0x%X " % (off, val) )
-        _cmos.write_cmos_high( off, val )
-    else:
-        logger().error( "unknown command-line option '%.32s'" % op )
-        print usage
-        return
+        try:
+            _cmos = CMOS(  )
+        except CmosRuntimeError, msg:
+            print msg
+            return
 
-    logger().log( "[CHIPSEC] (cmos) time elapsed %.3f" % (time.time()-t) )
+        op = self.argv[2]
+        t = time.time()
 
+        if ( 'dump' == op ):
+            self.logger.log( "[CHIPSEC] Dumping CMOS memory.." )
+            _cmos.dump()
+        elif ( 'readl' == op ):
+            off = int(self.argv[3],16)
+            val = _cmos.read_cmos_low( off )
+            self.logger.log( "[CHIPSEC] CMOS low byte 0x%X = 0x%X" % (off, val) )
+        elif ( 'writel' == op ):
+            off = int(self.argv[3],16)
+            val = int(self.argv[4],16)
+            self.logger.log( "[CHIPSEC] Writing CMOS low byte 0x%X <- 0x%X " % (off, val) )
+            _cmos.write_cmos_low( off, val )
+        elif ( 'readh' == op ):
+            off = int(self.argv[3],16)
+            val = _cmos.read_cmos_high( off )
+            self.logger.log( "[CHIPSEC] CMOS high byte 0x%X = 0x%X" % (off, val) )
+        elif ( 'writeh' == op ):
+            off = int(self.argv[3],16)
+            val = int(self.argv[4],16)
+            self.logger.log( "[CHIPSEC] Writing CMOS high byte 0x%X <- 0x%X " % (off, val) )
+            _cmos.write_cmos_high( off, val )
+        else:
+            self.logger.error( "unknown command-line option '%.32s'" % op )
+            print CMOSCommand.__doc__
+            return
 
-chipsec_util.commands['cmos'] = {'func' : cmos,    'start_driver' : True, 'help' : cmos.__doc__  }
+        self.logger.log( "[CHIPSEC] (cmos) time elapsed %.3f" % (time.time()-t) )
+
+commands = { 'cmos': CMOSCommand }

--- a/source/tool/chipsec/utilcmd/cpuid_cmd.py
+++ b/source/tool/chipsec/utilcmd/cpuid_cmd.py
@@ -24,22 +24,14 @@
 
 __version__ = '1.0'
 
-import os
-import sys
-import time
-
-import chipsec_util
-
-from chipsec.logger             import *
-from chipsec.file               import *
-#_cs = cs()
+from chipsec.command import BaseCommand
 
 # ###################################################################
 #
 # CPUid
 #
 # ###################################################################
-def cpuid(argv):
+class CPUIDCommand(BaseCommand):
     """
     >>> chipsec_util cpuid <eax> [ecx]
 
@@ -47,22 +39,29 @@ def cpuid(argv):
 
     >>> chipsec_util cpuid 40000000
     """
-    if 3 > len(argv):
-        print cpuid.__doc__
-        return
 
-    eax = int(argv[2],16)
-    ecx = int(argv[3],16) if 4 == len(argv) else 0
+    def requires_driver(self):
+        # No driver required when printing the util documentation
+        if len(self.argv) < 3:
+            return False
+        return True
 
-    logger().log( "[CHIPSEC] CPUID < EAX: 0x%08X" % eax)
-    logger().log( "[CHIPSEC]         ECX: 0x%08X" % ecx)
+    def run(self):
+        if len(self.argv) < 3:
+            print CPUIDCommand.__doc__
+            return
 
-    val = chipsec_util._cs.cpuid.cpuid( eax, ecx )
+        eax = int(self.argv[2],16)
+        ecx = int(self.argv[3],16) if 4 == len(self.argv) else 0
 
-    logger().log( "[CHIPSEC] CPUID > EAX: 0x%08X" % (val[0]) )
-    logger().log( "[CHIPSEC]         EBX: 0x%08X" % (val[1]) )
-    logger().log( "[CHIPSEC]         ECX: 0x%08X" % (val[2]) )
-    logger().log( "[CHIPSEC]         EDX: 0x%08X" % (val[3]) )
+        self.logger.log( "[CHIPSEC] CPUID < EAX: 0x%08X" % eax)
+        self.logger.log( "[CHIPSEC]         ECX: 0x%08X" % ecx)
 
+        val = self.cs.cpuid.cpuid( eax, ecx )
 
-chipsec_util.commands['cpuid'] = {'func' : cpuid , 'start_driver' : True, 'help' : cpuid.__doc__  }
+        self.logger.log( "[CHIPSEC] CPUID > EAX: 0x%08X" % (val[0]) )
+        self.logger.log( "[CHIPSEC]         EBX: 0x%08X" % (val[1]) )
+        self.logger.log( "[CHIPSEC]         ECX: 0x%08X" % (val[2]) )
+        self.logger.log( "[CHIPSEC]         EDX: 0x%08X" % (val[3]) )
+
+commands = { 'cpuid': CPUIDCommand }

--- a/source/tool/chipsec/utilcmd/decode_cmd.py
+++ b/source/tool/chipsec/utilcmd/decode_cmd.py
@@ -36,13 +36,10 @@ This will create multiple log files, binaries, and directories that correspond t
 __version__ = '1.0'
 
 import os
-import sys
 import time
 
-import chipsec_util
-
-from  chipsec.logger import *
-import  chipsec.file
+from chipsec.file import read_file, write_file
+from chipsec.command import BaseCommand
 
 import chipsec.hal.spi            as spi
 import chipsec.hal.spi_descriptor as spi_descriptor
@@ -50,9 +47,7 @@ import chipsec.hal.spi_uefi       as spi_uefi
 import chipsec.hal.uefi           as uefi
 
 
-_uefi = uefi.UEFI( chipsec_util._cs )
-
-def decode(argv):
+class DecodeCommand(BaseCommand):
     """
     >>> chipsec_util decode <rom> [fw_type]
 
@@ -64,70 +59,74 @@ def decode(argv):
 
     >>> chipsec_util decode spi.bin vss
     """
-        
-    if 3 > len(argv):
-        print decode.__doc__
-        return
-    
-    if argv[2] == "types":
-        print "\n<fw_type> should be in [ %s ]\n" % ( " | ".join( ["%s" % t for t in uefi.fw_types] ) )
-        return
-        
-    rom_file = argv[2]
 
-    fwtype = ''
-    if 4 == len(argv):
-        fwtype = argv[3]
-
-    logger().log( "[CHIPSEC] Decoding SPI ROM image from a file '%s'" % rom_file )
-    t = time.time()
-
-    f = chipsec.file.read_file( rom_file )
-    (fd_off, fd) = spi_descriptor.get_spi_flash_descriptor( f )
-    if (-1 == fd_off) or (fd is None):
-        logger().error( "Could not find SPI Flash descriptor in the binary '%s'" % rom_file )
+    def requires_driver(self):
         return False
 
-    logger().log( "[CHIPSEC] Found SPI Flash descriptor at offset 0x%x in the binary '%s'" % (fd_off, rom_file) )
-    rom = f[fd_off:]
-    # Decoding Flash Descriptor
-    #logger().LOG_COMPLETE_FILE_NAME = os.path.join( pth, 'flash_descriptor.log' )
-    #parse_spi_flash_descriptor( fd )
+    def run(self):
+        if len(self.argv) < 3:
+            print DecodeCommand.__doc__
+            return
+        
+        _uefi = uefi.UEFI( self.cs )
+        if self.argv[2] == "types":
+            print "\n<fw_type> should be in [ %s ]\n" % ( " | ".join( ["%s" % t for t in uefi.fw_types] ) )
+            return
+            
+        rom_file = self.argv[2]
 
-    # Decoding SPI Flash Regions
-    # flregs[r] = (r,SPI_REGION_NAMES[r],flreg,base,limit,notused)
-    flregs = spi_descriptor.get_spi_regions( fd )
-    if flregs is None:
-        logger().error( "SPI Flash descriptor region is not valid" )
-        return False
+        fwtype = ''
+        if 4 == len(self.argv):
+            fwtype = self.argv[3]
 
-    _orig_logname = logger().LOG_FILE_NAME
+        self.logger.log( "[CHIPSEC] Decoding SPI ROM image from a file '%s'" % rom_file )
+        t = time.time()
 
-    pth = os.path.join( chipsec_util._cs.helper.getcwd(), rom_file + ".dir" )
-    if not os.path.exists( pth ):
-        os.makedirs( pth )
+        f = read_file( rom_file )
+        (fd_off, fd) = spi_descriptor.get_spi_flash_descriptor( f )
+        if (-1 == fd_off) or (fd is None):
+            self.logger.error( "Could not find SPI Flash descriptor in the binary '%s'" % rom_file )
+            return False
 
-    for r in flregs:
-        idx     = r[0]
-        name    = r[1]
-        base    = r[3]
-        limit   = r[4]
-        notused = r[5]
-        if not notused:
-            region_data = rom[base:limit+1]
-            fname = os.path.join( pth, '%d_%04X-%04X_%s.bin' % (idx, base, limit, name) )
-            chipsec.file.write_file( fname, region_data )
-            if spi.FLASH_DESCRIPTOR == idx:
-                # Decoding Flash Descriptor
-                logger().set_log_file( os.path.join( pth, fname + '.log' ) )
-                spi_descriptor.parse_spi_flash_descriptor( region_data )
-            elif spi.BIOS == idx:
-                # Decoding EFI Firmware Volumes
-                logger().set_log_file( os.path.join( pth, fname + '.log' ) )
-                spi_uefi.decode_uefi_region(_uefi, pth, fname, fwtype)
+        self.logger.log( "[CHIPSEC] Found SPI Flash descriptor at offset 0x%x in the binary '%s'" % (fd_off, rom_file) )
+        rom = f[fd_off:]
+        # Decoding Flash Descriptor
+        #self.logger.LOG_COMPLETE_FILE_NAME = os.path.join( pth, 'flash_descriptor.log' )
+        #parse_spi_flash_descriptor( fd )
 
-    logger().set_log_file( _orig_logname )
-    logger().log( "[CHIPSEC] (decode) time elapsed %.3f" % (time.time()-t) )
+        # Decoding SPI Flash Regions
+        # flregs[r] = (r,SPI_REGION_NAMES[r],flreg,base,limit,notused)
+        flregs = spi_descriptor.get_spi_regions( fd )
+        if flregs is None:
+            self.logger.error( "SPI Flash descriptor region is not valid" )
+            return False
 
+        _orig_logname = self.logger.LOG_FILE_NAME
 
-chipsec_util.commands['decode'] = {'func' : decode,     'start_driver' : False, 'help' : decode.__doc__  }
+        pth = os.path.join( self.cs.helper.getcwd(), rom_file + ".dir" )
+        if not os.path.exists( pth ):
+            os.makedirs( pth )
+
+        for r in flregs:
+            idx     = r[0]
+            name    = r[1]
+            base    = r[3]
+            limit   = r[4]
+            notused = r[5]
+            if not notused:
+                region_data = rom[base:limit+1]
+                fname = os.path.join( pth, '%d_%04X-%04X_%s.bin' % (idx, base, limit, name) )
+                write_file( fname, region_data )
+                if spi.FLASH_DESCRIPTOR == idx:
+                    # Decoding Flash Descriptor
+                    self.logger.set_log_file( os.path.join( pth, fname + '.log' ) )
+                    spi_descriptor.parse_spi_flash_descriptor( region_data )
+                elif spi.BIOS == idx:
+                    # Decoding EFI Firmware Volumes
+                    self.logger.set_log_file( os.path.join( pth, fname + '.log' ) )
+                    spi_uefi.decode_uefi_region(_uefi, pth, fname, fwtype)
+
+        self.logger.set_log_file( _orig_logname )
+        self.logger.log( "[CHIPSEC] (decode) time elapsed %.3f" % (time.time()-t) )
+
+commands = { "decode": DecodeCommand }

--- a/source/tool/chipsec/utilcmd/desc_cmd.py
+++ b/source/tool/chipsec/utilcmd/desc_cmd.py
@@ -27,21 +27,10 @@ The idt and gdt commands print the IDT and GDT, respectively.
 
 __version__ = '1.0'
 
-import os
-import sys
-import time
-
-import chipsec_util
-
-
-from chipsec.logger     import *
-from chipsec.file       import *
-
-#from chipsec.hal.msr        import Msr
-
+from chipsec.command import BaseCommand
 
 # CPU descriptor tables
-def idt(argv):
+class IDTCommand(BaseCommand):
     """
     >>> chipsec_util idt|gdt|ldt [cpu_id]
 
@@ -50,14 +39,19 @@ def idt(argv):
     >>> chipsec_util idt 0
     >>> chipsec_util gdt
     """
-    if (2 == len(argv)):
-        logger().log( "[CHIPSEC] Dumping IDT of %d CPU threads" % chipsec_util._cs.msr.get_cpu_thread_count() )
-        chipsec_util._cs.msr.IDT_all( 4 )
-    elif (3 == len(argv)):
-        tid = int(argv[2],16)
-        chipsec_util._cs.msr.IDT( tid, 4 )
 
-def gdt(argv):
+    def requires_driver(self):
+        return True
+
+    def run(self):
+        if (2 == len(self.argv)):
+            self.logger.log( "[CHIPSEC] Dumping IDT of %d CPU threads" % self.cs.msr.get_cpu_thread_count() )
+            self.cs.msr.IDT_all( 4 )
+        elif (3 == len(self.argv)):
+            tid = int(self.argv[2],16)
+            self.cs.msr.IDT( tid, 4 )
+
+class GDTCommand(BaseCommand):
     """
     >>> chipsec_util idt|gdt|ldt [cpu_id]
 
@@ -66,14 +60,19 @@ def gdt(argv):
     >>> chipsec_util idt 0
     >>> chipsec_util gdt
     """
-    if (2 == len(argv)):
-        logger().log( "[CHIPSEC] Dumping GDT of %d CPU threads" % chipsec_util._cs.msr.get_cpu_thread_count() )
-        chipsec_util._cs.msr.GDT_all( 4 )
-    elif (3 == len(argv)):
-        tid = int(argv[2],16)
-        chipsec_util._cs.msr.GDT( tid, 4 )
 
-def ldt(argv):
+    def requires_driver(self):
+        return True
+
+    def run(self):
+        if (2 == len(self.argv)):
+            self.logger.log( "[CHIPSEC] Dumping GDT of %d CPU threads" % self.cs.msr.get_cpu_thread_count() )
+            self.cs.msr.GDT_all( 4 )
+        elif (3 == len(self.argv)):
+            tid = int(self.argv[2],16)
+            self.cs.msr.GDT( tid, 4 )
+
+class LDTCommand(BaseCommand):
     """
     >>> chipsec_util idt|gdt|ldt [cpu_id]
 
@@ -82,8 +81,10 @@ def ldt(argv):
     >>> chipsec_util idt 0
     >>> chipsec_util gdt
     """
-    logger().error( "[CHIPSEC] ldt not implemented" )
+    def requires_driver(self):
+        return True
 
+    def run(self):
+        self.logger.error( "[CHIPSEC] ldt not implemented" )
 
-chipsec_util.commands['idt'] = {'func' : idt, 'start_driver' : True, 'help' : idt.__doc__ }
-chipsec_util.commands['gdt'] = {'func' : gdt, 'start_driver' : True, 'help' : gdt.__doc__ }
+commands = { 'idt': IDTCommand, 'gdt': GDTCommand }

--- a/source/tool/chipsec/utilcmd/pci_cmd.py
+++ b/source/tool/chipsec/utilcmd/pci_cmd.py
@@ -27,21 +27,14 @@ The pci command can enumerate PCI devices and allow direct access to them by bus
 
 __version__ = '1.0'
 
-import os
-import sys
 import time
 
-import chipsec_util
-
-
-from chipsec.logger     import *
-from chipsec.file       import *
-
+from chipsec.command    import BaseCommand
 from chipsec.hal.pci    import *
 
 
 # PCIe Devices and Configuration Registers
-def pci(argv):
+class PCICommand(BaseCommand):
     """
     >>> chipsec_util pci enumerate
     >>> chipsec_util pci <bus> <device> <function> <offset> <width> [value]
@@ -54,64 +47,72 @@ def pci(argv):
     >>> chipsec_util pci 0 0x1F 0 0xDC 1 0x1
     >>> chipsec_util pci 0 0 0 0x98 dword 0x004E0040
     """
-    if 3 > len(argv):
-        print pci.__doc__
-        return
 
-    op = argv[2]
-    t = time.time()
+    def requires_driver(self):
+        # No driver required when printing the util documentation
+        if len(self.argv) < 3:
+            return False
+        return True
 
-    if ( 'enumerate' == op ):
-        logger().log( "[CHIPSEC] Enumerating available PCIe devices.." )
-        print_pci_devices( chipsec_util._cs.pci.enumerate_devices() )
-        logger().log( "[CHIPSEC] (pci) time elapsed %.3f" % (time.time()-t) )
-        return
+    def run(self):
+        if len(self.argv) < 3:
+            print PCICommand.__doc__
+            return
 
-    try:
-        bus         = int(argv[2],16)
-        device      = int(argv[3],16)
-        function    = int(argv[4],16)
-        offset      = int(argv[5],16)
+        op = self.argv[2]
+        t = time.time()
 
-        if 6 == len(argv):
-            width = 1
-        else:
-            if 'byte' == argv[6]:
+        if ( 'enumerate' == op ):
+            self.logger.log( "[CHIPSEC] Enumerating available PCIe devices.." )
+            print_pci_devices( self.cs.pci.enumerate_devices() )
+            self.logger.log( "[CHIPSEC] (pci) time elapsed %.3f" % (time.time()-t) )
+            return
+
+        try:
+            bus         = int(self.argv[2],16)
+            device      = int(self.argv[3],16)
+            function    = int(self.argv[4],16)
+            offset      = int(self.argv[5],16)
+
+            if 6 == len(self.argv):
                 width = 1
-            elif 'word' == argv[6]:
-                width = 2
-            elif 'dword' == argv[6]:
-                width = 4
             else:
-                width = int(argv[6])
-    except Exception as e :
-        print pci.__doc__
-        return
-
-    if 8 == len(argv):
-        value = int(argv[7], 16)
-        if 1 == width:
-            chipsec_util._cs.pci.write_byte( bus, device, function, offset, value )
-        elif 2 == width:
-            chipsec_util._cs.pci.write_word( bus, device, function, offset, value )
-        elif 4 == width:
-            chipsec_util._cs.pci.write_dword( bus, device, function, offset, value )
-        else:
-            print "ERROR: Unsupported width 0x%x" % width
+                if 'byte' == self.argv[6]:
+                    width = 1
+                elif 'word' == self.argv[6]:
+                    width = 2
+                elif 'dword' == self.argv[6]:
+                    width = 4
+                else:
+                    width = int(self.argv[6])
+        except Exception as e :
+            print PCICommand.__doc__
             return
-        logger().log( "[CHIPSEC] writing PCI %d/%d/%d, off 0x%02X: 0x%X" % (bus, device, function, offset, value) )
-    else:
-        if 1 == width:
-            pci_value = chipsec_util._cs.pci.read_byte(bus, device, function, offset)
-        elif 2 == width:
-            pci_value = chipsec_util._cs.pci.read_word(bus, device, function, offset)
-        elif 4 == width:
-            pci_value = chipsec_util._cs.pci.read_dword(bus, device, function, offset)
+
+        if 8 == len(self.argv):
+            value = int(self.argv[7], 16)
+            if 1 == width:
+                self.cs.pci.write_byte( bus, device, function, offset, value )
+            elif 2 == width:
+                self.cs.pci.write_word( bus, device, function, offset, value )
+            elif 4 == width:
+                self.cs.pci.write_dword( bus, device, function, offset, value )
+            else:
+                print "ERROR: Unsupported width 0x%x" % width
+                return
+            self.logger.log( "[CHIPSEC] writing PCI %d/%d/%d, off 0x%02X: 0x%X" % (bus, device, function, offset, value) )
         else:
-            print "ERROR: Unsupported width 0x%x" % width
-            return
-        logger().log( "[CHIPSEC] reading PCI B/D/F %d/%d/%d, off 0x%02X: 0x%X" % (bus, device, function, offset, pci_value) )
+            if 1 == width:
+                pci_value = self.cs.pci.read_byte(bus, device, function, offset)
+            elif 2 == width:
+                pci_value = self.cs.pci.read_word(bus, device, function, offset)
+            elif 4 == width:
+                pci_value = self.cs.pci.read_dword(bus, device, function, offset)
+            else:
+                print "ERROR: Unsupported width 0x%x" % width
+                return
+            self.logger.log( "[CHIPSEC] reading PCI B/D/F %d/%d/%d, off 0x%02X: 0x%X" % (bus, device, function, offset, pci_value) )
 
-    logger().log( "[CHIPSEC] (pci) time elapsed %.3f" % (time.time()-t) )
+        self.logger.log( "[CHIPSEC] (pci) time elapsed %.3f" % (time.time()-t) )
 
-chipsec_util.commands['pci'] = {'func' : pci , 'start_driver' : True, 'help' : pci.__doc__ }
+commands = { 'pci': PCICommand }

--- a/source/tool/chipsec/utilcmd/spd_cmd.py
+++ b/source/tool/chipsec/utilcmd/spd_cmd.py
@@ -23,21 +23,14 @@
 
 __version__ = '1.0'
 
-import os
-import sys
 import time
 
-import chipsec_util
-
-
-from chipsec.logger     import *
-from chipsec.file       import *
-
+from chipsec.command     import BaseCommand
 from chipsec.hal.smbus   import *
 from chipsec.hal.spd     import *
 
 
-def spd(argv):
+class SPDCommand(BaseCommand):
     """
     >>> chipsec_util spd detect
     >>> chipsec_util spd dump [device_addr]
@@ -51,69 +44,76 @@ def spd(argv):
     >>> chipsec_util spd read  0xA0 0x0
     >>> chipsec_util spd write 0xA0 0x0 0xAA
     """
-    if 3 > len(argv):
-        print spd.__doc__
-        return
 
-    try:
-        _smbus = SMBus( chipsec_util._cs )
-        _spd   = SPD( _smbus )
-    except BaseException, msg:
-        print msg
-        return
+    def requires_driver(self):
+        # No driver required when printing the util documentation
+        if len(self.argv) < 3:
+            return False
+        return True
 
-    op = argv[2]
-    t = time.time()
-
-    if not _smbus.is_SMBus_supported():
-        logger().log( "[CHIPSEC] SMBus controller is not supported" )
-        return
-    #smbus.display_SMBus_info()
-
-    dev_addr = SPD_SMBUS_ADDRESS
-
-    if( 'detect' == op ):
-
-        logger().log( "[CHIPSEC] Searching for DIMMs with SPD.." )
-        _spd.detect()
-
-    elif( 'dump' == op ):
-
-        if len(argv) > 3:
-            dev = argv[3].upper()
-            dev_addr = chipsec.hal.spd.SPD_DIMM_ADDRESSES[ dev ] if dev in chipsec.hal.spd.SPD_DIMM_ADDRESSES else int(argv[3],16)
-            if not _spd.isSPDPresent( dev_addr ):
-                logger().log( "[CHIPSEC] SPD for DIMM 0x%X is not found" % dev_addr )
-                return
-            _spd.decode( dev_addr )
-        else:
-            _dimms = _spd.detect()
-            for d in _dimms: _spd.decode( d )
- 
-    elif( 'read' == op ) or ( 'write' == op ):
-
-        if len(argv) > 3:
-            dev = argv[3].upper()
-            dev_addr = chipsec.hal.spd.SPD_DIMM_ADDRESSES[ dev ] if dev in chipsec.hal.spd.SPD_DIMM_ADDRESSES else int(argv[3],16)
-        if not _spd.isSPDPresent( dev_addr ):
-            logger().log( "[CHIPSEC] SPD for DIMM 0x%X is not found" % dev_addr )
+    def run(self):
+        if len(self.argv) < 3:
+            print SPDCommand.__doc__
             return
 
-        off = int(argv[4],16)
-        if( 'read' == op ):
-            val      = _spd.read_byte( off, dev_addr )
-            logger().log( "[CHIPSEC] SPD read: offset 0x%X = 0x%X" % (off, val) )
-        elif( 'write' == op ):
-            val      = int(argv[5],16)
-            logger().log( "[CHIPSEC] SPD write: offset 0x%X = 0x%X" % (off, val) )
-            _spd.write_byte( off, val, dev_addr )
+        try:
+            _smbus = SMBus( self.cs )
+            _spd   = SPD( _smbus )
+        except BaseException, msg:
+            print msg
+            return
 
-    else:
-        logger().error( "unknown command-line option '%.32s'" % op )
-        logger().log( spd.__doc__ )
-        return
+        op = self.argv[2]
+        t = time.time()
 
-    logger().log( "[CHIPSEC] (spd) time elapsed %.3f" % (time.time()-t) )
+        if not _smbus.is_SMBus_supported():
+            self.logger.log( "[CHIPSEC] SMBus controller is not supported" )
+            return
+        #smbus.display_SMBus_info()
 
+        dev_addr = SPD_SMBUS_ADDRESS
 
-chipsec_util.commands['spd'] = {'func' : spd, 'start_driver' : True, 'help' : spd.__doc__ }
+        if( 'detect' == op ):
+
+            self.logger.log( "[CHIPSEC] Searching for DIMMs with SPD.." )
+            _spd.detect()
+
+        elif( 'dump' == op ):
+
+            if len(self.argv) > 3:
+                dev = self.argv[3].upper()
+                dev_addr = chipsec.hal.spd.SPD_DIMM_ADDRESSES[ dev ] if dev in chipsec.hal.spd.SPD_DIMM_ADDRESSES else int(self.argv[3],16)
+                if not _spd.isSPDPresent( dev_addr ):
+                    self.logger.log( "[CHIPSEC] SPD for DIMM 0x%X is not found" % dev_addr )
+                    return
+                _spd.decode( dev_addr )
+            else:
+                _dimms = _spd.detect()
+                for d in _dimms: _spd.decode( d )
+     
+        elif( 'read' == op ) or ( 'write' == op ):
+
+            if len(self.argv) > 3:
+                dev = self.argv[3].upper()
+                dev_addr = chipsec.hal.spd.SPD_DIMM_ADDRESSES[ dev ] if dev in chipsec.hal.spd.SPD_DIMM_ADDRESSES else int(self.argv[3],16)
+            if not _spd.isSPDPresent( dev_addr ):
+                self.logger.log( "[CHIPSEC] SPD for DIMM 0x%X is not found" % dev_addr )
+                return
+
+            off = int(self.argv[4],16)
+            if( 'read' == op ):
+                val      = _spd.read_byte( off, dev_addr )
+                self.logger.log( "[CHIPSEC] SPD read: offset 0x%X = 0x%X" % (off, val) )
+            elif( 'write' == op ):
+                val      = int(self.argv[5],16)
+                self.logger.log( "[CHIPSEC] SPD write: offset 0x%X = 0x%X" % (off, val) )
+                _spd.write_byte( off, val, dev_addr )
+
+        else:
+            self.logger.error( "unknown command-line option '%.32s'" % op )
+            self.logger.log( SPDCommand.__doc__ )
+            return
+
+        self.logger.log( "[CHIPSEC] (spd) time elapsed %.3f" % (time.time()-t) )
+
+commands = { 'spd': SPDCommand }

--- a/source/tool/chipsec/utilcmd/spidesc_cmd.py
+++ b/source/tool/chipsec/utilcmd/spidesc_cmd.py
@@ -23,18 +23,13 @@
 
 __version__ = '1.0'
 
-import os
-import sys
 import time
 
-import chipsec_util
-
-from chipsec.logger     import *
-from chipsec.file       import *
-
+from chipsec.command            import BaseCommand
+from chipsec.file               import read_file
 from chipsec.hal.spi_descriptor import *
 
-def spidesc(argv):
+class SPIDescCommand(BaseCommand):
     """
     >>> chipsec_util spidesc [rom]
 
@@ -42,17 +37,20 @@ def spidesc(argv):
 
     >>> chipsec_util spidesc spi.bin
     """
-    if 3 > len(argv):
-        print spidesc.__doc__
-        return
+    def requires_driver(self):
+        return False
 
-    fd_file = argv[2]
-    logger().log( "[CHIPSEC] Parsing SPI Flash Descriptor from file '%s'\n" % fd_file )
+    def run(self):
+        if len(self.argv) < 3:
+            print SPIDescCommand.__doc__
+            return
 
-    t = time.time()
-    fd = read_file( fd_file )
-    if type(fd) == str: parse_spi_flash_descriptor( fd )
-    logger().log( "\n[CHIPSEC] (spidesc) time elapsed %.3f" % (time.time()-t) )
+        fd_file = self.argv[2]
+        self.logger.log( "[CHIPSEC] Parsing SPI Flash Descriptor from file '%s'\n" % fd_file )
 
+        t = time.time()
+        fd = read_file( fd_file )
+        if type(fd) == str: parse_spi_flash_descriptor( fd )
+        self.logger.log( "\n[CHIPSEC] (spidesc) time elapsed %.3f" % (time.time()-t) )
 
-chipsec_util.commands['spidesc'] = {'func' : spidesc, 'start_driver' : False, 'help' : spidesc.__doc__ }
+commands = { 'spidesc': SPIDescCommand }

--- a/source/tool/chipsec/utilcmd/uefi_cmd.py
+++ b/source/tool/chipsec/utilcmd/uefi_cmd.py
@@ -28,7 +28,6 @@ The uefi command provides access to UEFI variables, both on the live system and 
 __version__ = '1.0'
 
 import os
-import sys
 import time
 
 import chipsec_util
@@ -39,11 +38,11 @@ from chipsec.file       import *
 from chipsec.hal.uefi          import *
 from chipsec.hal.spi_uefi      import *
 
-_uefi = UEFI( chipsec_util._cs )
+from chipsec.command    import BaseCommand
 
 
 # Unified Extensible Firmware Interface (UEFI)
-def uefi(argv):
+class UEFICommand(BaseCommand):
     """
     >>> chipsec_util uefi var-list
     >>> chipsec_util uefi var-find <name>|<GUID>
@@ -74,285 +73,294 @@ def uefi(argv):
     >>> chipsec_util uefi assemble AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE freeform lzma uefi_file.raw uefi_file.bin
     >>> chipsec_util uefi replace  AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE bios.bin modified_bios.bin uefi_file.bin
     """
-       
-    if 3 > len(argv):
-        print uefi.__doc__
-        return
-    
-    if argv[2] == "types":
-        print "\n<fw_type> should be in [ %s ]\n" % (" | ".join( ["%s" % t for t in fw_types])) + \
-        "chipsec_util uefi keys <keyvar_file>\n" + \
-        "                  <keyvar_file> should be one of the following EFI variables\n" + \
-        "                  [ %s ]\n" % (" | ".join( ["%s" % var for var in SECURE_BOOT_KEY_VARIABLES]))
-        return
+
+    def requires_driver(self):
+        # No driver required when printing the util documentation
+        if len(self.argv) < 3:
+            return False
+        return True
+
+    def run(self):
+        _uefi = UEFI( self.cs )
+        if len(self.argv) < 3:
+            print UEFICommand.__doc__
+            return
         
-    op = argv[2]
-    t = time.time()
+        if self.argv[2] == "types":
+            print "\n<fw_type> should be in [ %s ]\n" % (" | ".join( ["%s" % t for t in fw_types])) + \
+            "chipsec_util uefi keys <keyvar_file>\n" + \
+            "                  <keyvar_file> should be one of the following EFI variables\n" + \
+            "                  [ %s ]\n" % (" | ".join( ["%s" % var for var in SECURE_BOOT_KEY_VARIABLES]))
+            return
+            
+        op = self.argv[2]
+        t = time.time()
 
-    filename = None
-    if ( 'var-read' == op ):
-        if (4 < len(argv)):
-            name = argv[3]
-            guid = argv[4]
-        if (5 < len(argv)):
-            filename = argv[5]
-        logger().log( "[CHIPSEC] Reading EFI variable Name='%s' GUID={%s} to '%s' via Variable API.." % (name, guid, filename) )
-        var = _uefi.get_EFI_variable( name, guid, filename )
+        filename = None
+        if ( 'var-read' == op ):
+            if (4 < len(self.argv)):
+                name = self.argv[3]
+                guid = self.argv[4]
+            if (5 < len(self.argv)):
+                filename = self.argv[5]
+            self.logger.log( "[CHIPSEC] Reading EFI variable Name='%s' GUID={%s} to '%s' via Variable API.." % (name, guid, filename) )
+            var = _uefi.get_EFI_variable( name, guid, filename )
 
-    elif ( 'var-write' == op ):
+        elif ( 'var-write' == op ):
 
-        if (5 < len(argv)):
-            name = argv[3]
-            guid = argv[4]
-            filename = argv[5]
+            if (5 < len(self.argv)):
+                name = self.argv[3]
+                guid = self.argv[4]
+                filename = self.argv[5]
+            else:
+                print UEFICommand.__doc__
+                return
+            self.logger.log( "[CHIPSEC] writing EFI variable Name='%s' GUID={%s} from '%s' via Variable API.." % (name, guid, filename) )
+            status = _uefi.set_EFI_variable_from_file( name, guid, filename )
+            self.logger.log("[CHIPSEC] status: %s" % chipsec.hal.uefi_common.EFI_STATUS_DICT[status])
+            if status == 0:
+                self.logger.log( "[CHIPSEC] set_EFI_variable return SUCCESS status" )
+            else:
+                self.logger.error( "set_EFI_variable wasn't able to modify variable" )
+
+        elif ( 'var-delete' == op ):
+
+            if (4 < len(self.argv)):
+                name = self.argv[3]
+                guid = self.argv[4]
+            else:
+                print UEFICommand.__doc__
+                return
+            self.logger.log( "[CHIPSEC] Deleting EFI variable Name='%s' GUID={%s} via Variable API.." % (name, guid) )
+            status = _uefi.delete_EFI_variable( name, guid )
+            self.logger.log("Returned %s" % chipsec.hal.uefi_common.EFI_STATUS_DICT[status])
+            if status == 0: self.logger.log( "[CHIPSEC] delete_EFI_variable return SUCCESS status" )
+            else:      self.logger.error( "delete_EFI_variable wasn't able to delete variable" )
+
+        elif ( 'var-list' == op ):
+
+            #infcls = 2
+            #if (3 < len(self.argv)): filename = self.argv[3]
+            #if (4 < len(self.argv)): infcls = int(self.argv[4],16)
+            self.logger.log( "[CHIPSEC] Enumerating all EFI variables via OS specific EFI Variable API.." )
+            efi_vars = _uefi.list_EFI_variables()
+            if efi_vars is None:
+                self.logger.log( "[CHIPSEC] Could not enumerate EFI Variables (Legacy OS?). Exit.." )
+                return
+
+            self.logger.log( "[CHIPSEC] Decoding EFI Variables.." )
+            _orig_logname = self.logger.LOG_FILE_NAME
+            self.logger.set_log_file( 'efi_variables.lst' )
+            #print_sorted_EFI_variables( efi_vars )
+            nvram_pth = 'efi_variables.dir'
+            if not os.path.exists( nvram_pth ): os.makedirs( nvram_pth )
+            decode_EFI_variables( efi_vars, nvram_pth )
+            self.logger.set_log_file( _orig_logname )
+
+            #efi_vars = _uefi.list_EFI_variables( infcls, filename )
+            #_orig_logname = self.logger.LOG_FILE_NAME
+            #self.logger.set_log_file( (filename + '.nv.lst') )
+            #_uefi.parse_EFI_variables( filename, efi_vars, False, FWType.EFI_FW_TYPE_WIN )
+            #self.logger.set_log_file( _orig_logname )
+
+            self.logger.log( "[CHIPSEC] Variables are in efi_variables.lst log and efi_variables.dir directory" )
+
+        elif ( 'var-find' == op ):
+
+            _vars = _uefi.list_EFI_variables()
+            if _vars is None:
+                self.logger.log_warning( 'Could not enumerate UEFI variables (non-UEFI OS?)' )
+                return
+
+            _input_var = self.argv[3]
+            if ('-' in _input_var):
+                self.logger.log( "[*] Searching for UEFI variable with GUID {%s}.." % _input_var )
+                for name in _vars:
+                    n = 0
+                    for (off, buf, hdr, data, guid, attrs) in _vars[name]:
+                        if _input_var == guid:
+                            var_fname = '%s_%s_%s_%d.bin' % (name,guid,get_attr_string(attrs).strip(),n)
+                            self.logger.log_good( "Found UEFI variable %s:%s. Dumped to '%s'" % (guid,name,var_fname) )
+                            write_file( var_fname, data )
+                        n += 1
+            else:
+                self.logger.log( "[*] Searching for UEFI variable with name %s.." % _input_var )
+                for name,_v in _vars.iteritems():
+                    n = 0
+                    for (off, buf, hdr, data, guid, attrs) in _v:
+                        if _input_var == name:
+                            var_fname = '%s_%s_%s_%d.bin' % (name,guid,get_attr_string(attrs).strip(),n)
+                            self.logger.log_good( "Found UEFI variable %s:%s. Dumped to '%s'" % (guid,name,var_fname) )
+                            write_file( var_fname, data )
+                        n += 1
+
+        elif ( 'nvram' == op or 'nvram-auth' == op ):
+
+            authvars = ('nvram-auth' == op)
+            efi_nvram_format = self.argv[3]
+            if (4 == len(self.argv)):
+                self.logger.log( "[CHIPSEC] Extracting EFI Variables directly in SPI ROM.." )
+                try:
+                    self.cs.init( True )
+                    _spi = SPI( self.cs )
+                except UnknownChipsetError, msg:
+                    print ("ERROR: Unknown chipset vendor (%s)" % str(msg))
+                    raise
+                except SpiRuntimeError, msg:
+                    print ("ERROR: SPI initialization error" % str(msg))
+                    raise
+
+                (bios_base,bios_limit,freg) = _spi.get_SPI_region( BIOS )
+                bios_size = bios_limit - bios_base + 1
+                self.logger.log( "[CHIPSEC] Reading BIOS: base = 0x%08X, limit = 0x%08X, size = 0x%08X" % (bios_base,bios_limit,bios_size) )
+                rom = _spi.read_spi( bios_base, bios_size )
+                self.cs.stop( True )
+                del _spi
+            elif (5 == len(self.argv)):
+                romfilename = self.argv[4]
+                self.logger.log( "[CHIPSEC] Extracting EFI Variables from ROM file '%s'" % romfilename )
+                rom = read_file( romfilename )
+
+            _orig_logname = self.logger.LOG_FILE_NAME
+            self.logger.set_log_file( (romfilename + '.nv.lst') )
+            _uefi.parse_EFI_variables( romfilename, rom, authvars, efi_nvram_format )
+            self.logger.set_log_file( _orig_logname )
+
+        elif ( 'decode' == op ):
+
+            if (4 < len(self.argv)):
+                filename = self.argv[3]
+                fwtype = self.argv[4]
+            else:
+                print UEFICommand.__doc__
+                return
+            self.logger.log( "[CHIPSEC] Parsing EFI volumes from '%s'.." % filename )
+            _orig_logname = self.logger.LOG_FILE_NAME
+            self.logger.set_log_file( filename + '.efi_fv.log' )
+            cur_dir = self.cs.helper.getcwd()
+            decode_uefi_region(_uefi, cur_dir, filename, fwtype)
+            self.logger.set_log_file( _orig_logname )
+
+        elif ( 'keys' == op ):
+
+            if (3 < len(self.argv)):
+                var_filename = self.argv[ 3 ]
+            else:
+                print UEFICommand.__doc__
+                return
+            self.logger.log( "[CHIPSEC] Parsing EFI variable from '%s'.." % var_filename )
+            parse_efivar_file( var_filename )
+
+        elif ( 'tables' == op ):
+            self.logger.log( "[CHIPSEC] Searching memory for and dumping EFI tables (this may take a minute)..\n" )
+            _uefi.dump_EFI_tables()
+
+        elif ( 's3bootscript' == op ):
+            self.logger.log( "[CHIPSEC] Searching for and parsing S3 resume bootscripts.." )
+            if len(self.argv) > 3:
+                bootscript_pa = int(self.argv[3],16)
+                self.logger.log( '[*] Reading S3 boot-script from memory at 0x%016X..' % bootscript_pa )
+                script_all = self.cs.mem.read_physical_mem( bootscript_pa, 0x100000 )
+                self.logger.log( '[*] Decoding S3 boot-script opcodes..' )
+                script_entries = chipsec.hal.uefi.parse_script( script_all, True )               
+            else:
+                (bootscript_PAs,parsed_scripts) = _uefi.get_s3_bootscript( True )
+
+        elif op in ['insert_before', 'insert_after', 'replace']:
+
+            if len(self.argv) < 7:
+                print UEFICommand.__doc__
+                return
+
+            (guid, rom_file, new_file, efi_file) = self.argv[3:7]
+
+            commands = {
+                'insert_before' :  CMD_UEFI_FILE_INSERT_BEFORE,
+                'insert_after'  :  CMD_UEFI_FILE_INSERT_AFTER,
+                'replace'       :  CMD_UEFI_FILE_REPLACE
+            }
+
+            if get_guid_bin(guid) == '':
+                print '*** Error *** Invalid GUID: %s' % guid
+                return
+
+            if not os.path.isfile(rom_file):
+                print '*** Error *** File doesn\'t exist: %s' % rom_file
+                return
+
+            if not os.path.isfile(efi_file):
+                print '*** Error *** File doesn\'t exist: %s' % efi_file
+                return
+
+            rom_image = chipsec.file.read_file(rom_file)
+            efi_image = chipsec.file.read_file(efi_file)
+            new_image = modify_uefi_region(rom_image, commands[op], guid, efi_image)
+            chipsec.file.write_file(new_file, new_image)
+
+        elif op == 'remove':
+
+            if len(self.argv) < 6:
+                print UEFICommand.__doc__
+                return
+
+            (guid, rom_file, new_file) = self.argv[3:6]
+
+            if get_guid_bin(guid) == '':
+                print '*** Error *** Invalid GUID: %s' % guid
+                return
+
+            if not os.path.isfile(rom_file):
+                print '*** Error *** File doesn\'t exist: %s' % rom_file
+                return
+
+            rom_image = chipsec.file.read_file(rom_file)
+            new_image = modify_uefi_region(rom_image, CMD_UEFI_FILE_REMOVE, guid)
+            chipsec.file.write_file(new_file, new_image)
+
+        elif op == 'assemble':
+
+            compression = {'none': 0, 'tiano': 1, 'lzma': 2}
+
+            if len(self.argv) < 8:
+                print UEFICommand.__doc__
+                return
+
+            (guid, file_type, comp, raw_file, efi_file) = self.argv[3:8]
+
+            if get_guid_bin(guid) == '':
+                print '*** Error *** Invalid GUID: %s' % guid
+                return
+
+            if not os.path.isfile(raw_file):
+                print '*** Error *** File doesn\'t exist: %s' % raw_file
+                return
+
+            if comp not in compression:
+                print '*** Error *** Unknown compression: %s' % comp
+                return
+
+            compression_type = compression[comp]
+
+            if file_type == 'freeform':
+                raw_image  = chipsec.file.read_file(raw_file)
+                wrap_image = assemble_uefi_raw(raw_image)
+                if compression_type > 0:
+                    comp_image = compress_image(_uefi, wrap_image, compression_type)
+                    wrap_image = assemble_uefi_section(comp_image, len(wrap_image), compression_type)
+                uefi_image = assemble_uefi_file(guid, wrap_image)
+                chipsec.file.write_file(efi_file, uefi_image)
+            else:
+                print '*** Error *** Unknow file type: %s' % file_type
+                return
+
+            self.logger.log( "[CHIPSEC]  UEFI file was successfully assembled! Binary file size: %d, compressed UEFI file size: %d" % (len(raw_image), len(uefi_image)) )
+
         else:
-            print uefi.__doc__
-            return
-        logger().log( "[CHIPSEC] writing EFI variable Name='%s' GUID={%s} from '%s' via Variable API.." % (name, guid, filename) )
-        status = _uefi.set_EFI_variable_from_file( name, guid, filename )
-        logger().log("[CHIPSEC] status: %s" % chipsec.hal.uefi_common.EFI_STATUS_DICT[status])
-        if status == 0:
-            logger().log( "[CHIPSEC] set_EFI_variable return SUCCESS status" )
-        else:
-            logger().error( "set_EFI_variable wasn't able to modify variable" )
-
-    elif ( 'var-delete' == op ):
-
-        if (4 < len(argv)):
-            name = argv[3]
-            guid = argv[4]
-        else:
-            print uefi.__doc__
-            return
-        logger().log( "[CHIPSEC] Deleting EFI variable Name='%s' GUID={%s} via Variable API.." % (name, guid) )
-        status = _uefi.delete_EFI_variable( name, guid )
-        logger().log("Returned %s" % chipsec.hal.uefi_common.EFI_STATUS_DICT[status])
-        if status == 0: logger().log( "[CHIPSEC] delete_EFI_variable return SUCCESS status" )
-        else:      logger().error( "delete_EFI_variable wasn't able to delete variable" )
-
-    elif ( 'var-list' == op ):
-
-        #infcls = 2
-        #if (3 < len(argv)): filename = argv[3]
-        #if (4 < len(argv)): infcls = int(argv[4],16)
-        logger().log( "[CHIPSEC] Enumerating all EFI variables via OS specific EFI Variable API.." )
-        efi_vars = _uefi.list_EFI_variables()
-        if efi_vars is None:
-            logger().log( "[CHIPSEC] Could not enumerate EFI Variables (Legacy OS?). Exit.." )
+            self.logger.error( "Unknown uefi command '%s'" % op )
+            print UEFICommand.__doc__
             return
 
-        logger().log( "[CHIPSEC] Decoding EFI Variables.." )
-        _orig_logname = logger().LOG_FILE_NAME
-        logger().set_log_file( 'efi_variables.lst' )
-        #print_sorted_EFI_variables( efi_vars )
-        nvram_pth = 'efi_variables.dir'
-        if not os.path.exists( nvram_pth ): os.makedirs( nvram_pth )
-        decode_EFI_variables( efi_vars, nvram_pth )
-        logger().set_log_file( _orig_logname )
+        self.logger.log( "[CHIPSEC] (uefi) time elapsed %.3f" % (time.time()-t) )
 
-        #efi_vars = _uefi.list_EFI_variables( infcls, filename )
-        #_orig_logname = logger().LOG_FILE_NAME
-        #logger().set_log_file( (filename + '.nv.lst') )
-        #_uefi.parse_EFI_variables( filename, efi_vars, False, FWType.EFI_FW_TYPE_WIN )
-        #logger().set_log_file( _orig_logname )
 
-        logger().log( "[CHIPSEC] Variables are in efi_variables.lst log and efi_variables.dir directory" )
-
-    elif ( 'var-find' == op ):
-
-        _vars = _uefi.list_EFI_variables()
-        if _vars is None:
-            logger().log_warning( 'Could not enumerate UEFI variables (non-UEFI OS?)' )
-            return
-
-        _input_var = argv[3]
-        if ('-' in _input_var):
-            logger().log( "[*] Searching for UEFI variable with GUID {%s}.." % _input_var )
-            for name in _vars:
-                n = 0
-                for (off, buf, hdr, data, guid, attrs) in _vars[name]:
-                    if _input_var == guid:
-                        var_fname = '%s_%s_%s_%d.bin' % (name,guid,get_attr_string(attrs).strip(),n)
-                        logger().log_good( "Found UEFI variable %s:%s. Dumped to '%s'" % (guid,name,var_fname) )
-                        write_file( var_fname, data )
-                    n += 1
-        else:
-            logger().log( "[*] Searching for UEFI variable with name %s.." % _input_var )
-            for name,_v in _vars.iteritems():
-                n = 0
-                for (off, buf, hdr, data, guid, attrs) in _v:
-                    if _input_var == name:
-                        var_fname = '%s_%s_%s_%d.bin' % (name,guid,get_attr_string(attrs).strip(),n)
-                        logger().log_good( "Found UEFI variable %s:%s. Dumped to '%s'" % (guid,name,var_fname) )
-                        write_file( var_fname, data )
-                    n += 1
-
-    elif ( 'nvram' == op or 'nvram-auth' == op ):
-
-        authvars = ('nvram-auth' == op)
-        efi_nvram_format = argv[3]
-        if (4 == len(argv)):
-            logger().log( "[CHIPSEC] Extracting EFI Variables directly in SPI ROM.." )
-            try:
-                chipsec_util._cs.init( True )
-                _spi = SPI( chipsec_util._cs )
-            except UnknownChipsetError, msg:
-                print ("ERROR: Unknown chipset vendor (%s)" % str(msg))
-                raise
-            except SpiRuntimeError, msg:
-                print ("ERROR: SPI initialization error" % str(msg))
-                raise
-
-            (bios_base,bios_limit,freg) = _spi.get_SPI_region( BIOS )
-            bios_size = bios_limit - bios_base + 1
-            logger().log( "[CHIPSEC] Reading BIOS: base = 0x%08X, limit = 0x%08X, size = 0x%08X" % (bios_base,bios_limit,bios_size) )
-            rom = _spi.read_spi( bios_base, bios_size )
-            chipsec_util._cs.stop( True )
-            del _spi
-        elif (5 == len(argv)):
-            romfilename = argv[4]
-            logger().log( "[CHIPSEC] Extracting EFI Variables from ROM file '%s'" % romfilename )
-            rom = read_file( romfilename )
-
-        _orig_logname = logger().LOG_FILE_NAME
-        logger().set_log_file( (romfilename + '.nv.lst') )
-        _uefi.parse_EFI_variables( romfilename, rom, authvars, efi_nvram_format )
-        logger().set_log_file( _orig_logname )
-
-    elif ( 'decode' == op ):
-
-        if (4 < len(argv)):
-            filename = argv[3]
-            fwtype = argv[4]
-        else:
-            print uefi.__doc__
-            return
-        logger().log( "[CHIPSEC] Parsing EFI volumes from '%s'.." % filename )
-        _orig_logname = logger().LOG_FILE_NAME
-        logger().set_log_file( filename + '.efi_fv.log' )
-        cur_dir = chipsec_util._cs.helper.getcwd()
-        decode_uefi_region(_uefi, cur_dir, filename, fwtype)
-        logger().set_log_file( _orig_logname )
-
-    elif ( 'keys' == op ):
-
-        if (3 < len(argv)):
-            var_filename = argv[ 3 ]
-        else:
-            print uefi.__doc__
-            return
-        logger().log( "[CHIPSEC] Parsing EFI variable from '%s'.." % var_filename )
-        parse_efivar_file( var_filename )
-
-    elif ( 'tables' == op ):
-        logger().log( "[CHIPSEC] Searching memory for and dumping EFI tables (this may take a minute)..\n" )
-        _uefi.dump_EFI_tables()
-
-    elif ( 's3bootscript' == op ):
-        logger().log( "[CHIPSEC] Searching for and parsing S3 resume bootscripts.." )
-        if len(argv) > 3:
-            bootscript_pa = int(argv[3],16)
-            logger().log( '[*] Reading S3 boot-script from memory at 0x%016X..' % bootscript_pa )
-            script_all = chipsec_util._cs.mem.read_physical_mem( bootscript_pa, 0x100000 )
-            logger().log( '[*] Decoding S3 boot-script opcodes..' )
-            script_entries = chipsec.hal.uefi.parse_script( script_all, True )               
-        else:
-            (bootscript_PAs,parsed_scripts) = _uefi.get_s3_bootscript( True )
-
-    elif op in ['insert_before', 'insert_after', 'replace']:
-
-        if len(argv) < 7:
-            print uefi.__doc__
-            return
-
-        (guid, rom_file, new_file, efi_file) = argv[3:7]
-
-        commands = {
-            'insert_before' :  CMD_UEFI_FILE_INSERT_BEFORE,
-            'insert_after'  :  CMD_UEFI_FILE_INSERT_AFTER,
-            'replace'       :  CMD_UEFI_FILE_REPLACE
-        }
-
-        if get_guid_bin(guid) == '':
-            print '*** Error *** Invalid GUID: %s' % guid
-            return
-
-        if not os.path.isfile(rom_file):
-            print '*** Error *** File doesn\'t exist: %s' % rom_file
-            return
-
-        if not os.path.isfile(efi_file):
-            print '*** Error *** File doesn\'t exist: %s' % efi_file
-            return
-
-        rom_image = chipsec.file.read_file(rom_file)
-        efi_image = chipsec.file.read_file(efi_file)
-        new_image = modify_uefi_region(rom_image, commands[op], guid, efi_image)
-        chipsec.file.write_file(new_file, new_image)
-
-    elif op == 'remove':
-
-        if len(argv) < 6:
-            print uefi.__doc__
-            return
-
-        (guid, rom_file, new_file) = argv[3:6]
-
-        if get_guid_bin(guid) == '':
-            print '*** Error *** Invalid GUID: %s' % guid
-            return
-
-        if not os.path.isfile(rom_file):
-            print '*** Error *** File doesn\'t exist: %s' % rom_file
-            return
-
-        rom_image = chipsec.file.read_file(rom_file)
-        new_image = modify_uefi_region(rom_image, CMD_UEFI_FILE_REMOVE, guid)
-        chipsec.file.write_file(new_file, new_image)
-
-    elif op == 'assemble':
-
-        compression = {'none': 0, 'tiano': 1, 'lzma': 2}
-
-        if len(argv) < 8:
-            print uefi.__doc__
-            return
-
-        (guid, file_type, comp, raw_file, efi_file) = argv[3:8]
-
-        if get_guid_bin(guid) == '':
-            print '*** Error *** Invalid GUID: %s' % guid
-            return
-
-        if not os.path.isfile(raw_file):
-            print '*** Error *** File doesn\'t exist: %s' % raw_file
-            return
-
-        if comp not in compression:
-            print '*** Error *** Unknown compression: %s' % comp
-            return
-
-        compression_type = compression[comp]
-
-        if file_type == 'freeform':
-            raw_image  = chipsec.file.read_file(raw_file)
-            wrap_image = assemble_uefi_raw(raw_image)
-            if compression_type > 0:
-                comp_image = compress_image(_uefi, wrap_image, compression_type)
-                wrap_image = assemble_uefi_section(comp_image, len(wrap_image), compression_type)
-            uefi_image = assemble_uefi_file(guid, wrap_image)
-            chipsec.file.write_file(efi_file, uefi_image)
-        else:
-            print '*** Error *** Unknow file type: %s' % file_type
-            return
-
-        logger().log( "[CHIPSEC]  UEFI file was successfully assembled! Binary file size: %d, compressed UEFI file size: %d" % (len(raw_image), len(uefi_image)) )
-
-    else:
-        logger().error( "Unknown uefi command '%s'" % op )
-        print uefi.__doc__
-        return
-
-    logger().log( "[CHIPSEC] (uefi) time elapsed %.3f" % (time.time()-t) )
-
-chipsec_util.commands['uefi'] = {'func' : uefi, 'start_driver' : True, 'help' : uefi.__doc__ }
+commands = { 'uefi': UEFICommand }


### PR DESCRIPTION
This pull request moves the util commands to specific classes, inheriting from BaseCommand. It includes:

- Define a new class BaseCommand
- For each utils:
  - Convert the function to a class, using the run() method for its main content
  - Use the attributes instead of global variables: `s/logger()/self.logger`, `s/argv/self.argv` and `s/chipsec_utils._cs/self.cs`
  - Add a requires_driver() method that determines if the OS driver needs to be loaded depending on the arguments and potentially other factors (platform).
  - Clean up some of the import if relevant
- Modify chipsec_utils.py to use the new classes

The diff for each command is rather verbose because of the different indentation level. Using `git diff -w` to ignore the space difference may help to review this request.

The purpose of this request is to clean up how the utils are implemented in order to ease the transition when using Chipsec without drivers.
