### PR TITLE
Make sure Limit of SPI Protected Range is calculated correctly

### DIFF
--- a/chipsec/hal/spi.py
+++ b/chipsec/hal/spi.py
@@ -222,6 +222,8 @@ class SPI:
 
         base = (pr_j & Cfg.PCH_RCBA_SPI_PR0_PRB_MASK) << 12
         limit = (pr_j & Cfg.PCH_RCBA_SPI_PR0_PRL_MASK) >> 4
+        if limit != 0:
+          limit = limit | 0xFFF	
         wpe = ((pr_j & Cfg.PCH_RCBA_SPI_PR0_WPE) != 0)
         rpe = ((pr_j & Cfg.PCH_RCBA_SPI_PR0_RPE) != 0)
 


### PR DESCRIPTION
"Address bits 11:0 are assumed to be FFFh for the limit comparison" as per reference 21.1.13 on page 730 on http://www.intel.com/content/dam/www/public/us/en/documents/datasheets/8-series-chipset-pch-datasheet.pdf

Therefore I'm ORing 0xFFF to limit, if limit is not 0, to make sure the correct limit is displayed by chipsec.

=================================
Output before this change:
----------------------
[*] BIOS Region: Base = 0x00510000, Limit = 0x00FFFFFF
SPI Protected Ranges
------------------------------------------------------------
PRx (offset) | Value    | Base     | Limit    | WP? | RP?
------------------------------------------------------------
PR0 (74)     | 8FFF0FF0 | 00FF0000 | 00FFF000 | 1   | 0 
PR1 (78)     | 00000000 | 00000000 | 00000000 | 0   | 0 
PR2 (7C)     | 00000000 | 00000000 | 00000000 | 0   | 0 
PR3 (80)     | 00000000 | 00000000 | 00000000 | 0   | 0 
PR4 (84)     | 00000000 | 00000000 | 00000000 | 0   | 0 

=================================
Output with this change:
------------------
[*] BIOS Region: Base = 0x00510000, Limit = 0x00FFFFFF
SPI Protected Ranges
------------------------------------------------------------
PRx (offset) | Value    | Base     | Limit    | WP? | RP?
------------------------------------------------------------
PR0 (74)     | 8FFF0FF0 | 00FF0000 | 00FFFFFF | 1   | 0 
PR1 (78)     | 00000000 | 00000000 | 00000000 | 0   | 0 
PR2 (7C)     | 00000000 | 00000000 | 00000000 | 0   | 0 
PR3 (80)     | 00000000 | 00000000 | 00000000 | 0   | 0 
PR4 (84)     | 00000000 | 00000000 | 00000000 | 0   | 0 