### PR TITLE
SPI HAL cleanup to use XML config

### DIFF
--- a/chipsec/cfg/common.xml
+++ b/chipsec/cfg/common.xml
@@ -212,8 +212,8 @@
 
     <!-- SPI Flash Controller -->
     <register name="BFPR" type="mmio" bar="SPIBAR" offset="0x00" size="4" desc="BIOS Flash Primary Region Register (= FREG1)">
-      <field name="PRB"  bit="0"  size="12" desc="BIOS Flash Primary Region Base"/>
-      <field name="PRL"  bit="16" size="12" desc="BIOS Flash Primary Region Limit"/>
+      <field name="PRB"  bit="0"  size="13" desc="BIOS Flash Primary Region Base"/>
+      <field name="PRL"  bit="16" size="13" desc="BIOS Flash Primary Region Limit"/>
     </register>
     <register name="HSFS" type="mmio" bar="SPIBAR" offset="0x04" size="2" desc="Hardware Sequencing Flash Status Register">
       <field name="FDONE"   bit="0"  size="1" desc="Flash Cycle Done"/>
@@ -283,34 +283,34 @@
       <field name="RL" bit="16" size="12" desc="Region Limit"/>
     </register>
     <register name="PR0" type="mmio" bar="SPIBAR" offset="0x74" size="4" desc="Protected Range 0">
-      <field name="PRB" bit="0"  size="13"/>
-      <field name="RPE" bit="15" size="1"/>
-      <field name="PRL" bit="16" size="13"/>
-      <field name="WPE" bit="31" size="1"/>
+      <field name="PRB" bit="0"  size="13" desc="Protected Range Base"/>
+      <field name="RPE" bit="15" size="1"  desc="Read Protection Enabled"/>
+      <field name="PRL" bit="16" size="13" desc="Protected Range Limit"/>
+      <field name="WPE" bit="31" size="1"  desc="Write Protection Enabled"/>
     </register>
     <register name="PR1" type="mmio" bar="SPIBAR" offset="0x78" size="4" desc="Protected Range 1">
-      <field name="PRB" bit="0"  size="13"/>
-      <field name="RPE" bit="15" size="1"/>
-      <field name="PRL" bit="16" size="13"/>
-      <field name="WPE" bit="31" size="1"/>
+      <field name="PRB" bit="0"  size="13" desc="Protected Range Base"/>
+      <field name="RPE" bit="15" size="1"  desc="Read Protection Enabled"/>
+      <field name="PRL" bit="16" size="13" desc="Protected Range Limit"/>
+      <field name="WPE" bit="31" size="1"  desc="Write Protection Enabled"/>
     </register>
     <register name="PR2" type="mmio" bar="SPIBAR" offset="0x7C" size="4" desc="Protected Range 2">
-      <field name="PRB" bit="0"  size="13"/>
-      <field name="RPE" bit="15" size="1"/>
-      <field name="PRL" bit="16" size="13"/>
-      <field name="WPE" bit="31" size="1"/>
+      <field name="PRB" bit="0"  size="13" desc="Protected Range Base"/>
+      <field name="RPE" bit="15" size="1"  desc="Read Protection Enabled"/>
+      <field name="PRL" bit="16" size="13" desc="Protected Range Limit"/>
+      <field name="WPE" bit="31" size="1"  desc="Write Protection Enabled"/>
     </register>
     <register name="PR3" type="mmio" bar="SPIBAR" offset="0x80" size="4" desc="Protected Range 3">
-      <field name="PRB" bit="0"  size="13"/>
-      <field name="RPE" bit="15" size="1"/>
-      <field name="PRL" bit="16" size="13"/>
-      <field name="WPE" bit="31" size="1"/>
+      <field name="PRB" bit="0"  size="13" desc="Protected Range Base"/>
+      <field name="RPE" bit="15" size="1"  desc="Read Protection Enabled"/>
+      <field name="PRL" bit="16" size="13" desc="Protected Range Limit"/>
+      <field name="WPE" bit="31" size="1"  desc="Write Protection Enabled"/>
     </register>
     <register name="PR4" type="mmio" bar="SPIBAR" offset="0x84" size="4" desc="Protected Range 4">
-      <field name="PRB" bit="0"  size="13"/>
-      <field name="RPE" bit="15" size="1"/>
-      <field name="PRL" bit="16" size="13"/>
-      <field name="WPE" bit="31" size="1"/>
+      <field name="PRB" bit="0"  size="13" desc="Protected Range Base"/>
+      <field name="RPE" bit="15" size="1"  desc="Read Protection Enabled"/>
+      <field name="PRL" bit="16" size="13" desc="Protected Range Limit"/>
+      <field name="WPE" bit="31" size="1"  desc="Write Protection Enabled"/>
     </register>
     <register name="PREOP" type="mmio" bar="SPIBAR" offset="0x94" size="2" desc="Prefix Opcode Configuration Register">
       <field name="PREOP0" bit="0" size="8" desc="Prefix Opcode 0"/>


### PR DESCRIPTION
Removed hardcoded offsets from hal.spi when reading FREGx and PRx and
replaced with XML config.

This pull request also includes PR #109 (Make sure Limit of SPI Protected
Range is calculated correctly) by @timevortex except bits 11:0 of PRx
limit are also set to FFFh when PRL field is 0 (in this case PRx applies
to the first 4kB of flash).