### PR TITLE
Minor fix: Only align to 4KB if WP or RP is set

### DIFF
--- a/chipsec/hal/spi.py
+++ b/chipsec/hal/spi.py
@@ -228,11 +228,15 @@ class SPI:
         base  = chipsec.chipset.get_register_field( self.cs, pr_name, pr_j, 'PRB' ) << SPI_FLA_SHIFT
         # Protected Range Limit corresponds to FLA bits 24:12
         limit = chipsec.chipset.get_register_field( self.cs, pr_name, pr_j, 'PRL' ) << SPI_FLA_SHIFT
-        # FLA bits 11:0 are assumed to be FFFh for the limit comparison
-        limit |= SPI_FLA_PAGE_MASK
-
+        
         wpe = (0 != chipsec.chipset.get_register_field( self.cs, pr_name, pr_j, 'WPE' ))
         rpe = (0 != chipsec.chipset.get_register_field( self.cs, pr_name, pr_j, 'RPE' ))
+
+        # Check if this is a valid PRx config
+        if wpe or rpe:
+            # FLA bits 11:0 are assumed to be FFFh for the limit comparison
+            limit |= SPI_FLA_PAGE_MASK
+
         return (base,limit,wpe,rpe,pr_j_reg,pr_j)
 
     ##############################################################################################################


### PR DESCRIPTION
Hi @c7zero,

I saw a minor bug after reading your comment in my PR #109. Just correcting that here.

============
Prior to this change, the output was:
[*] BIOS Region: Base = 0x00510000, Limit = 0x00FFFFFF
SPI Protected Ranges
------------------------------------------------------------
PRx (offset) | Value    | Base     | Limit    | WP? | RP?
------------------------------------------------------------
PR0 (74)     | 8FFF0FF0 | 00FF0000 | 00FFFFFF | 1   | 0 
PR1 (78)     | 00000000 | 00000000 | 00000FFF | 0   | 0 
PR2 (7C)     | 00000000 | 00000000 | 00000FFF | 0   | 0 
PR3 (80)     | 00000000 | 00000000 | 00000FFF | 0   | 0 
PR4 (84)     | 00000000 | 00000000 | 00000FFF | 0   | 0 

Now: it is:
[*] BIOS Region: Base = 0x00510000, Limit = 0x00FFFFFF
SPI Protected Ranges
------------------------------------------------------------
PRx (offset) | Value    | Base     | Limit    | WP? | RP?
------------------------------------------------------------
PR0 (74)     | 8FFF0FF0 | 00FF0000 | 00FFFFFF | 1   | 0 
PR1 (78)     | 00000000 | 00000000 | 00000000 | 0   | 0 
PR2 (7C)     | 00000000 | 00000000 | 00000000 | 0   | 0 
PR3 (80)     | 00000000 | 00000000 | 00000000 | 0   | 0 
PR4 (84)     | 00000000 | 00000000 | 00000000 | 0   | 0