### PR TITLE
Add detection of EFI binaries vulnerable to ThinkPwn to blacklist config

### DIFF
--- a/source/tool/chipsec/modules/tools/uefi/blacklist.json
+++ b/source/tool/chipsec/modules/tools/uefi/blacklist.json
@@ -3,5 +3,11 @@
   "HT_rkloader_name" : { "name": "rkloader" },
   "HT_Ntfs"          : { "guid": "F50258A9-2F4D-4DA9-861E-BDA84D07A44C" },
   "HT_Ntfs_name"     : { "name": "Ntfs" },
-  "HT_app"           : { "guid": "EAEA9AEC-C9C1-46E2-9D52-432AD25A9B0B" }
+  "HT_app"           : { "guid": "EAEA9AEC-C9C1-46E2-9D52-432AD25A9B0B" },
+
+  "ThinkPwn_SmmRuntimeProtGuid"      : { "regexp": "\\xA1\\x97\\x68\\xA5\\x7F\\xA7\\x00\\x46\\x84\\xDB\\x22\\xB0\\xA8\\x01\\xFA\\x9A" },
+  "ThinkPwn_SystemSmmRuntimeRt_name" : { "name": "SystemSmmRuntimeRt.efi" },
+  "ThinkPwn_SystemSmmRuntimeRt"      : { "guid": "7C79AC8C-5E6C-4E3D-BA6F-C260EE7C172E" },
+  "ThinkPwn_SmmRuntime_name"         : { "name": "SmmRuntime" },
+  "ThinkPwn_SmmRuntime"              : { "guid": "A56897A1-A77F-4600-84DB-22B0A801FA9A" }
 }

--- a/source/tool/chipsec/modules/tools/uefi/blacklist.py
+++ b/source/tool/chipsec/modules/tools/uefi/blacklist.py
@@ -25,13 +25,16 @@ which can be EFI firmware volumes, EFI executable binaries (PEI modules, DXE dri
 The module can find EFI binaries by their UI names, EFI GUIDs, MD5/SHA-1/SHA-256 hashes
 or contents matching specified regular expressions.
 
+Important! This module can only detect what it knows about from its config file.
+If a bad or vulnerable binary is not detected then its 'signature' needs to be added to the config.
+
 Usage:
     chipsec_main.py -i -m tools.uefi.blacklist [-a <fw_image>,<blacklist>]
 
       fw_image  : Full file path to UEFI firmware image
-                  If <fw_image> is not specified, the module will dump firmware image directly from flash memory device
-      blacklist : File name of JSON file with configuration of black-listed EFI binaries (default = blacklist.json)
-                  Config file should be located in the same directory as blacklist.py module
+                  If not specified, the module will dump firmware image directly from ROM
+      blacklist : JSON file with configuration of black-listed EFI binaries (default = blacklist.json)
+                  Config file should be located in the same directory as this module
     
 Examples:
 
@@ -65,9 +68,9 @@ Usage:
     chipsec_main.py -i -m tools.uefi.blacklist [-a <fw_image>,<blacklist>]
 
       fw_image  : Full file path to UEFI firmware image
-                  If <fw_image> is not specified, the module will dump firmware image directly from flash memory device
-      blacklist : File name of JSON file with configuration of black-listed EFI binaries (default = blacklist.json)
-                  Config file should be located in the same directory as blacklist.py module
+                  If not specified, the module will dump firmware image directly from ROM
+      blacklist : JSON file with configuration of black-listed EFI binaries (default = blacklist.json)
+                  Config file should be located in the same directory as this module
     
 Examples:
 
@@ -82,6 +85,10 @@ Examples:
       checks for black-listed EFI modules defined in 'blacklist.json' config
       None: -i and --no_driver arguments can be used in this case because the test
       does not depend on the platform and no kernel driver is required when firmware image is specified
+
+Important! This module can only detect what it knows about from its config file.
+If a bad or vulnerable binary is not detected then its 'signature' needs to be added to the config.
+
 '''
 
 
@@ -100,7 +107,7 @@ class blacklist(BaseModule):
     def check_blacklist( self ):
         res = ModuleResult.PASSED
 
-        self.logger.log( "[CHIPSEC] looking for black-listed EFI binaries defined in '%s'..." % self.cfg_name )
+        self.logger.log( "[*] looking for black-listed EFI binaries defined in '%s'..." % self.cfg_name )
         #self.logger.log( self.efi_blacklist )
 
         # no need to output the entire hierarchy of EFI modules
@@ -141,13 +148,13 @@ class blacklist(BaseModule):
             self.spi = chipsec.hal.spi.SPI( self.cs )
             (base,limit,freg) = self.spi.get_SPI_region( chipsec.hal.spi.BIOS )
             image_size = limit + 1 - base
-            self.logger.log( "[CHIPSEC] dumping FW image from ROM to %s: 0x%08X bytes at [0x%08X:0x%08X]" % (image_file,base,limit,image_size) )
-            self.logger.log( "[CHIPSEC] this may take a few minutes (instead, use 'chipsec_util spi dump')..." )
+            self.logger.log( "[*] dumping FW image from ROM to %s: 0x%08X bytes at [0x%08X:0x%08X]" % (image_file,base,limit,image_size) )
+            self.logger.log( "[*] this may take a few minutes (instead, use 'chipsec_util spi dump')..." )
             self.spi.read_spi_to_file( base, image_size, image_file )
         elif len(module_argv) > 0:
             # Use provided firmware image 
             image_file = module_argv[0]
-            self.logger.log( "[CHIPSEC] reading FW image from file: %s" % image_file )
+            self.logger.log( "[*] reading FW image from file: %s" % image_file )
 
         self.image = chipsec.file.read_file( image_file )
 


### PR DESCRIPTION
This change extends _blacklist.json_ configuration file for _tools.uefi.blacklist_ module with detection of EFI binaries vulnerable to SmmRuntime privilege escalation vulnerability a.k.a. 'ThinkPwn' discovered by Dmytro Oleksiuk (https://github.com/Cr4sh).

Refer to this blog for details: http://blog.cr4.sh/2016/06/exploring-and-exploiting-lenovo.html

It detects EFI binaries which have the following attributes:
1. GUID _A56897A1-A77F-4600-84DB-22B0A801FA9A_ string of vulnerable UEFI SmmRuntime protocol within the contents of EFI binaries
2. Two names (UI strings) '_SystemSmmRuntimeRt.efi_' and '_SmmRuntime_' and two GUIDs _7C79AC8C-5E6C-4E3D-BA6F-C260EE7C172E_ and _A56897A1-A77F-4600-84DB-22B0A801FA9A_ of vulnerable EFI binaries found in different systems

**Note!** The _tools.uefi.blacklist_ module is only as good as its config in _blacklist.json_. It only detects what it knows about. If there's any other bad or vulnerable binary which is not detected then its "signature" (GUID, hash or contents regexp) needs to be added to _blacklist.json_