### PR TITLE
chipsec_km.c : GCC warning (-Wmisleading-indentation)

### DIFF
--- a/source/drivers/linux/chipsec_km.c
+++ b/source/drivers/linux/chipsec_km.c
@@ -1469,10 +1469,11 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
         // Write to MCR register to send the message on the message bus
         WritePCICfg( MSGBUS_BUS, MSGBUS_DEV, MSGBUS_FUN, MCR, 4, mcr );
 
-        if (direction & MSGBUS_MDR_OUT_MASK)
+        if (direction & MSGBUS_MDR_OUT_MASK) {
             // Read data from MDR register
             mdr_out = ReadPCICfg( MSGBUS_BUS, MSGBUS_DEV, MSGBUS_FUN, MDR, 4 );
-            ptr[4] = mdr_out;	
+            ptr[4] = mdr_out;
+        }
 
         if(copy_to_user((void*)ioctl_param, (void*)ptrbuf, (sizeof(long) * numargs)) > 0)
           return -EFAULT;	


### PR DESCRIPTION
GCC 6.1.1 triggers a warning while compiling chipsec drivers for Linux :

```
chipsec/source/drivers/linux/chipsec_km.c: Dans la fonction ‘d_ioctl’:
chipsec/source/drivers/linux/chipsec_km.c:1472:9: attention : this ‘if’ clause does not guard... [-Wmisleading-indentation]
         if (direction & MSGBUS_MDR_OUT_MASK)
         ^~
chipsec/source/drivers/linux/chipsec_km.c:1475:13: note : ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
             ptr[4] = mdr_out;

```

I believe someone forgot braces around if statement. However the patch has not been tested ;) 