### PR TITLE
Add posibility to free allocated memory

### DIFF
--- a/source/drivers/linux/chipsec_km.c
+++ b/source/drivers/linux/chipsec_km.c
@@ -50,6 +50,9 @@ module_param(a1,ulong,0); //a1 is addr of page_is_ram function
 /// Char we show before each debug print
 const char program_name[] = "chipsec";
 
+// list of allocated memory
+struct allocated_mem_list allocated_mem_list;
+
 typedef struct tagCONTEXT {
    unsigned long a;   // rax - 0x00; eax - 0x0
    unsigned long b;   // rbx - 0x08; ebx - 0x4
@@ -1063,7 +1066,9 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
         //IN params: size
         //OUT params: physical address
         uint32_t NumberOfBytes = 0;
-        void *va, *pa, *max_pa;
+        void *va;
+        phys_addr_t pa, max_pa;
+        struct allocated_mem_list *tmp = NULL;
         
         numargs = 2;
         if(copy_from_user((void*)ptrbuf, (void*)ioctl_param, (sizeof(long) * numargs)) > 0)
@@ -1073,7 +1078,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
         }
         
         NumberOfBytes = ptr[0];
-        max_pa = (void *)ptr[1];
+        max_pa = ptr[1];
         
         va = kmalloc(NumberOfBytes, GFP_KERNEL );
         if( !va )
@@ -1083,20 +1088,25 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
         }
          
         memset(va, 0, NumberOfBytes);
-        pa = (void*)virt_to_phys(va);
+        pa = virt_to_phys(va);
 
         if (pa > max_pa)
         {
-            //printk(KERN_ALERT "[chipsec] ERROR: STATUS_UNSUCCESSFUL - could not allocate memory below max_pa (%p > %p)\n", pa, max_pa );
-            //kfree(va);
-            //return -EFAULT;
-            printk(KERN_ALERT "[chipsec] WARNING: allocated memory (%p) is not below max_pa (%p) (ignoring)", pa, max_pa);
+            printk(KERN_ALERT "[chipsec] WARNING: allocated memory (0x%llx) is not below max_pa (0x%llx) (ignoring)", pa, max_pa);
         }
-        //else
-        //{
-            ptr[0] = (unsigned long)va;
-            ptr[1] = (unsigned long)pa;
-        //}
+
+        tmp = kmalloc(sizeof(struct allocated_mem_list), GFP_KERNEL);
+        if (tmp == NULL) {
+            printk(KERN_ALERT "[chipsec] ERROR: STATUS_UNSUCCESSFUL - could not allocate memory\n");
+            return -EFAULT;
+        }
+
+        tmp->va = va;
+        tmp->pa = pa;
+        list_add(&(tmp->list), &(allocated_mem_list.list));
+
+        ptr[0] = (unsigned long)va;
+        ptr[1] = pa;
 		
         if(copy_to_user((void*)ioctl_param, (void*)ptrbuf, (sizeof(long) * numargs)) > 0)
 			return -EFAULT;
@@ -1106,9 +1116,11 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
     case IOCTL_FREE_PHYSMEM:
     {
         // IN params : physical address
-        // OUT params :
-        phys_addr_t pa;
-        void *va;
+        // OUT params : 0 not freed, 1 freed
+        phys_addr_t pa = 0;
+        void *va = NULL;
+        struct list_head *pos, *q;
+        struct allocated_mem_list *element;
 
         numargs = 1;
         if (copy_from_user((void*) ptrbuf, (void*) ioctl_param, (sizeof(long) * numargs)) > 0) {
@@ -1117,9 +1129,30 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
         }
 
         pa = ptr[0];
-        va = phys_to_virt(pa);
-        printk(KERN_INFO "[chipsec] freeing pa = 0x%llx, va = %p\n", pa, va);
-        kfree(va);
+
+        // look for va inside allocated mem list
+        list_for_each_safe(pos, q, &allocated_mem_list.list) {
+            element = list_entry(pos, struct allocated_mem_list, list);
+            if (element->pa == pa) {
+                va = element->va;
+                list_del(pos);
+                kfree(element);
+                break;
+            }
+        }
+
+        if (va != NULL) {
+            // freeing
+            printk(KERN_INFO "[chipsec] freeing pa = 0x%llx, va = %p\n", pa, va);
+            kfree(va);
+            ptr[0] = 1;
+        } else {
+            ptr[0] = 0;
+        }
+
+        if(copy_to_user((void*)ioctl_param, (void*)ptrbuf, (sizeof(long) * numargs)) > 0) {
+            return -EFAULT;
+        }
 
         break;
     }
@@ -1574,13 +1607,28 @@ init_module (void)
 		return ret;
 	}
 
+    // initialize allocated mem list
+    INIT_LIST_HEAD(&allocated_mem_list.list);
+
 	return 0;
 }
 
 /// Function executed when unloading module
 void cleanup_module (void)
 {
+    struct list_head *pos, *q;
+    struct allocated_mem_list *element;
+
 	dbgprint ("Destroying chipsec device");
 	misc_deregister(&chipsec_dev);
 	dbgprint ("exit");
+
+    // freeing
+    list_for_each_safe(pos, q, &allocated_mem_list.list) {
+        element = list_entry(pos, struct allocated_mem_list, list);
+        printk(KERN_INFO "auto freeing allocated memory (va = %p, pa = 0x%llx)\n", element->va, element->pa);
+        kfree(element->va);
+        list_del(pos);
+        kfree(element);
+    }
 }

--- a/source/drivers/linux/chipsec_km.c
+++ b/source/drivers/linux/chipsec_km.c
@@ -1102,6 +1102,27 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 			return -EFAULT;
 		break;
 	}
+
+    case IOCTL_FREE_PHYSMEM:
+    {
+        // IN params : physical address
+        // OUT params :
+        phys_addr_t pa;
+        void *va;
+
+        numargs = 1;
+        if (copy_from_user((void*) ptrbuf, (void*) ioctl_param, (sizeof(long) * numargs)) > 0) {
+            printk( KERN_ALERT "[chipsec] ERROR: STATUS_INVALID_PARAMETER\n" );
+            return -EFAULT;
+        }
+
+        pa = ptr[0];
+        va = phys_to_virt(pa);
+        printk(KERN_INFO "[chipsec] freeing pa = 0x%llx, va = %p\n", pa, va);
+        kfree(va);
+
+        break;
+    }
    
 #ifdef EFI_NOT_READY
 	case IOCTL_GET_EFIVAR:

--- a/source/drivers/linux/include/chipsec.h
+++ b/source/drivers/linux/include/chipsec.h
@@ -84,3 +84,8 @@ typedef struct _DESCRIPTOR_TABLE_RECORD {
 } DESCRIPTOR_TABLE_RECORD, *PDESCRIPTOR_TABLE_RECORD;
 #pragma pack()
 
+struct allocated_mem_list {
+  physaddr_t pa;
+  void *va;
+  struct list_head list;
+};

--- a/source/drivers/linux/include/chipsec.h
+++ b/source/drivers/linux/include/chipsec.h
@@ -25,6 +25,7 @@
 #define IOCTL_WRMMIO                   _IOWR(0, 0x13, int*)
 #define IOCTL_VA2PA                    _IOWR(0, 0x14, int*)
 #define IOCTL_MSGBUS_SEND_MESSAGE      _IOWR(0, 0x15, int*)
+#define IOCTL_FREE_PHYSMEM             _IOWR(0, 0x16, int*)
 
 //
 // SoC IOSF Message Bus constants

--- a/source/tool/chipsec/hal/physmem.py
+++ b/source/tool/chipsec/hal/physmem.py
@@ -137,9 +137,9 @@ class Memory:
     # Free physical memory buffer
 
     def free_physical_mem(self, pa):
-        self.helper.free_physical_mem(pa)
+        ret = self.helper.free_physical_mem(pa)
         if logger().HAL: logger().log( '[mem] Deallocated : PA = 0x%016X' % pa )
-        return
+        return True if ret == 1 else False
 
     def set_mem_bit(self, addr, bit):
         addr += bit >> 3

--- a/source/tool/chipsec/helper/linux/helper.py
+++ b/source/tool/chipsec/helper/linux/helper.py
@@ -76,6 +76,7 @@ IOCTL_RDMMIO                   = 0x12
 IOCTL_WRMMIO                   = 0x13
 IOCTL_VA2PA                    = 0x14
 IOCTL_MSGBUS_SEND_MESSAGE      = 0x15
+IOCTL_FREE_PHYSMEM             = 0x16
 
 class LinuxHelper(Helper):
 
@@ -394,6 +395,10 @@ class LinuxHelper(Helper):
         in_buf = struct.pack( "2"+self._pack, num_bytes, max_addr)
         out_buf = self.ioctl(IOCTL_ALLOC_PHYSMEM, in_buf)
         return struct.unpack( "2"+self._pack, out_buf )
+
+    def free_phys_mem(self, physmem):
+        in_buf = struct.pack( "1"+self._pack, physmem)
+        out_buf = self.ioctl(IOCTL_FREE_PHYSMEM, in_buf)
 
     def read_mmio_reg(self, phys_address, size):
         if self.driver_loaded:

--- a/source/tool/chipsec/helper/linux/helper.py
+++ b/source/tool/chipsec/helper/linux/helper.py
@@ -399,6 +399,7 @@ class LinuxHelper(Helper):
     def free_phys_mem(self, physmem):
         in_buf = struct.pack( "1"+self._pack, physmem)
         out_buf = self.ioctl(IOCTL_FREE_PHYSMEM, in_buf)
+        return struct.unpack( "1"+self._pack, out_buf)[0]
 
     def read_mmio_reg(self, phys_address, size):
         if self.driver_loaded:


### PR DESCRIPTION
The linux driver doesn't implement memory freeing of allocated memory.
Every allocated memory is saved inside a list. Each time ```IOCTL_FREE_PHYSMEM``` is called, the driver retrieves the virtual address by looking inside the previous allocated memory list. If a valid virtual address if found, the memory buffer is freed. Hence :

- double free is not possible
- only allocated buffer can be freed
- memory leaks are avoided by freeing every buffer still inside the list at the driver cleanup

This simple chipsec module can be used to test this feature :

```python

from chipsec.module_common import *

class test_alloc_free(BaseModule):

	def __init__(self):
		BaseModule.__init__(self)

	def is_supported(self):
		return True

	def run(self, argv):
		l = []
		for i in range(10):
			l.append(self.cs.mem.alloc_physical_mem(0x1000))

		# double free
		print self.cs.mem.free_physical_mem(l[0][1]) # True
		print self.cs.mem.free_physical_mem(l[0][1]) # False

		print self.cs.mem.free_physical_mem(0x1337babe) # False

		for i in range(1, 5):
			print self.cs.mem.free_physical_mem(l[i][1]) # True
```

```
[ 4238.049500] Chipsec module loaded 
[ 4238.049504] ** This module exposes hardware & memory access, **
[ 4238.049505] ** which can effect the secure operation of      **
[ 4238.049506] ** production systems!! Use for research only!   **
[ 4238.142070] [chipsec] freeing pa = 0x20e073000, va = ffff88020e073000
[ 4238.142119] [chipsec] freeing pa = 0x20e076000, va = ffff88020e076000
[ 4238.142134] [chipsec] freeing pa = 0x20e071000, va = ffff88020e071000
[ 4238.142149] [chipsec] freeing pa = 0x20e072000, va = ffff88020e072000
[ 4238.142164] [chipsec] freeing pa = 0x20e077000, va = ffff88020e077000
[ 4238.143760] chipsec cleanup_module 1622: Destroying chipsec device
[ 4238.143826] chipsec cleanup_module 1624: exit
[ 4238.143829] auto freeing allocated memory (va = ffff880222453000, pa = 0x222453000)
[ 4238.143830] auto freeing allocated memory (va = ffff880222451000, pa = 0x222451000)
[ 4238.143831] auto freeing allocated memory (va = ffff880222450000, pa = 0x222450000)
[ 4238.143832] auto freeing allocated memory (va = ffff880222454000, pa = 0x222454000)
[ 4238.143833] auto freeing allocated memory (va = ffff88020e075000, pa = 0x20e075000)
```