### PR TITLE
chipsec_km: utilize inode_lock/unlock wrappers for new kernels

### DIFF
--- a/source/drivers/linux/chipsec_km.c
+++ b/source/drivers/linux/chipsec_km.c
@@ -534,6 +534,9 @@ static loff_t memory_lseek(struct file * file, loff_t offset, int orig)
 //Older kernels (<20) uses f_dentry instead of f_path.dentry
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,20)
 	mutex_lock(&file->f_dentry->d_inode->i_mutex);
+//As of v4.5, use the wrappers inode_lock/unlock
+#elseif LINUX_VERSION_CODE >= KERNEL_VERSION(4,5,0)
+	inode_lock(inode);
 #else
 	mutex_lock(&file->f_path.dentry->d_inode->i_mutex);
 #endif 
@@ -555,6 +558,9 @@ static loff_t memory_lseek(struct file * file, loff_t offset, int orig)
 //Older kernels (<20) uses f_dentry instead of f_path.dentry
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,20)
 	mutex_unlock(&file->f_dentry->d_inode->i_mutex);
+//As of v4.5, use the wrappers inode_lock/unlock
+#elseif LINUX_VERSION_CODE >= KERNEL_VERSION(4,5,0)
+	inode_lock(inode);
 #else
 	mutex_unlock(&file->f_path.dentry->d_inode->i_mutex);
 #endif 


### PR DESCRIPTION
As of v4.5, wrappers to lock and unlock the inode's mutex were
introduced. This change is useful to leverage future changes in the
implementation of inode locking. For instance, a new change coming in
Linux v4.7-rc1 changed the i_node locking mechanism from using a mutex
to a rw sempahore.

Signed-off-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>