### PR TITLE
Modify SPI Protected Range Masks to ignore reserved bits

### DIFF
--- a/chipsec/cfg/common.py
+++ b/chipsec/cfg/common.py
@@ -137,9 +137,9 @@ class Cfg:
 
     # Protected Range Registers
     PCH_RCBA_SPI_PR0_WPE             = BIT31                         # Write Protection Enable
-    PCH_RCBA_SPI_PR0_PRL_MASK        = 0x7FFF0000                    # Protected Range Limit Mask
+    PCH_RCBA_SPI_PR0_PRL_MASK        = 0x1FFF0000                    # Protected Range Limit Mask
     PCH_RCBA_SPI_PR0_RPE             = BIT15                         # Read Protection Enable
-    PCH_RCBA_SPI_PR0_PRB_MASK        = 0x00007FFF                    # Protected Range Base Mask
+    PCH_RCBA_SPI_PR0_PRB_MASK        = 0x00001FFF                    # Protected Range Base Mask
 
     PCH_RCBA_SPI_OPTYPE_RDNOADDR     = 0x00
     PCH_RCBA_SPI_OPTYPE_WRNOADDR     = 0x01


### PR DESCRIPTION
The current masks include reserved bits for calculations when they shouldn't be included according to the documentation. Bit 30:29 and bit 14:13 are reserved according to "21.1.13 PR0—Protected Range 0 Register" on page 730 of http://www.intel.com/content/dam/www/public/us/en/documents/datasheets/8-series-chipset-pch-datasheet.pdf

Only Bit 16:28 should be exposed from PCH_RCBA_SPI_PR0_PRL_MASK:
- Old = 0x7FFF0000 = 0111 1111 1111 1111 0000 0000 0000 0000
- New = 0x1FFF0000 = 0001 1111 1111 1111 0000 0000 0000 0000

Only bit 0:12 should be exposed from PCH_RCBA_SPI_PR0_PRB_MASK:
- Old = 0x00007FFF = 0000 0000 0000 0000 01111 1111 1111 1111
- New = 0x00001FFF = 0000 0000 0000 0000 0001 1111 1111 1111