### PR TITLE
Add BOOT_MODE to hardware tests

### DIFF
--- a/source/tool/tests/hardware/test_elitebook_1040_ubuntu.py
+++ b/source/tool/tests/hardware/test_elitebook_1040_ubuntu.py
@@ -1,23 +1,28 @@
 from tests.hardware import test_ubuntu
 
+
 class EliteBook1040UbuntuTest(test_ubuntu.GenericUbuntuTest):
 
     PRODUCT_NAME = 'HP EliteBook Folio 1040 G1'
     BIOS_VERSION = 'L83 Ver. 01.21'
-    PASS = ["chipsec.modules.common.spi_desc",
-            "chipsec.modules.common.bios_wp",
-            "chipsec.modules.common.spi_lock",
-            "chipsec.modules.common.smrr",
-            "chipsec.modules.common.smm",
-            "chipsec.modules.common.bios_ts",
-            "chipsec.modules.common.bios_smi",
-            "chipsec.modules.smm_dma",
-            "chipsec.modules.remap"]
+    BOOT_MODE = test_ubuntu.GenericUbuntuTest.BOOT_MODE_LEGACY
+    PASS = [
+        "chipsec.modules.common.bios_smi",
+        "chipsec.modules.common.bios_ts",
+        "chipsec.modules.common.bios_wp",
+        "chipsec.modules.common.smm",
+        "chipsec.modules.common.smrr",
+        "chipsec.modules.common.spi_desc",
+        "chipsec.modules.common.spi_lock",
+        "chipsec.modules.remap",
+        "chipsec.modules.smm_dma",
+    ]
 
-    SKIPPED = ["chipsec.modules.common.secureboot.variables",
-               "chipsec.modules.common.uefi.s3bootscript",
-               "chipsec.modules.common.uefi.access_uefispec",
-               "chipsec.modules.module_template"]
+    SKIPPED = [
+        "chipsec.modules.common.secureboot.variables",
+        "chipsec.modules.common.uefi.s3bootscript",
+        "chipsec.modules.common.uefi.access_uefispec",
+    ]
 
     def test_main(self):
         self._generic_main()

--- a/source/tool/tests/hardware/test_generic.py
+++ b/source/tool/tests/hardware/test_generic.py
@@ -6,17 +6,30 @@ import unittest
 import chipsec_main
 from chipsec import logger
 
+
 class GenericHardwareTest(unittest.TestCase):
+
+    BOOT_MODE_LEGACY = 1
+    BOOT_MODE_UEFI = 2
 
     def setUp(self):
         if hasattr(self, "SYSTEM") and platform.system() != self.SYSTEM:
             self.skipTest("Unsupported system {}".format(self.SYSTEM))
+
         if hasattr(self, "DIST") and platform.dist() != self.DIST:
             self.skipTest("Unsupported distribution {}".format(self.DIST))
-        if hasattr(self, "PRODUCT_NAME") and self.product_name() != self.PRODUCT_NAME:
+
+        if (hasattr(self, "PRODUCT_NAME") and
+                self.product_name() != self.PRODUCT_NAME):
             self.skipTest("Unsupported platform {}".format(self.PRODUCT_NAME))
-        if hasattr(self, "BIOS_VERSION") and self.bios_version() != self.BIOS_VERSION:
-            self.skipTest("Unsupported BIOS version {}".format(self.BIOS_VERSION))
+
+        if (hasattr(self, "BIOS_VERSION") and
+                self.bios_version() != self.BIOS_VERSION):
+            self.skipTest("Unsupported BIOS version "
+                          "{}".format(self.BIOS_VERSION))
+
+        if hasattr(self, "BOOT_MODE") and self.boot_mode() != self.BOOT_MODE:
+            self.skipTest("Unsupported boot type {}".format(self.BOOT_MODE))
         _, self.log_file = tempfile.mkstemp()
 
     def tearDown(self):
@@ -27,7 +40,8 @@ class GenericHardwareTest(unittest.TestCase):
         error_code = cm.main()
         logger.logger().close()
         self.log = open(self.log_file).read()
-        self.assertLessEqual(error_code, 31, "At least one test raised an error")
+        self.assertLessEqual(error_code, 31,
+                             "At least one test raised an error")
         for test in self.PASS:
             self.assertIn("PASSED: {}".format(test), self.log)
         for test in self.SKIPPED:

--- a/source/tool/tests/hardware/test_ubuntu.py
+++ b/source/tool/tests/hardware/test_ubuntu.py
@@ -5,10 +5,15 @@ from tests.hardware import test_generic
 
 from chipsec.helper import oshelper
 
+
 class GenericUbuntuTest(test_generic.GenericHardwareTest):
 
     SYSTEM = 'Linux'
-    DIST = ('Ubuntu', '14.04', 'trusty')
+    DIST = ('Ubuntu', '16.04', 'xenial')
+
+    PRODUCT_NAME_PATH = "/sys/class/dmi/id/product_name"
+    BIOS_VERSION_PATH = "/sys/class/dmi/id/bios_version"
+    BOOT_MODE_PATH = "/sys/firmware/efi"
 
     def setUp(self):
         super(GenericUbuntuTest, self).setUp()
@@ -30,14 +35,21 @@ class GenericUbuntuTest(test_generic.GenericHardwareTest):
 
     def product_name(self):
         try:
-            product_name = open("/sys/class/dmi/id/product_name").read().strip()
+            product_name = open(self.PRODUCT_NAME_PATH).read().strip()
             return product_name
-        except:
+        except IOError:
             return None
 
     def bios_version(self):
         try:
-            bios_version = open("/sys/class/dmi/id/bios_version").read().strip()
+            bios_version = open(self.BIOS_VERSION_PATH).read().strip()
             return bios_version
-        except:
+        except IOError:
             return None
+
+    def boot_mode(self):
+        """Check if the current boot method is UEFI or Legacy"""
+        if os.path.isdir(self.BOOT_MODE_PATH):
+            return self.BOOT_MODE_UEFI
+        else:
+            return self.BOOT_MODE_LEGACY

--- a/source/tool/tests/hardware/test_x1_carbon_ubuntu.py
+++ b/source/tool/tests/hardware/test_x1_carbon_ubuntu.py
@@ -1,22 +1,26 @@
 from tests.hardware import test_ubuntu
 
+
 class X1CarbonUbuntuTest(test_ubuntu.GenericUbuntuTest):
 
     PRODUCT_NAME = '20FCS00Y01'
     BIOS_VERSION = 'N1FET34W (1.08 )'
-    PASS = ["chipsec.modules.common.spi_desc",
-            "chipsec.modules.common.bios_wp",
-            "chipsec.modules.common.spi_lock",
-            "chipsec.modules.common.smrr",
-            "chipsec.modules.common.bios_ts",
-            "chipsec.modules.common.smm",
-            "chipsec.modules.common.secureboot.variables",
-            "chipsec.modules.common.uefi.access_uefispec",
-            "chipsec.modules.common.bios_smi",
-            "chipsec.modules.smm_dma",
-            "chipsec.modules.remap"]
+    BOOT_MODE = test_ubuntu.GenericUbuntuTest.BOOT_MODE_UEFI
+    PASS = [
+        "chipsec.modules.common.bios_smi",
+        "chipsec.modules.common.bios_ts",
+        "chipsec.modules.common.bios_wp",
+        "chipsec.modules.common.secureboot.variables",
+        "chipsec.modules.common.smm",
+        "chipsec.modules.common.smrr",
+        "chipsec.modules.common.spi_desc",
+        "chipsec.modules.common.spi_lock",
+        "chipsec.modules.common.uefi.access_uefispec",
+        "chipsec.modules.remap",
+        "chipsec.modules.smm_dma"
+    ]
 
-    SKIPPED = ["chipsec.modules.module_template"]
+    SKIPPED = []
 
     def test_main(self):
         self._generic_main()

--- a/source/tool/tests/hardware/test_z420_ubuntu.py
+++ b/source/tool/tests/hardware/test_z420_ubuntu.py
@@ -1,23 +1,27 @@
 from tests.hardware import test_ubuntu
 
+
 class Z420UbuntuTest(test_ubuntu.GenericUbuntuTest):
 
     PRODUCT_NAME = 'HP Z420 Workstation'
     BIOS_VERSION = 'J61 v03.88'
-    PASS = ["chipsec.modules.common.spi_desc",
-            "chipsec.modules.common.bios_wp",
-            "chipsec.modules.common.spi_lock",
-            "chipsec.modules.common.smrr",
-            "chipsec.modules.common.bios_ts",
-            "chipsec.modules.common.bios_smi"]
+    BOOT_MODE = test_ubuntu.GenericUbuntuTest.BOOT_MODE_LEGACY
+    PASS = [
+        "chipsec.modules.common.bios_smi",
+        "chipsec.modules.common.bios_ts",
+        "chipsec.modules.common.bios_wp",
+        "chipsec.modules.common.secureboot.variables",
+        "chipsec.modules.common.smrr",
+        "chipsec.modules.common.spi_desc",
+        "chipsec.modules.common.spi_lock"
+    ]
 
-    SKIPPED = ["chipsec.modules.common.smm",
-               "chipsec.modules.common.secureboot.variables",
-               "chipsec.modules.common.uefi.s3bootscript",
-               "chipsec.modules.common.uefi.access_uefispec",
-               "chipsec.modules.smm_dma",
-               "chipsec.modules.remap",
-               "chipsec.modules.module_template"]
+    # This platform does not support the following tests
+    SKIPPED = [
+        "chipsec.modules.common.smm",
+        "chipsec.modules.remap",
+        "chipsec.modules.smm_dma"
+    ]
 
     def test_main(self):
         self._generic_main()


### PR DESCRIPTION
Add the BOOT_MODE attribute for hardware tests to probe and filter the platform depending on the boot mode: UEFI or Legacy.