### PR TITLE
Check that hardware sequencing is enabled

### DIFF
--- a/source/tool/chipsec/hal/spi.py
+++ b/source/tool/chipsec/hal/spi.py
@@ -480,6 +480,13 @@ class SPI:
 
         return cycle_done
 
+    def check_hardware_sequencing(self):
+        # Test if the flash decriptor is valid (and hardware sequencing enabled)
+        fdv = chipsec.chipset.read_register_field(self.cs, 'HSFS', 'FDV')
+        if fdv == 0:
+            logger().error("HSFS.FDV is 0, hardware sequencing is disabled")
+            raise SpiRuntimeError("Chipset does not support hardware sequencing")
+
     #
     # SPI Flash operations
     #
@@ -500,6 +507,9 @@ class SPI:
         #return self.write_spi( spi_fla, struct.unpack('B'*len(buf), buf) )
 
     def read_spi(self, spi_fla, data_byte_count ):
+
+        self.check_hardware_sequencing()
+	
         buf = []
         dbc = SPI_READ_WRITE_DEF_DBC
         if (data_byte_count >= SPI_READ_WRITE_MAX_DBC):
@@ -550,6 +560,9 @@ class SPI:
         return buf
 
     def write_spi(self, spi_fla, buf ):
+	
+        self.check_hardware_sequencing()
+
         write_ok = True
         data_byte_count = len(buf)
         dbc = 4
@@ -590,6 +603,9 @@ class SPI:
         return write_ok
 
     def erase_spi_block(self, spi_fla ):
+
+        self.check_hardware_sequencing()
+
         if logger().UTIL_TRACE or logger().VERBOSE:
             logger().log( "[spi] Erasing SPI Flash block @ 0x%X" % spi_fla )
 

--- a/source/tool/tests/software/mock_helper.py
+++ b/source/tool/tests/software/mock_helper.py
@@ -194,6 +194,7 @@ class SPIHelper(TestHelper):
     RCBA_ADDR = 0xFED0000
     SPIBAR_ADDR = RCBA_ADDR + 0x3800
     SPIBAR_END = SPIBAR_ADDR + 0x200
+    HSFS = SPIBAR_ADDR + 0x4
     FRAP = SPIBAR_ADDR + 0x50
     FREG0 = SPIBAR_ADDR + 0x54
     LPC_BRIDGE_DEVICE = (0, 0x1F, 0)
@@ -218,6 +219,8 @@ class SPIHelper(TestHelper):
             return 0x00020002
         elif pa == self.FRAP:
             return 0xEEEEEEEE
+        elif pa == self.HSFS:
+            return (1 << 14) # FDV = 1, the flash descriptor is valid
         elif pa >= self.SPIBAR_ADDR and pa < self.SPIBAR_END:
             return 0x0
         else:


### PR DESCRIPTION
Currently, no check is performed to detect that hardware sequencing is enabled (HSFS.FDV). When such configuration is encountered, although the base and limit values are meaningless, Chipsec still interpret them and try to read/write to the flash.

This patch add a method to the SPI HAL to detect such configuration. A call to this method is added to the beginning of each SPI operation.

By doing so, it is still possible to run 'chipsec_utils.py spi info' to get some information on the flash.