### PR TITLE
Add a check for primary to sideband bridge hide.

### DIFF
--- a/chipsec/cfg/skl.xml
+++ b/chipsec/cfg/skl.xml
@@ -190,7 +190,11 @@
     <register name="TCO1_CNT" type="iobar" bar="TCOBASE" offset="0x8" size="2" desc="TCO1 Control">
       <field name="TCO_LOCK" bit="12" size="1" desc="TCO Lock"/>
     </register>
-
+    
+    <!-- Private to Sideband Bridge Registers -->
+    <register name="P2SBC" type="pcicfg" bus="0" dev="0x1F" fun="1" offset="0xE0" size="4" desc="P2SB Control">
+      <field  name="Hide"  bit="8" size="1"   desc="Hide Device"/>
+    </register>
    
   </registers>
 
@@ -201,7 +205,8 @@
   <!--                                      -->
   <!-- #################################### -->
   <controls>
-    <control name="BiosInterfaceLockDown"  register="BC"                  field="BILD"               desc="BIOS Interface Lock-Down"/>
+    <control name="BiosInterfaceLockDown" register="BC" field="BILD" desc="BIOS Interface Lock-Down"/>
+    <control name="P2sbHide" register="P2SBC" field="Hide" desc="Hide Primary to Sideband Bridge"/>
   </controls>
 
 </configuration>

--- a/chipsec/modules/common/p2sb_hide.py
+++ b/chipsec/modules/common/p2sb_hide.py
@@ -1,0 +1,57 @@
+#CHIPSEC: Platform Security Assessment Framework
+#Copyright (c) 2010-2015, Intel Corporation
+# 
+#This program is free software; you can redistribute it and/or
+#modify it under the terms of the GNU General Public License
+#as published by the Free Software Foundation; Version 2.
+#
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program; if not, write to the Free Software
+#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#Contact information:
+#chipsec@intel.com
+#
+
+
+
+"""
+P2SB device is to be hidden by the BIOS before PCI enumeration step.
+After post, the unhiding should be done within SMM only to prevent OS from seeing it. 
+"""
+from chipsec.module_common import *
+TAGS = [MTAG_BIOS]
+
+class p2sb_hide(BaseModule):
+
+    def __init__(self):
+        BaseModule.__init__(self)
+
+    def is_supported(self):
+        if not chipsec.chipset.is_register_defined(self.cs, 'P2SBC'):
+            self.logger.error( "Couldn't find definition of required configuration registers" )
+            return False
+        else:
+            return True
+
+    def check_p2sb_hide(self):
+        self.logger.start_test( "Primary to Sideband bridge Hide" )
+
+        p2sb_hide_res = ModuleResult.FAILED
+        p2sb_hide_val = chipsec.chipset.get_control(self.cs, 'P2sbHide', with_print=True)
+
+        if 1 == p2sb_hide_val:
+            p2sb_hide_res = ModuleResult.PASSED
+            self.logger.log_passed_check( "Primary to Sideband Bridge is hided" )
+        else:
+            self.logger.log_failed_check( "Primary to Sideband Bridge is not hided" )
+
+        return p2sb_hide_res
+
+    def run( self, module_argv ):
+        return self.check_p2sb_hide()


### PR DESCRIPTION
Primary to sideband bridge device is to be hidden by the BIOS before PCI enumeration step.
After post, the unhiding should be done within SMM only to prevent OS from seeing it. 
