### PR TITLE
Use HALBase for all HAL modules

### DIFF
--- a/chipsec/hal/acpi.py
+++ b/chipsec/hal/acpi.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python
 #CHIPSEC: Platform Security Assessment Framework
 #Copyright (c) 2010-2015, Intel Corporation
-# 
+#
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
 #as published by the Free Software Foundation; Version 2.
@@ -44,9 +44,8 @@ from collections import namedtuple
 from chipsec.logger import *
 from chipsec.file import *
 
-import chipsec.hal.acpi_tables
-import chipsec.hal.uefi
-import chipsec.helper.oshelper
+from chipsec.hal import acpi_tables, hal_base, uefi
+from chipsec.helper import oshelper
 
 class AcpiRuntimeError (RuntimeError):
     pass
@@ -116,44 +115,44 @@ ACPI_TABLE_SIG_LPIT = 'LPIT'
 ACPI_TABLE_SIG_ASPT = 'ASPT'
 
 ACPI_TABLES = {
-  ACPI_TABLE_SIG_ROOT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_RSDT: chipsec.hal.acpi_tables.RSDT,
-  ACPI_TABLE_SIG_XSDT: chipsec.hal.acpi_tables.XSDT,
-  ACPI_TABLE_SIG_FACP: chipsec.hal.acpi_tables.FADT,
-  ACPI_TABLE_SIG_FACS: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_DSDT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_SSDT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_PSDT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_APIC: chipsec.hal.acpi_tables.APIC,
-  ACPI_TABLE_SIG_SBST: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_ECDT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_SRAT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_SLIC: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_SLIT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_BOOT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_CPEP: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_DBGP: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_ETDT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_HPET: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_MCFG: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_SPCR: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_SPMI: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_TCPA: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_WDAT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_WDRT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_WSPT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_WDDT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_ASF : chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_MSEG: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_DMAR: chipsec.hal.acpi_tables.DMAR,
-  ACPI_TABLE_SIG_UEFI: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_FPDT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_PCCT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_MSDM: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_BATB: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_BGRT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_LPIT: chipsec.hal.acpi_tables.ACPI_TABLE,
-  ACPI_TABLE_SIG_ASPT: chipsec.hal.acpi_tables.ACPI_TABLE
+  ACPI_TABLE_SIG_ROOT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_RSDT: acpi_tables.RSDT,
+  ACPI_TABLE_SIG_XSDT: acpi_tables.XSDT,
+  ACPI_TABLE_SIG_FACP: acpi_tables.FADT,
+  ACPI_TABLE_SIG_FACS: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_DSDT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_SSDT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_PSDT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_APIC: acpi_tables.APIC,
+  ACPI_TABLE_SIG_SBST: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_ECDT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_SRAT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_SLIC: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_SLIT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_BOOT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_CPEP: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_DBGP: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_ETDT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_HPET: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_MCFG: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_SPCR: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_SPMI: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_TCPA: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_WDAT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_WDRT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_WSPT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_WDDT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_ASF : acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_MSEG: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_DMAR: acpi_tables.DMAR,
+  ACPI_TABLE_SIG_UEFI: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_FPDT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_PCCT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_MSDM: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_BATB: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_BGRT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_LPIT: acpi_tables.ACPI_TABLE,
+  ACPI_TABLE_SIG_ASPT: acpi_tables.ACPI_TABLE
 }
 
 ########################################################################################################
@@ -213,10 +212,10 @@ class RSDP():
 #
 ########################################################################################################
 
-class ACPI:
-    def __init__( self, cs ):
-        self.cs     = cs
-        self.uefi   = chipsec.hal.uefi.UEFI( self.cs )
+class ACPI(hal_base.HALBase):
+    def __init__(self, cs):
+        super(ACPI, self).__init__(cs)
+        self.uefi = uefi.UEFI(self.cs)
         self.tableList = defaultdict(list)
         self.get_ACPI_table_list()
 

--- a/chipsec/hal/cmos.py
+++ b/chipsec/hal/cmos.py
@@ -46,7 +46,7 @@ import struct
 import sys
 import time
 
-from chipsec.hal.hal_base import HALBase
+from chipsec.hal import hal_base
 import chipsec.logger
 
 class CmosRuntimeError (RuntimeError):
@@ -60,7 +60,10 @@ CMOS_ADDR_PORT_HIGH = 0x72
 CMOS_DATA_PORT_HIGH = 0x73
 
 
-class CMOS(HALBase):
+class CMOS(hal_base.HALBase):
+
+    def __init__(self, cs):
+        super(CMOS, self).__init__(cs)
 
     def read_cmos_high( self, offset ):
         self.cs.io.write_port_byte( CMOS_ADDR_PORT_HIGH, offset );

--- a/chipsec/hal/cpuid.py
+++ b/chipsec/hal/cpuid.py
@@ -41,16 +41,17 @@ import struct
 import sys
 import os.path
 
+from chipsec.hal import hal_base
 from chipsec.logger import logger
 
 class CpuIDRuntimeError (RuntimeError):
     pass
 
-class CpuID:
+class CpuID(hal_base.HALBase):
 
-    def __init__( self, cs ):
+    def __init__(self, cs):
+        super(CpuID, self).__init__(cs)
         self.helper = cs.helper
-        self.cs = cs
 
     def cpuid(self, eax, ecx ):
         if logger().VERBOSE: logger().log( "[cpuid] in: EAX=0x%08X, ECX=0x%08X" % (eax, ecx) )

--- a/chipsec/hal/ec.py
+++ b/chipsec/hal/ec.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python
 #CHIPSEC: Platform Security Assessment Framework
 #Copyright (c) 2010-2016, Intel Corporation
-# 
+#
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
 #as published by the Free Software Foundation; Version 2.
@@ -44,6 +44,7 @@ Usage:
 
 """
 
+from chipsec.hal import hal_base
 from chipsec.logger import *
 from chipsec.cfg.common import *
 
@@ -76,10 +77,7 @@ EC_COMMAND_ACPI_QUERY       = 0x084  # Query EC event
 EC_COMMAND_ACPI_READ_EXT    = 0x0F0  # Read EC ACPI extended memory
 EC_COMMAND_ACPI_WRITE_EXT   = 0x0F1  # Write EC ACPI extended memory
 
-class EC:
-    def __init__( self, cs ):
-        self.cs = cs
-
+class EC(hal_base.HALBase):
 
     #
     # EC ACPI memory access

--- a/chipsec/hal/hal_base.py
+++ b/chipsec/hal/hal_base.py
@@ -1,6 +1,6 @@
 #CHIPSEC: Platform Security Assessment Framework
 #Copyright (c) 2010-2016, Intel Corporation
-# 
+#
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
 #as published by the Free Software Foundation; Version 2.
@@ -25,10 +25,8 @@ Base for HAL Components
 """
 
 import chipsec.logger
-import chipsec.chipset
-import chipsec.defines
 
-class HALBase( object ):
-    def __init__(self):
-        self.cs = chipsec.chipset.cs()
+class HALBase(object):
+    def __init__(self, cs):
+        self.cs = cs
         self.logger = chipsec.logger.logger()

--- a/chipsec/hal/interrupts.py
+++ b/chipsec/hal/interrupts.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python
 #CHIPSEC: Platform Security Assessment Framework
 #Copyright (c) 2010-2015, Intel Corporation
-# 
+#
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
 #as published by the Free Software Foundation; Version 2.
@@ -44,6 +44,7 @@ __version__ = '1.0'
 import struct
 import sys
 
+from chipsec.hal import hal_base
 from chipsec.logger import *
 from chipsec.cfg.common import *
 
@@ -53,9 +54,7 @@ NMI_TCO1_CTL = 0x8 # NMI_NOW is bit [8] in TCO1_CTL (or bit [1] in TCO1_CTL + 1)
 NMI_NOW      = 0x1
 
 
-class Interrupts:
-    def __init__( self, cs ):
-        self.cs = cs
+class Interrupts(hal_base.HALBase):
 
     def send_SW_SMI( self, thread_id, SMI_code_port_value, SMI_data_port_value, _rax, _rbx, _rcx, _rdx, _rsi, _rdi ):
         SMI_code_data = (SMI_data_port_value << 8 | SMI_code_port_value)

--- a/chipsec/hal/iobar.py
+++ b/chipsec/hal/iobar.py
@@ -44,8 +44,7 @@ import struct
 import sys
 import time
 
-import chipsec.chipset
-#from chipsec.hal.hal_base import HALBase
+from chipsec.hal import hal_base
 from chipsec.logger import logger
 
 DEFAULT_IO_BAR_SIZE = 0x100
@@ -55,11 +54,10 @@ class IOBARRuntimeError (RuntimeError):
 class IOBARNotFoundError (RuntimeError):
     pass
 
+class IOBAR(hal_base.HALBase):
 
-class iobar:
-
-    def __init__( self, cs ):
-        self.cs = cs
+    def __init__(self, cs):
+        super(IOBAR, self).__init__(cs)
 
     #
     # Check if I/O BAR with bar_name has been defined in XML config
@@ -85,9 +83,9 @@ class iobar:
             bar_reg   = bar['register']
             if 'base_field' in bar:
                 base_field = bar['base_field']
-                base = chipsec.chipset.read_register_field( self.cs, bar_reg, base_field, preserve_field_position=True )
+                base = self.cs.read_register_field( bar_reg, base_field, preserve_field_position=True )
             else:
-                base = chipsec.chipset.read_register( self.cs, bar_reg )
+                base = self.cs.read_register( bar_reg )
         else:
             # this method is not preferred
             base = self.cs.pci.read_word( int(bar['bus'],16), int(bar['dev'],16), int(bar['fun'],16), int(bar['reg'],16) )
@@ -132,7 +130,7 @@ class iobar:
             bar_reg = bar['register']
             if 'enable_field' in bar:
                 bar_en_field = bar['enable_field']
-                is_enabled = (1 == chipsec.chipset.read_register_field( self.cs, bar_reg, bar_en_field ))
+                is_enabled = (1 == self.cs.read_register_field( bar_reg, bar_en_field ))
         return is_enabled
 
 

--- a/chipsec/hal/mmio.py
+++ b/chipsec/hal/mmio.py
@@ -1,7 +1,7 @@
 #!/usr/local/bin/python
 #CHIPSEC: Platform Security Assessment Framework
 #Copyright (c) 2010-2015, Intel Corporation
-# 
+#
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
 #as published by the Free Software Foundation; Version 2.
@@ -18,7 +18,6 @@
 #Contact information:
 #chipsec@intel.com
 #
-
 
 
 # -------------------------------------------------------------------------------
@@ -38,7 +37,7 @@ usage:
     >>> dump_MMIO( cs, bar_base, 0x1000 )
 
     Access MMIO by BAR name:
-    
+
     >>> read_MMIO_BAR_reg( cs, 'MCHBAR', 0x0, 4 )
     >>> write_MMIO_BAR_reg( cs, 'MCHBAR', 0x0, 0xFFFFFFFF, 4 )
     >>> get_MMIO_BAR_base_address( cs, 'MCHBAR' )
@@ -48,128 +47,25 @@ usage:
     >>> list_MMIO_BARs( cs )
 
     Access Memory Mapped Config Space:
-    
+
     >>> get_MMCFG_base_address(cs)
     >>> read_mmcfg_reg( cs, 0, 0, 0, 0x10, 4 )
     >>> read_mmcfg_reg( cs, 0, 0, 0, 0x10, 4, 0xFFFFFFFF )
-    
+
     DEPRECATED: Access MMIO by BAR id:
-    
+
     >>> read_MMIOBAR_reg( cs, mmio.MMIO_BAR_MCHBAR, 0x0 )
     >>> write_MMIOBAR_reg( cs, mmio.MMIO_BAR_MCHBAR, 0xFFFFFFFF )
     >>> get_MMIO_base_address( cs, mmio.MMIO_BAR_MCHBAR )
 """
 
-__version__ = '1.0'
-
 import struct
 import sys
 
-import chipsec.chipset
+from chipsec.hal import hal_base
 from chipsec.logger import logger
-#from chipsec.pci import PCI_BDF
 
 from chipsec.cfg.common import *
-
-
-##################################################################################
-# Access to MMIO BAR defined by configuration files (chipsec/cfg/*.py)
-##################################################################################
-#
-# To add your own MMIO bar:
-#   1. Add new MMIO BAR id (any)
-#   2. Write a function get_yourBAR_base_address() with no args that returns base addres of new bar
-#   3. Add a pointer to this function to MMIO_BAR_base map
-#   4. Don't touch read/write_MMIO_reg functions ;)
-#
-##################################################################################
-
-#
-# Dev0 BARs: MCHBAR, DMIBAR
-#
-def get_MCHBAR_base_address(cs):
-    #bar = PCI_BDF( 0, 0, 0, Cfg.PCI_MCHBAR_REG_OFF )
-    base = cs.pci.read_dword( 0, 0, 0, Cfg.PCI_MCHBAR_REG_OFF )
-    if (0 == base & 0x1):
-        logger().warn('MCHBAR is disabled')
-    base = base & 0xFFFFF000
-    if logger().VERBOSE:
-        logger().log( '[mmio] MCHBAR: 0x%016X' % base )
-    return base
-
-def get_DMIBAR_base_address(cs):
-    #bar = PCI_BDF( 0, 0, 0, Cfg.PCI_DMIBAR_REG_OFF )
-    base_lo = cs.pci.read_dword( 0, 0, 0, Cfg.PCI_DMIBAR_REG_OFF )
-    base_hi = cs.pci.read_dword( 0, 0, 0, Cfg.PCI_DMIBAR_REG_OFF + 4 )
-    if (0 == base_lo & 0x1):
-        logger().warn('DMIBAR is disabled')
-    base = (base_hi << 32) | (base_lo & 0xFFFFF000)
-    if logger().VERBOSE:
-        logger().log( '[mmio] DMIBAR: 0x%016X' % base )
-    return base
-
-#
-# PCH LPC Interface Root Complex base address (RCBA)
-#
-def get_LPC_RCBA_base_address(cs):
-    reg_value = cs.pci.read_dword( 0, 31, 0, Cfg.LPC_RCBA_REG_OFFSET )
-    #RcbaReg = LPC_RCBA_REG( (reg_value>>14)&0x3FFFF, (reg_value>>1)&0x1FFF, reg_value&0x1 )
-    #rcba_base = RcbaReg.BaseAddr << Cfg.RCBA_BASE_ADDR_SHIFT
-    rcba_base = (reg_value >> Cfg.RCBA_BASE_ADDR_SHIFT) << Cfg.RCBA_BASE_ADDR_SHIFT
-    if logger().VERBOSE:
-        logger().log( "[mmio] LPC RCBA: 0x%08X" % rcba_base )
-    return rcba_base
-
-#
-# GFx MMIO: GMADR/GTTMMADR
-#
-def get_GFx_base_address(cs, dev2_offset):
-    #bar = PCI_BDF( 0, 2, 0, dev2_offset )
-    base_lo = cs.pci.read_dword( 0, 2, 0, dev2_offset )
-    base_hi = cs.pci.read_dword( 0, 2, 0, dev2_offset + 4 )
-    base = base_hi | (base_lo & 0xFF000000)
-    return base
-def get_GMADR_base_address( cs ):
-    base = get_GFx_base_address(cs, Cfg.PCI_GMADR_REG_OFF)
-    if logger().VERBOSE:
-        logger().log( '[mmio] GMADR: 0x%016X' % base )
-    return base
-def get_GTTMMADR_base_address( cs ):
-    base = get_GFx_base_address(cs, Cfg.PCI_GTTMMADR_REG_OFF)
-    if logger().VERBOSE:
-        logger().log( '[mmio] GTTMMADR: 0x%016X' % base )
-    return base
-
-#
-# HD Audio MMIO
-#
-def get_HDAudioBAR_base_address(cs):
-    base = cs.pci.read_dword( 0, Cfg.PCI_HDA_DEV, 0, Cfg.PCI_HDAUDIOBAR_REG_OFF )
-    base = base & (0xFFFFFFFF << 14)
-    if logger().VERBOSE:
-        logger().log( '[mmio] HD Audio MMIO: 0x%08X' % base )
-    return base
-
-#
-# PCIEXBAR - technically not MMIO but Memory-mapped CFG space (MMCFG)
-# but defined by BAR similarly to MMIO BARs
-#
-def get_PCIEXBAR_base_address(cs):
-    base_lo = cs.pci.read_dword( 0, 0, 0, Cfg.PCI_PCIEXBAR_REG_OFF )
-    base_hi = cs.pci.read_dword( 0, 0, 0, Cfg.PCI_PCIEXBAR_REG_OFF + 4 )
-    if (0 == base_lo & 0x1):
-        logger().warn('PCIEXBAR is disabled')
-
-    base_lo &= Cfg.PCI_PCIEXBAR_REG_ADMSK256
-    if (Cfg.PCI_PCIEXBAR_REG_LENGTH_128MB == (base_lo & Cfg.PCI_PCIEXBAR_REG_LENGTH_MASK) >> 1):
-        base_lo |= Cfg.PCI_PCIEXBAR_REG_ADMSK128
-    elif (Cfg.PCI_PCIEXBAR_REG_LENGTH_64MB == (base_lo & Cfg.PCI_PCIEXBAR_REG_LENGTH_MASK) >> 1):
-        base_lo |= (Cfg.PCI_PCIEXBAR_REG_ADMSK128|Cfg.PCI_PCIEXBAR_REG_ADMSK64)
-    base = (base_hi << 32) | base_lo
-    if logger().VERBOSE:
-        logger().log( '[mmio] PCIEXBAR (MMCFG): 0x%016X' % base )
-    return base
-
 
 # CPU
 # Device 0
@@ -189,313 +85,416 @@ MMIO_BAR_HDABAR      = 20  # HD Audio MMIO BAR
 MMIO_BAR_LPCRCBA     = 100 # ICH LPC Interface Root Complex (RCBA)
 MMIO_BAR_LPCRCBA_SPI = 101 # RCBA SPIBASE
 
-MMIO_BAR_base = {
-                  MMIO_BAR_MCHBAR      : get_MCHBAR_base_address,
-                  MMIO_BAR_DMIBAR      : get_DMIBAR_base_address,
-                  MMIO_BAR_PCIEXBAR    : get_PCIEXBAR_base_address,
-                  MMIO_BAR_GMADR       : get_GMADR_base_address,
-                  MMIO_BAR_GTTMMADR    : get_GTTMMADR_base_address,
-                  MMIO_BAR_HDABAR      : get_HDAudioBAR_base_address,
-                  MMIO_BAR_LPCRCBA     : get_LPC_RCBA_base_address
-                }
 MMIO_BAR_name = {
-                  MMIO_BAR_MCHBAR      : "MCHBAR",
-                  MMIO_BAR_DMIBAR      : "DMIBAR",
-                  MMIO_BAR_PCIEXBAR    : "PCIEXBAR",
-                  MMIO_BAR_GMADR       : "GMADR",
-                  MMIO_BAR_GTTMMADR    : "GTTMMADR",
-                  MMIO_BAR_HDABAR      : "HDABAR",
-                  MMIO_BAR_LPCRCBA     : "RCBA"
-                }
-#MMIO_BAR_name = dict( MMIO_BAR_base+[(e[1], e[0]) for e in MMIO_BAR_base] )
-
-
-#
-# Get base address of MMIO range by MMIO_BAR_* id
-#
-def get_MMIO_base_address( cs, bar_id ):
-    return MMIO_BAR_base[ bar_id ](cs)
-#
-# Read MMIO register in MMIO BAR defined by MMIO_BAR_* id
-#
-def read_MMIOBAR_reg(cs, bar_id, offset ):
-    bar_base  = MMIO_BAR_base[ bar_id ](cs)
-    reg_addr  = bar_base + offset
-    reg_value = cs.helper.read_mmio_reg( reg_addr, 4 )
-    if logger().VERBOSE:
-        logger().log( '[mmio] %s + 0x%08X (0x%08X) = 0x%08X' % (MMIO_BAR_name[bar_id], offset, reg_addr, reg_value) )
-    return reg_value
-#
-# Write MMIO register in MMIO BAR defined by MMIO_BAR_* id
-#
-def write_MMIOBAR_reg(cs, bar_id, offset, dword_value ):
-    bar_base  = MMIO_BAR_base[ bar_id ]()
-    reg_addr  = bar_base + offset
-    if logger().VERBOSE: logger().log( '[mmio] write %s + 0x%08X (0x%08X) = 0x%08X' % (MMIO_BAR_name[bar_id], offset, reg_addr, dword_value) )
-    cs.helper.write_mmio_reg( reg_addr, 4, dword_value )
-
-
-
-#
-# Read MMIO register as an offset off of MMIO range base address
-#
-def read_MMIO_reg(cs, bar_base, offset, size=4 ):
-    reg_value = cs.helper.read_mmio_reg( bar_base + offset, size )
-    if logger().VERBOSE: logger().log( '[mmio] 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, reg_value) )
-    return reg_value
-
-def read_MMIO_reg_byte(cs, bar_base, offset ):
-    reg_value = cs.helper.read_mmio_reg( bar_base + offset, 1 )
-    if logger().VERBOSE: logger().log( '[mmio] 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, reg_value) )
-    return reg_value
-    
-def read_MMIO_reg_word(cs, bar_base, offset ):
-    reg_value = cs.helper.read_mmio_reg( bar_base + offset, 2 )
-    if logger().VERBOSE: logger().log( '[mmio] 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, reg_value) )
-    return reg_value
-    
-def read_MMIO_reg_dword(cs, bar_base, offset ):
-    reg_value = cs.helper.read_mmio_reg( bar_base + offset, 4 )
-    if logger().VERBOSE: logger().log( '[mmio] 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, reg_value) )
-    return reg_value
-    
-#
-# Write MMIO register as an offset off of MMIO range base address
-#
-def write_MMIO_reg(cs, bar_base, offset, value, size=4 ):
-    if logger().VERBOSE: logger().log( '[mmio] write 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, value) )
-    cs.helper.write_mmio_reg( bar_base + offset, size, value )
-    
-def write_MMIO_reg_byte(cs, bar_base, offset, value ):
-    if logger().VERBOSE: logger().log( '[mmio] write 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, value) )
-    cs.helper.write_mmio_reg( bar_base + offset, 1, value )
-    
-def write_MMIO_reg_word(cs, bar_base, offset, value ):
-    if logger().VERBOSE: logger().log( '[mmio] write 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, value) )
-    cs.helper.write_mmio_reg( bar_base + offset, 2, value )
-    
-def write_MMIO_reg_dword(cs, bar_base, offset, value ):
-    if logger().VERBOSE: logger().log( '[mmio] write 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, value) )
-    cs.helper.write_mmio_reg( bar_base + offset, 4, value )
-
-#
-# Read MMIO registers as offsets off of MMIO range base address
-#
-def read_MMIO( cs, bar_base, size ):
-    regs = []
-    size -= size%4
-    for offset in range(0,size,4):
-        regs.append( read_MMIO_reg( cs, bar_base, offset ) )
-    return regs
-
-#
-# Dump MMIO range
-#
-def dump_MMIO( cs, bar_base, size ):
-    logger().log("[mmio] MMIO register range [0x%016X:0x%016X+%08X]:" % (bar_base,bar_base,size))
-    size -= size%4
-    for offset in range(0,size,4):
-        logger().log( '+%08X: %08X' % (offset, read_MMIO_reg( cs, bar_base, offset )) )
-
-
-###############################################################################
-# Access to MMIO BAR defined by XML configuration files (chipsec/cfg/*.xml)
-###############################################################################
+    MMIO_BAR_MCHBAR      : "MCHBAR",
+    MMIO_BAR_DMIBAR      : "DMIBAR",
+    MMIO_BAR_PCIEXBAR    : "PCIEXBAR",
+    MMIO_BAR_GMADR       : "GMADR",
+    MMIO_BAR_GTTMMADR    : "GTTMMADR",
+    MMIO_BAR_HDABAR      : "HDABAR",
+    MMIO_BAR_LPCRCBA     : "RCBA"
+}
 
 DEFAULT_MMIO_BAR_SIZE = 0x1000
 
-#
-# Check if MMIO BAR with bar_name has been defined in XML config
-# Use this function to fall-back to hardcoded config in case XML config is not available
-#
-def is_MMIO_BAR_defined( cs, bar_name ):
-    is_bar_defined = False
-    try:
-        _bar = cs.Cfg.MMIO_BARS[ bar_name ]
-        if _bar is not None:
+class MMIO(hal_base.HALBase):
+
+    def __init__(self, cs):
+        super(MMIO, self).__init__(cs)
+        self.MMIO_BAR_base = {
+            MMIO_BAR_MCHBAR      : self.get_MCHBAR_base_address,
+            MMIO_BAR_DMIBAR      : self.get_DMIBAR_base_address,
+            MMIO_BAR_PCIEXBAR    : self.get_PCIEXBAR_base_address,
+            MMIO_BAR_GMADR       : self.get_GMADR_base_address,
+            MMIO_BAR_GTTMMADR    : self.get_GTTMMADR_base_address,
+            MMIO_BAR_HDABAR      : self.get_HDAudioBAR_base_address,
+            MMIO_BAR_LPCRCBA     : self.get_LPC_RCBA_base_address
+        }
+
+    ###########################################################################
+    # Access to MMIO BAR defined by configuration files (chipsec/cfg/*.py)
+    ###########################################################################
+    #
+    # To add your own MMIO bar:
+    #   1. Add new MMIO BAR id (any)
+    #   2. Write a function get_yourBAR_base_address() with no args that
+    #      returns base addres of new bar
+    #   3. Add a pointer to this function to MMIO_BAR_base map
+    #   4. Don't touch read/write_MMIO_reg functions ;)
+    #
+    ###########################################################################
+
+
+    #
+    # Dev0 BARs: MCHBAR, DMIBAR
+    #
+    def get_MCHBAR_base_address(self):
+        base = self.cs.pci.read_dword(0, 0, 0, Cfg.PCI_MCHBAR_REG_OFF)
+        if (0 == base & 0x1):
+            logger().warn('MCHBAR is disabled')
+        base = base & 0xFFFFF000
+        if logger().VERBOSE:
+            logger().log('[mmio] MCHBAR: 0x%016X' % base)
+        return base
+
+    def get_DMIBAR_base_address(self):
+        base_lo = self.cs.pci.read_dword(0, 0, 0, Cfg.PCI_DMIBAR_REG_OFF)
+        base_hi = self.cs.pci.read_dword(0, 0, 0, Cfg.PCI_DMIBAR_REG_OFF + 4)
+        if (0 == base_lo & 0x1):
+            logger().warn('DMIBAR is disabled')
+        base = (base_hi << 32) | (base_lo & 0xFFFFF000)
+        if logger().VERBOSE:
+            logger().log( '[mmio] DMIBAR: 0x%016X' % base )
+        return base
+
+    #
+    # PCH LPC Interface Root Complex base address (RCBA)
+    #
+    def get_LPC_RCBA_base_address(self):
+        reg_value = self.cs.pci.read_dword(0, 31, 0, Cfg.LPC_RCBA_REG_OFFSET)
+        #RcbaReg = LPC_RCBA_REG( (reg_value>>14)&0x3FFFF, (reg_value>>1)&0x1FFF, reg_value&0x1 )
+        #rcba_base = RcbaReg.BaseAddr << Cfg.RCBA_BASE_ADDR_SHIFT
+        rcba_base = (reg_value >> Cfg.RCBA_BASE_ADDR_SHIFT) << Cfg.RCBA_BASE_ADDR_SHIFT
+        if logger().VERBOSE:
+            logger().log( "[mmio] LPC RCBA: 0x%08X" % rcba_base )
+        return rcba_base
+
+    #
+    # GFx MMIO: GMADR/GTTMMADR
+    #
+    def get_GFx_base_address(self, dev2_offset):
+        #bar = PCI_BDF(0, 2, 0, dev2_offset)
+        base_lo = self.cs.pci.read_dword(0, 2, 0, dev2_offset)
+        base_hi = self.cs.pci.read_dword(0, 2, 0, dev2_offset + 4)
+        base = base_hi | (base_lo & 0xFF000000)
+        return base
+
+    def get_GMADR_base_address(self):
+        base = self.get_GFx_base_address(Cfg.PCI_GMADR_REG_OFF)
+        if logger().VERBOSE:
+            logger().log( '[mmio] GMADR: 0x%016X' % base )
+        return base
+
+    def get_GTTMMADR_base_address(self):
+        base = self.get_GFx_base_address(Cfg.PCI_GTTMMADR_REG_OFF)
+        if logger().VERBOSE:
+            logger().log( '[mmio] GTTMMADR: 0x%016X' % base )
+        return base
+
+    #
+    # HD Audio MMIO
+    #
+    def get_HDAudioBAR_base_address(self):
+        base = self.cs.pci.read_dword( 0, Cfg.PCI_HDA_DEV, 0, Cfg.PCI_HDAUDIOBAR_REG_OFF )
+        base = base & (0xFFFFFFFF << 14)
+        if logger().VERBOSE:
+            logger().log( '[mmio] HD Audio MMIO: 0x%08X' % base )
+        return base
+
+    #
+    # PCIEXBAR - technically not MMIO but Memory-mapped CFG space (MMCFG)
+    # but defined by BAR similarly to MMIO BARs
+    #
+    def get_PCIEXBAR_base_address(self):
+        base_lo = self.cs.pci.read_dword( 0, 0, 0, Cfg.PCI_PCIEXBAR_REG_OFF )
+        base_hi = self.cs.pci.read_dword( 0, 0, 0, Cfg.PCI_PCIEXBAR_REG_OFF + 4 )
+        if (0 == base_lo & 0x1):
+            logger().warn('PCIEXBAR is disabled')
+
+        base_lo &= Cfg.PCI_PCIEXBAR_REG_ADMSK256
+        if (Cfg.PCI_PCIEXBAR_REG_LENGTH_128MB == (base_lo & Cfg.PCI_PCIEXBAR_REG_LENGTH_MASK) >> 1):
+            base_lo |= Cfg.PCI_PCIEXBAR_REG_ADMSK128
+        elif (Cfg.PCI_PCIEXBAR_REG_LENGTH_64MB == (base_lo & Cfg.PCI_PCIEXBAR_REG_LENGTH_MASK) >> 1):
+            base_lo |= (Cfg.PCI_PCIEXBAR_REG_ADMSK128|Cfg.PCI_PCIEXBAR_REG_ADMSK64)
+        base = (base_hi << 32) | base_lo
+        if logger().VERBOSE:
+            logger().log( '[mmio] PCIEXBAR (MMCFG): 0x%016X' % base )
+        return base
+
+    #
+    # Get base address of MMIO range by MMIO_BAR_* id
+    #
+    def get_MMIO_base_address(self, bar_id):
+        return self.MMIO_BAR_base[bar_id]
+
+    #
+    # Read MMIO register in MMIO BAR defined by MMIO_BAR_* id
+    #
+    def read_MMIOBAR_reg(self, bar_id, offset ):
+        bar_base  = self.MMIO_BAR_base[ bar_id ]
+        reg_addr  = bar_base + offset
+        reg_value = self.cs.helper.read_mmio_reg( reg_addr, 4 )
+        if logger().VERBOSE:
+            logger().log( '[mmio] %s + 0x%08X (0x%08X) = 0x%08X' % (MMIO_BAR_name[bar_id], offset, reg_addr, reg_value) )
+        return reg_value
+
+    #
+    # Write MMIO register in MMIO BAR defined by MMIO_BAR_* id
+    #
+    def write_MMIOBAR_reg(self, bar_id, offset, dword_value):
+        bar_base  = self.MMIO_BAR_base[bar_id]
+        reg_addr  = bar_base + offset
+        if logger().VERBOSE:
+            logger().log('[mmio] write %s + 0x%08X (0x%08X) = 0x%08X' % (self.MMIO_BAR_name[bar_id], offset, reg_addr, dword_value) )
+        self.cs.helper.write_mmio_reg(reg_addr, 4, dword_value)
+
+
+    #
+    # Read MMIO register as an offset off of MMIO range base address
+    #
+    def read_MMIO_reg(self, bar_base, offset, size=4 ):
+        reg_value = self.cs.helper.read_mmio_reg( bar_base + offset, size )
+        if logger().VERBOSE: logger().log( '[mmio] 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, reg_value) )
+        return reg_value
+
+    def read_MMIO_reg_byte(self, bar_base, offset ):
+        reg_value = self.cs.helper.read_mmio_reg( bar_base + offset, 1 )
+        if logger().VERBOSE: logger().log( '[mmio] 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, reg_value) )
+        return reg_value
+
+    def read_MMIO_reg_word(self, bar_base, offset ):
+        reg_value = self.cs.helper.read_mmio_reg( bar_base + offset, 2 )
+        if logger().VERBOSE: logger().log( '[mmio] 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, reg_value) )
+        return reg_value
+
+    def read_MMIO_reg_dword(self, bar_base, offset ):
+        reg_value = self.cs.helper.read_mmio_reg( bar_base + offset, 4 )
+        if logger().VERBOSE: logger().log( '[mmio] 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, reg_value) )
+        return reg_value
+
+    #
+    # Write MMIO register as an offset off of MMIO range base address
+    #
+    def write_MMIO_reg(self, bar_base, offset, value, size=4 ):
+        if logger().VERBOSE: logger().log( '[mmio] write 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, value) )
+        self.cs.helper.write_mmio_reg( bar_base + offset, size, value )
+
+    def write_MMIO_reg_byte(self, bar_base, offset, value ):
+        if logger().VERBOSE: logger().log( '[mmio] write 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, value) )
+        self.cs.helper.write_mmio_reg( bar_base + offset, 1, value )
+
+    def write_MMIO_reg_word(self, bar_base, offset, value ):
+        if logger().VERBOSE: logger().log( '[mmio] write 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, value) )
+        self.cs.helper.write_mmio_reg( bar_base + offset, 2, value )
+
+    def write_MMIO_reg_dword(self, bar_base, offset, value ):
+        if logger().VERBOSE: logger().log( '[mmio] write 0x%08X + 0x%08X = 0x%08X' % (bar_base, offset, value) )
+        self.cs.helper.write_mmio_reg( bar_base + offset, 4, value )
+
+    #
+    # Read MMIO registers as offsets off of MMIO range base address
+    #
+    def read_MMIO(self, bar_base, size):
+        regs = []
+        size -= size % 4
+        for offset in range(0, size, 4):
+            regs.append(self.read_MMIO_reg(bar_base, offset))
+        return regs
+
+    #
+    # Dump MMIO range
+    #
+    def dump_MMIO(self, bar_base, size ):
+        logger().log("[mmio] MMIO register range [0x%016X:0x%016X+%08X]:" % (bar_base, bar_base, size))
+        size -= size % 4
+        for offset in range(0, size, 4):
+            logger().log( '+%08X: %08X' % (offset, self.read_MMIO_reg(bar_base, offset)) )
+
+
+    ###############################################################################
+    # Access to MMIO BAR defined by XML configuration files (chipsec/cfg/*.xml)
+    ###############################################################################
+
+    #
+    # Check if MMIO BAR with bar_name has been defined in XML config
+    # Use this function to fall-back to hardcoded config in case XML config is not available
+    #
+    def is_MMIO_BAR_defined(self, bar_name):
+        is_bar_defined = False
+        try:
+            _bar = self.cs.Cfg.MMIO_BARS[ bar_name ]
+            if _bar is not None:
+                if 'register' in _bar:
+                    is_bar_defined = self.cs.is_register_defined(_bar['register'])
+                elif ('bus' in _bar) and ('dev' in _bar) and ('fun' in _bar) and ('reg' in _bar):
+                    # old definition
+                    is_bar_defined = True
+        except KeyError:
+            pass
+
+        if not is_bar_defined:
+            if logger().VERBOSE: logger().warn( "'%s' MMIO BAR definition not found/correct in XML config" % bar_name )
+        return is_bar_defined
+
+    #
+    # Get base address of MMIO range by MMIO BAR name
+    #
+    def get_MMIO_BAR_base_address(self, bar_name):
+        bar = self.cs.Cfg.MMIO_BARS[ bar_name ]
+        if bar is None or bar == {}: return -1,-1
+
+        if 'register' in bar:
+            bar_reg   = bar['register']
+            if 'base_field' in bar:
+                base_field = bar['base_field']
+                base = self.cs.read_register_field(bar_reg, base_field, preserve_field_position=True)
+            else:
+                base = self.cs.read_register(bar_reg)
+        else:
+            # this method is not preferred (less flexible)
+            b = int(bar['bus'],16)
+            d = int(bar['dev'],16)
+            f = int(bar['fun'],16)
+            r = int(bar['reg'],16)
+            width = int(bar['width'],16)
+            if 8 == width:
+                base_lo = self.cs.pci.read_dword( b, d, f, r )
+                base_hi = self.cs.pci.read_dword( b, d, f, r + 4 )
+                base = (base_hi << 32) | base_lo
+            else:
+                base = self.cs.pci.read_dword( b, d, f, r )
+
+        if 'mask' in bar: base &= int(bar['mask'],16)
+        if 'offset' in bar: base = base + int(bar['offset'],16)
+        size = int(bar['size'],16) if ('size' in bar) else DEFAULT_MMIO_BAR_SIZE
+
+        if logger().VERBOSE: logger().log( '[mmio] %s: 0x%016X (size = 0x%X)' % (bar_name,base,size) )
+        return base, size
+
+    #
+    # Check if MMIO range is enabled by MMIO BAR name
+    #
+    def is_MMIO_BAR_enabled(self, bar_name):
+        bar = self.cs.Cfg.MMIO_BARS[ bar_name ]
+        is_enabled = True
+        if 'register' in bar:
+            bar_reg   = bar['register']
+            if 'enable_field' in bar:
+                bar_en_field = bar['enable_field']
+                is_enabled = (1 == self.cs.read_register_field(bar_reg, bar_en_field))
+        else:
+            # this method is not preferred (less flexible)
+            b = int(bar['bus'],16)
+            d = int(bar['dev'],16)
+            f = int(bar['fun'],16)
+            r = int(bar['reg'],16)
+            width = int(bar['width'],16)
+            if 8 == width:
+                base_lo = self.cs.pci.read_dword( b, d, f, r )
+                base_hi = self.cs.pci.read_dword( b, d, f, r + 4 )
+                base = (base_hi << 32) | base_lo
+            else:
+                base = self.cs.pci.read_dword( b, d, f, r )
+
+            if 'enable_bit' in bar:
+                en_mask = 1 << int(bar['enable_bit'])
+                is_enabled = (0 != base & en_mask)
+
+        return is_enabled
+
+    #
+    # Check if MMIO range is programmed by MMIO BAR name
+    #
+    def is_MMIO_BAR_programmed(self, bar_name):
+        bar = self.cs.Cfg.MMIO_BARS[bar_name]
+
+        if 'register' in bar:
+            bar_reg   = bar['register']
+            if 'base_field' in bar:
+                base_field = bar['base_field']
+                base = self.cs.read_register_field(bar_reg, base_field, preserve_field_position=True)
+            else:
+                base = self.cs.read_register(bar_reg)
+        else:
+            # this method is not preferred (less flexible)
+            b = int(bar['bus'],16)
+            d = int(bar['dev'],16)
+            f = int(bar['fun'],16)
+            r = int(bar['reg'],16)
+            width = int(bar['width'],16)
+            if 8 == width:
+                base_lo = self.cs.pci.read_dword( b, d, f, r )
+                base_hi = self.cs.pci.read_dword( b, d, f, r + 4 )
+                base = (base_hi << 32) | base_lo
+            else:
+                base = self.cs.pci.read_dword( b, d, f, r )
+
+        #if 'mask' in bar: base &= int(bar['mask'],16)
+        return (0 != base)
+
+    #
+    # Read MMIO register from MMIO range defined by MMIO BAR name
+    #
+    def read_MMIO_BAR_reg(self, bar_name, offset, size=4 ):
+        (bar_base,bar_size) = self.get_MMIO_BAR_base_address(bar_name)
+        # @TODO: check offset exceeds BAR size
+        return self.read_MMIO_reg(bar_base, offset, size)
+
+    #
+    # Write MMIO register from MMIO range defined by MMIO BAR name
+    #
+    def write_MMIO_BAR_reg(self, bar_name, offset, value, size=4 ):
+        (bar_base,bar_size) = self.get_MMIO_BAR_base_address(bar_name)
+        # @TODO: check offset exceeds BAR size
+        return self.write_MMIO_reg(bar_base, offset, value, size)
+
+    #
+    # Dump MMIO range by MMIO BAR name
+    #
+    def dump_MMIO_BAR(self, bar_name):
+        (bar_base,bar_size) = self.get_MMIO_BAR_base_address(bar_name)
+        self.dump_MMIO(bar_base, bar_size)
+
+    def list_MMIO_BARs(self):
+        logger().log('')
+        logger().log( '--------------------------------------------------------------------------------' )
+        logger().log( ' MMIO Range   | BAR Register   | Base             | Size     | En? | Description' )
+        logger().log( '--------------------------------------------------------------------------------' )
+        for _bar_name in self.cs.Cfg.MMIO_BARS:
+            if not self.is_MMIO_BAR_defined( _bar_name ): continue
+            _bar = self.cs.Cfg.MMIO_BARS[_bar_name]
+            (_base,_size) = self.get_MMIO_BAR_base_address(_bar_name)
+            _en = self.is_MMIO_BAR_enabled( _bar_name)
+
             if 'register' in _bar:
-                is_bar_defined = chipsec.chipset.is_register_defined( cs, _bar['register'] )
-            elif ('bus' in _bar) and ('dev' in _bar) and ('fun' in _bar) and ('reg' in _bar):
-                # old definition
-                is_bar_defined = True
-    except KeyError:
-        pass
+                _s = _bar['register']
+                if 'offset' in _bar: _s += (' + 0x%X' % int(_bar['offset'],16))
+            else:
+                _s = '%02X:%02X.%01X + %s' % ( int(_bar['bus'],16),int(_bar['dev'],16),int(_bar['fun'],16),_bar['reg'] )
 
-    if not is_bar_defined:
-        if logger().VERBOSE: logger().warn( "'%s' MMIO BAR definition not found/correct in XML config" % bar_name )
-    return is_bar_defined
+            logger().log( ' %-12s | %-14s | %016X | %08X | %d   | %s' % (_bar_name, _s, _base, _size, _en, _bar['desc']) )
 
 
-#
-# Get base address of MMIO range by MMIO BAR name
-#
-def get_MMIO_BAR_base_address( cs, bar_name ):
-    bar = cs.Cfg.MMIO_BARS[ bar_name ]
-    if bar is None or bar == {}: return -1,-1
+    ##################################################################################
+    # Access to Memory Mapped PCIe Configuration Space
+    ##################################################################################
 
-    if 'register' in bar:
-        bar_reg   = bar['register']
-        if 'base_field' in bar:
-            base_field = bar['base_field']
-            base = chipsec.chipset.read_register_field( cs, bar_reg, base_field, preserve_field_position=True )
-        else:
-            base = chipsec.chipset.read_register( cs, bar_reg )
-    else:
-        # this method is not preferred (less flexible)
-        b = int(bar['bus'],16)
-        d = int(bar['dev'],16)
-        f = int(bar['fun'],16)
-        r = int(bar['reg'],16)
-        width = int(bar['width'],16)
-        if 8 == width:
-            base_lo = cs.pci.read_dword( b, d, f, r )
-            base_hi = cs.pci.read_dword( b, d, f, r + 4 )
-            base = (base_hi << 32) | base_lo
-        else:
-            base = cs.pci.read_dword( b, d, f, r )
+    def get_MMCFG_base_address(self):
+        (bar_base,bar_size)  = self.get_MMIO_BAR_base_address('MMCFG')
+        # @TODO: temporary w/a
+        #if (Cfg.PCI_PCIEXBAR_REG_LENGTH_256MB == (bar_base & Cfg.PCI_PCIEXBAR_REG_LENGTH_MASK) >> 1):
+        #    bar_base &= ~(Cfg.PCI_PCIEXBAR_REG_ADMSK128|Cfg.PCI_PCIEXBAR_REG_ADMSK64)
+        #elif (Cfg.PCI_PCIEXBAR_REG_LENGTH_128MB == (bar_base & Cfg.PCI_PCIEXBAR_REG_LENGTH_MASK) >> 1):
+        #    bar_base &= ~Cfg.PCI_PCIEXBAR_REG_ADMSK64
+        ##elif (Cfg.PCI_PCIEXBAR_REG_LENGTH_64MB == (bar_base & Cfg.PCI_PCIEXBAR_REG_LENGTH_MASK) >> 1):
+        ##   pass
+        if logger().HAL: logger().log( '[mmcfg] Memory Mapped CFG Base: 0x%016X' % bar_base )
+        return bar_base
 
-    if 'mask' in bar: base &= int(bar['mask'],16)
-    if 'offset' in bar: base = base + int(bar['offset'],16)
-    size = int(bar['size'],16) if ('size' in bar) else DEFAULT_MMIO_BAR_SIZE
+    def read_mmcfg_reg(self, bus, dev, fun, off, size):
+        pciexbar = self.get_MMCFG_base_address()
+        pciexbar_off = (bus * 32 * 8 + dev * 8 + fun) * 0x1000 + off
+        value = self.read_MMIO_reg(pciexbar, pciexbar_off)
+        if logger().VERBOSE: logger().log( "[mmcfg] reading %02d:%02d.%d + 0x%02X (MMCFG + 0x%08X): 0x%08X" % (bus, dev, fun, off, pciexbar_off, value) )
+        if 1 == size:
+            return (value & 0xFF)
+        elif 2 == size:
+            return (value & 0xFFFF)
+        return value
 
-    if logger().VERBOSE: logger().log( '[mmio] %s: 0x%016X (size = 0x%X)' % (bar_name,base,size) )
-    return base, size
-
-#
-# Check if MMIO range is enabled by MMIO BAR name
-#
-def is_MMIO_BAR_enabled( cs, bar_name ):
-    bar = cs.Cfg.MMIO_BARS[ bar_name ]
-    is_enabled = True
-    if 'register' in bar:
-        bar_reg   = bar['register']
-        if 'enable_field' in bar:
-            bar_en_field = bar['enable_field']
-            is_enabled = (1 == chipsec.chipset.read_register_field( cs, bar_reg, bar_en_field ))
-    else:
-        # this method is not preferred (less flexible)
-        b = int(bar['bus'],16)
-        d = int(bar['dev'],16)
-        f = int(bar['fun'],16)
-        r = int(bar['reg'],16)
-        width = int(bar['width'],16)
-        if 8 == width:
-            base_lo = cs.pci.read_dword( b, d, f, r )
-            base_hi = cs.pci.read_dword( b, d, f, r + 4 )
-            base = (base_hi << 32) | base_lo
-        else:
-            base = cs.pci.read_dword( b, d, f, r )
-
-        if 'enable_bit' in bar:
-            en_mask = 1 << int(bar['enable_bit'])
-            is_enabled = (0 != base & en_mask)
-
-    return is_enabled
-
-#
-# Check if MMIO range is programmed by MMIO BAR name
-#
-def is_MMIO_BAR_programmed( cs, bar_name ):
-    bar = cs.Cfg.MMIO_BARS[ bar_name ]
-
-    if 'register' in bar:
-        bar_reg   = bar['register']
-        if 'base_field' in bar:
-            base_field = bar['base_field']
-            base = chipsec.chipset.read_register_field( cs, bar_reg, base_field, preserve_field_position=True )
-        else:
-            base = chipsec.chipset.read_register( cs, bar_reg )
-    else:
-        # this method is not preferred (less flexible)
-        b = int(bar['bus'],16)
-        d = int(bar['dev'],16)
-        f = int(bar['fun'],16)
-        r = int(bar['reg'],16)
-        width = int(bar['width'],16)
-        if 8 == width:
-            base_lo = cs.pci.read_dword( b, d, f, r )
-            base_hi = cs.pci.read_dword( b, d, f, r + 4 )
-            base = (base_hi << 32) | base_lo
-        else:
-            base = cs.pci.read_dword( b, d, f, r )
-
-    #if 'mask' in bar: base &= int(bar['mask'],16)
-    return (0 != base)
-
-#
-# Read MMIO register from MMIO range defined by MMIO BAR name
-#
-def read_MMIO_BAR_reg(cs, bar_name, offset, size=4 ):
-    (bar_base,bar_size) = get_MMIO_BAR_base_address( cs, bar_name )
-    # @TODO: check offset exceeds BAR size
-    return read_MMIO_reg(cs, bar_base, offset, size )
-
-#
-# Write MMIO register from MMIO range defined by MMIO BAR name
-#
-def write_MMIO_BAR_reg(cs, bar_name, offset, value, size=4 ):
-    (bar_base,bar_size) = get_MMIO_BAR_base_address( cs, bar_name )
-    # @TODO: check offset exceeds BAR size
-    return write_MMIO_reg(cs, bar_base, offset, value, size )
-
-#
-# Dump MMIO range by MMIO BAR name
-#
-def dump_MMIO_BAR( cs, bar_name ):
-    (bar_base,bar_size) = get_MMIO_BAR_base_address( cs, bar_name )
-    dump_MMIO( cs, bar_base, bar_size )
-
-def list_MMIO_BARs( cs ):
-    logger().log('')
-    logger().log( '--------------------------------------------------------------------------------' )
-    logger().log( ' MMIO Range   | BAR Register   | Base             | Size     | En? | Description' )
-    logger().log( '--------------------------------------------------------------------------------' )
-    for _bar_name in cs.Cfg.MMIO_BARS:
-        if not is_MMIO_BAR_defined( cs, _bar_name ): continue
-        _bar = cs.Cfg.MMIO_BARS[ _bar_name ]
-        (_base,_size) = get_MMIO_BAR_base_address( cs, _bar_name )
-        _en = is_MMIO_BAR_enabled( cs, _bar_name )
-
-        if 'register' in _bar:
-            _s = _bar['register']
-            if 'offset' in _bar: _s += (' + 0x%X' % int(_bar['offset'],16))
-        else:
-            _s = '%02X:%02X.%01X + %s' % ( int(_bar['bus'],16),int(_bar['dev'],16),int(_bar['fun'],16),_bar['reg'] )
-
-        logger().log( ' %-12s | %-14s | %016X | %08X | %d   | %s' % (_bar_name, _s, _base, _size, _en, _bar['desc']) )
-
-
-
-##################################################################################
-# Access to Memory Mapped PCIe Configuration Space
-##################################################################################
-
-def get_MMCFG_base_address(cs):
-    (bar_base,bar_size)  = get_MMIO_BAR_base_address( cs, 'MMCFG' )
-    # @TODO: temporary w/a
-    #if (Cfg.PCI_PCIEXBAR_REG_LENGTH_256MB == (bar_base & Cfg.PCI_PCIEXBAR_REG_LENGTH_MASK) >> 1):
-    #    bar_base &= ~(Cfg.PCI_PCIEXBAR_REG_ADMSK128|Cfg.PCI_PCIEXBAR_REG_ADMSK64)
-    #elif (Cfg.PCI_PCIEXBAR_REG_LENGTH_128MB == (bar_base & Cfg.PCI_PCIEXBAR_REG_LENGTH_MASK) >> 1):
-    #    bar_base &= ~Cfg.PCI_PCIEXBAR_REG_ADMSK64
-    ##elif (Cfg.PCI_PCIEXBAR_REG_LENGTH_64MB == (bar_base & Cfg.PCI_PCIEXBAR_REG_LENGTH_MASK) >> 1):
-    ##   pass
-    if logger().HAL: logger().log( '[mmcfg] Memory Mapped CFG Base: 0x%016X' % bar_base )
-    return bar_base
-
-def read_mmcfg_reg( cs, bus, dev, fun, off, size ):
-    pciexbar = get_MMCFG_base_address(cs)
-    pciexbar_off = (bus * 32 * 8 + dev * 8 + fun) * 0x1000 + off
-    value = read_MMIO_reg( cs, pciexbar, pciexbar_off )
-    if logger().VERBOSE: logger().log( "[mmcfg] reading %02d:%02d.%d + 0x%02X (MMCFG + 0x%08X): 0x%08X" % (bus, dev, fun, off, pciexbar_off, value) )
-    if 1 == size:
-        return (value & 0xFF)
-    elif 2 == size:
-        return (value & 0xFFFF)
-    return value
-
-def write_mmcfg_reg( cs, bus, dev, fun, off, size, value ):
-    pciexbar = get_MMCFG_base_address(cs)
-    pciexbar_off = (bus * 32 * 8 + dev * 8 + fun) * 0x1000 + off
-    write_MMIO_reg( cs, pciexbar, pciexbar_off, (value&0xFFFFFFFF) )
-    if logger().VERBOSE: logger().log( "[mmcfg] writing %02d:%02d.%d + 0x%02X (MMCFG + 0x%08X): 0x%08X" % (bus, dev, fun, off, pciexbar_off, value) )
-    return True
+    def write_mmcfg_reg(self, bus, dev, fun, off, size, value):
+        pciexbar = self.get_MMCFG_base_address()
+        pciexbar_off = (bus * 32 * 8 + dev * 8 + fun) * 0x1000 + off
+        self.write_MMIO_reg(pciexbar, pciexbar_off, (value&0xFFFFFFFF))
+        if logger().VERBOSE: logger().log( "[mmcfg] writing %02d:%02d.%d + 0x%02X (MMCFG + 0x%08X): 0x%08X" % (bus, dev, fun, off, pciexbar_off, value) )
+        return True

--- a/chipsec/hal/paging.py
+++ b/chipsec/hal/paging.py
@@ -93,7 +93,7 @@ class c_translation(object):
     def get_address_space(self):
         total = 0
         mem_range = self.get_mem_range()
-        for i in mem_range:                                                         
+        for i in mem_range:
             total += i[1] - i[0]
         return total
 

--- a/chipsec/hal/smbus.py
+++ b/chipsec/hal/smbus.py
@@ -31,9 +31,9 @@
 Access to SMBus Controller
 """
 
-from chipsec.logger import *
+from chipsec.hal import iobar, hal_base
 
-import chipsec.hal.iobar
+from chipsec.logger import *
 
 SMBUS_COMMAND_QUICK         = 0
 SMBUS_COMMAND_BYTE          = 1
@@ -49,10 +49,11 @@ SMBUS_POLL_COUNT = 1000
 SMBUS_COMMAND_WRITE = 0
 SMBUS_COMMAND_READ  = 1
 
-class SMBus:
+class SMBus(hal_base.HALBase):
+
     def __init__( self, cs ):
-        self.cs = cs
-        self.iobar = chipsec.hal.iobar.iobar( self.cs )
+        super(SMBus, self).__init__(cs)
+        self.iobar = iobar.IOBAR(self.cs)
         self.smb_reg_status  = 'SMBUS_HST_STS'
         self.smb_reg_command = 'SMBUS_HST_CMD'
         self.smb_reg_address = 'SMBUS_HST_SLVA'
@@ -65,12 +66,12 @@ class SMBus:
             (sba_base, sba_size) = self.iobar.get_IO_BAR_base_address( 'SMBUS_BASE' )
             return sba_base
         else:
-            raise chipsec.hal.iobar.IOBARNotFoundError, ('IOBARAccessError: SMBUS_BASE')
+            raise iobar.IOBARNotFoundError, ('IOBARAccessError: SMBUS_BASE')
 
     def get_SMBus_HCFG( self ):
-        if chipsec.chipset.is_register_defined( self.cs, 'SMBUS_HCFG' ):
-            reg_value = chipsec.chipset.read_register( self.cs, 'SMBUS_HCFG' )
-            if logger().HAL: chipsec.chipset.print_register( self.cs, 'SMBUS_HCFG', reg_value )
+        if self.cs.is_register_defined( 'SMBUS_HCFG' ):
+            reg_value = self.cs.read_register( 'SMBUS_HCFG' )
+            if logger().HAL: self.cs.print_register( 'SMBUS_HCFG', reg_value )
             return reg_value
         else:
             raise chipsec.chipset.RegisterNotFoundError, ('RegisterNotFound: SMBUS_HCFG')
@@ -96,13 +97,13 @@ class SMBus:
 
     def enable_SMBus_host_controller( self ):
         # Enable SMBus Host Controller Interface in HCFG
-        reg_value = chipsec.chipset.read_register( self.cs, 'SMBUS_HCFG' )
-        if 0 == (reg_value & 0x1): chipsec.chipset.write_register( self.cs, 'SMBUS_HCFG', (reg_value|0x1) )
+        reg_value = self.cs.read_register( 'SMBUS_HCFG' )
+        if 0 == (reg_value & 0x1): self.cs.write_register( 'SMBUS_HCFG', (reg_value|0x1) )
         # @TODO: check SBA is programmed
         sba = self.get_SMBus_Base_Address()
         # Enable SMBus I/O Space
-        cmd = chipsec.chipset.read_register( self.cs, 'SMBUS_CMD' )
-        if 0 == (cmd & 0x1): chipsec.chipset.write_register( self.cs, 'SMBUS_CMD', (cmd|0x1) )
+        cmd = self.cs.read_register( 'SMBUS_CMD' )
+        if 0 == (cmd & 0x1): self.cs.write_register( 'SMBUS_CMD', (cmd|0x1) )
 
 
     #
@@ -113,7 +114,7 @@ class SMBus:
     def _is_smbus_ready( self ):
         for i in range(SMBUS_POLL_COUNT):
             #time.sleep( SMBUS_POLL_SLEEP_INTERVAL )
-            busy = chipsec.chipset.read_register_field( self.cs, self.smb_reg_status, 'BUSY' )
+            busy = self.cs.read_register_field( self.smb_reg_status, 'BUSY' )
             if 0 == busy: return True
         return (0 == busy)
 
@@ -121,9 +122,9 @@ class SMBus:
     def _wait_for_cycle( self ):
         for i in range(SMBUS_POLL_COUNT):
             #time.sleep( SMBUS_POLL_SLEEP_INTERVAL )
-            sts    = chipsec.chipset.read_register( self.cs, self.smb_reg_status )
-            busy   = chipsec.chipset.get_register_field( self.cs, self.smb_reg_status, sts, 'BUSY' )
-            failed = chipsec.chipset.get_register_field( self.cs, self.smb_reg_status, sts, 'FAILED' )
+            sts    = self.cs.read_register( self.smb_reg_status )
+            busy   = self.cs.get_register_field( self.smb_reg_status, sts, 'BUSY' )
+            failed = self.cs.get_register_field( self.smb_reg_status, sts, 'FAILED' )
             if 0 == busy:
                 #if logger().VERBOSE:
                 #    intr = chipsec.chipset.get_register_field( self.cs, self.smb_reg_status, sts, 'INTR' )
@@ -136,39 +137,39 @@ class SMBus:
                 if logger().HAL: logger().error( "SMBus transaction failed (FAILED/ERROR bit = 1)" )
                 return False
             else:
-                if chipsec.chipset.register_has_field( self.cs, self.smb_reg_status, 'DEV_ERR' ):
-                    if 1 == chipsec.chipset.get_register_field( self.cs, self.smb_reg_status, sts, 'DEV_ERR' ): 
+                if self.cs.register_has_field( self.smb_reg_status, 'DEV_ERR' ):
+                    if 1 == self.cs.get_register_field( self.smb_reg_status, sts, 'DEV_ERR' ): 
                         if logger().HAL: logger().error( "SMBus device error (invalid cmd, unclaimed cycle or time-out error)" )
                         return False
-                if chipsec.chipset.register_has_field( self.cs, self.smb_reg_status, 'BUS_ERR' ):
-                    if 1 == chipsec.chipset.get_register_field( self.cs, self.smb_reg_status, sts, 'BUS_ERR' ):
+                if self.cs.register_has_field( self.smb_reg_status, 'BUS_ERR' ):
+                    if 1 == self.cs.get_register_field( self.smb_reg_status, sts, 'BUS_ERR' ):
                         if logger().HAL: logger().error( "SMBus bus error" )
                         return False
         return (0 == busy)
 
     def read_byte( self, target_address, offset ):
         # clear status bits
-        chipsec.chipset.write_register( self.cs, self.smb_reg_status, 0xFF )
+        self.cs.write_register( self.smb_reg_status, 0xFF )
 
         # SMBus txn RW direction = Read, SMBus slave address = target_address
         hst_sa = 0x0
-        hst_sa = chipsec.chipset.set_register_field( self.cs, self.smb_reg_address, hst_sa, 'RW', SMBUS_COMMAND_READ )
-        hst_sa = chipsec.chipset.set_register_field( self.cs, self.smb_reg_address, hst_sa, 'Address', target_address, True )
-        chipsec.chipset.write_register( self.cs, self.smb_reg_address, hst_sa )
+        hst_sa = self.cs.set_register_field( self.smb_reg_address, hst_sa, 'RW', SMBUS_COMMAND_READ )
+        hst_sa = self.cs.set_register_field( self.smb_reg_address, hst_sa, 'Address', target_address, True )
+        self.cs.write_register( self.smb_reg_address, hst_sa )
         # command data = byte offset (bus txn address)
-        chipsec.chipset.write_register_field( self.cs, self.smb_reg_command, 'DataOffset', offset )
+        self.cs.write_register_field( self.smb_reg_command, 'DataOffset', offset )
         # command = Byte Data
-        #if chipsec.chipset.register_has_field( self.cs, self.smb_reg_control, 'SMB_CMD' ):
-        chipsec.chipset.write_register_field( self.cs, self.smb_reg_control, 'SMB_CMD', SMBUS_COMMAND_BYTE_DATA )
+        #if self.cs.register_has_field( self.smb_reg_control, 'SMB_CMD' ):
+        self.cs.write_register_field( self.smb_reg_control, 'SMB_CMD', SMBUS_COMMAND_BYTE_DATA )
         # send SMBus txn
-        chipsec.chipset.write_register_field( self.cs, self.smb_reg_control, 'START', 1 )
+        self.cs.write_register_field( self.smb_reg_control, 'START', 1 )
 
         # wait for cycle to complete
         if not self._wait_for_cycle(): return 0xFF
         # read the data
-        value = chipsec.chipset.read_register_field( self.cs, self.smb_reg_data0, 'Data' )
+        value = self.cs.read_register_field( self.smb_reg_data0, 'Data' )
         # clear status bits
-        chipsec.chipset.write_register( self.cs, self.smb_reg_status, 0xFF )
+        self.cs.write_register( self.smb_reg_status, 0xFF )
         # clear address/offset registers
         #chipsec.chipset.write_register( self.cs, self.smb_reg_address, 0x0 )
         #chipsec.chipset.write_register( self.cs, self.smb_reg_command, 0x0 )
@@ -177,27 +178,27 @@ class SMBus:
 
     def write_byte( self, target_address, offset, value ):
         # clear status bits
-        chipsec.chipset.write_register( self.cs, self.smb_reg_status, 0xFF )
+        self.cs.write_register( self.smb_reg_status, 0xFF )
 
         # SMBus txn RW direction = Write, SMBus slave address = target_address
         hst_sa = 0x0
-        hst_sa = chipsec.chipset.set_register_field( self.cs, self.smb_reg_address, hst_sa, 'RW', SMBUS_COMMAND_WRITE )
-        hst_sa = chipsec.chipset.set_register_field( self.cs, self.smb_reg_address, hst_sa, 'Address', target_address, True )
-        chipsec.chipset.write_register( self.cs, self.smb_reg_address, hst_sa )
+        hst_sa = self.cs.set_register_field( self.smb_reg_address, hst_sa, 'RW', SMBUS_COMMAND_WRITE )
+        hst_sa = self.cs.set_register_field( self.smb_reg_address, hst_sa, 'Address', target_address, True )
+        self.cs.write_register( self.smb_reg_address, hst_sa )
         # command data = byte offset (bus txn address)
-        chipsec.chipset.write_register_field( self.cs, self.smb_reg_command, 'DataOffset', offset )
+        self.cs.write_register_field( self.smb_reg_command, 'DataOffset', offset )
         # write the data
-        chipsec.chipset.write_register_field( self.cs, self.smb_reg_data0, 'Data', value )
+        self.cs.write_register_field( self.smb_reg_data0, 'Data', value )
         # command = Byte Data
-        #if chipsec.chipset.register_has_field( self.cs, self.smb_reg_control, 'SMB_CMD' ):
-        chipsec.chipset.write_register_field( self.cs, self.smb_reg_control, 'SMB_CMD', SMBUS_COMMAND_BYTE_DATA )
+        #if self.cs.register_has_field( self.smb_reg_control, 'SMB_CMD' ):
+        self.cs.write_register_field( self.smb_reg_control, 'SMB_CMD', SMBUS_COMMAND_BYTE_DATA )
         # send SMBus txn
-        chipsec.chipset.write_register_field( self.cs, self.smb_reg_control, 'START', 1 )
+        self.cs.write_register_field( self.smb_reg_control, 'START', 1 )
 
         # wait for cycle to complete
         if not self._wait_for_cycle(): return False
         # clear status bits
-        chipsec.chipset.write_register( self.cs, self.smb_reg_status, 0xFF )
+        self.cs.write_register( self.smb_reg_status, 0xFF )
         # clear address/offset registers
         #chipsec.chipset.write_register( self.cs, self.smb_reg_address, 0x0 )
         #chipsec.chipset.write_register( self.cs, self.smb_reg_command, 0x0 )

--- a/chipsec/hal/spi_descriptor.py
+++ b/chipsec/hal/spi_descriptor.py
@@ -47,7 +47,7 @@ from chipsec.logger import *
 from chipsec.file import *
 
 from chipsec.cfg.common import *
-from chipsec.hal.spi import *
+from chipsec.hal import spi
 
 SPI_FLASH_DESCRIPTOR_SIGNATURE = struct.pack('=I', 0x0FF0A55A )
 SPI_FLASH_DESCRIPTOR_SIZE      = 0x1000
@@ -80,13 +80,13 @@ def get_spi_regions( fd ):
     # Number of Regions (bits [26:24])
     nr   = ( ((flmap0 & 0xFF000000) >> 24) & 0x7 )
 
-    flregs = [None]*SPI_REGION_NUMBER_IN_FD
-    for r in range( SPI_REGION_NUMBER_IN_FD ):
+    flregs = [None] * spi.SPI_REGION_NUMBER_IN_FD
+    for r in range( spi.SPI_REGION_NUMBER_IN_FD ):
         flreg_off = frba + r*4
         flreg = struct.unpack_from( '=I', fd[flreg_off:flreg_off + 0x4] )[0]
-        (base,limit) = get_SPI_region( flreg )
+        (base,limit) = spi.get_SPI_region(flreg)
         notused = (base > limit)
-        flregs[r] = (r,SPI_REGION_NAMES[r],flreg,base,limit,notused)
+        flregs[r] = (r, spi.SPI_REGION_NAMES[r],flreg,base,limit,notused)
 
     fd_size    = flregs[FLASH_DESCRIPTOR][4] - flregs[FLASH_DESCRIPTOR][3] + 1
     fd_notused = flregs[FLASH_DESCRIPTOR][5]
@@ -184,11 +184,11 @@ def parse_spi_flash_descriptor( rom ):
     logger().log( '+ 0x%04X Region Section:' % frba )
     logger().log( '========================================================' )
 
-    flregs = [None]*SPI_REGION_NUMBER_IN_FD
-    for r in range( SPI_REGION_NUMBER_IN_FD ):
+    flregs = [None] * spi.SPI_REGION_NUMBER_IN_FD
+    for r in range( spi.SPI_REGION_NUMBER_IN_FD ):
         flreg_off = frba + r*4
         flreg = struct.unpack_from( '=I', fd[flreg_off:flreg_off + 0x4] )[0]
-        (base,limit) = get_SPI_region( flreg )
+        (base,limit) = spi.get_SPI_region( flreg )
         notused = ''
         if base > limit:
             notused = '(not used)'
@@ -200,8 +200,8 @@ def parse_spi_flash_descriptor( rom ):
     logger().log( '--------------------------------------------------------' )
     logger().log( ' Region                | FLREGx    | Base     | Limit   ' )
     logger().log( '--------------------------------------------------------' )
-    for r in range( SPI_REGION_NUMBER_IN_FD ):
-        logger().log( '%d %-020s | %08X  | %08X | %08X %s' % (r,SPI_REGION_NAMES[r],flregs[r][0],flregs[r][1],flregs[r][2],flregs[r][3]) )
+    for r in range( spi.SPI_REGION_NUMBER_IN_FD ):
+        logger().log( '%d %-020s | %08X  | %08X | %08X %s' % (r, spi.SPI_REGION_NAMES[r],flregs[r][0],flregs[r][1],flregs[r][2],flregs[r][3]) )
 
     #
     # Flash Descriptor Master Section
@@ -210,8 +210,8 @@ def parse_spi_flash_descriptor( rom ):
     logger().log( '+ 0x%04X Master Section:' % fmba )
     logger().log( '========================================================' )
 
-    flmstrs = [None]*SPI_MASTER_NUMBER_IN_FD
-    for m in range( SPI_MASTER_NUMBER_IN_FD ):
+    flmstrs = [None] * spi.SPI_MASTER_NUMBER_IN_FD
+    for m in range( spi.SPI_MASTER_NUMBER_IN_FD ):
         flmstr_off = fmba + m*4
         flmstr = struct.unpack_from( '=I', fd[flmstr_off:flmstr_off + 0x4] )[0]
         (requester_id, master_region_ra, master_region_wa) = get_SPI_master( flmstr )
@@ -222,13 +222,13 @@ def parse_spi_flash_descriptor( rom ):
     logger().log( 'Master Read/Write Access to Flash Regions' )
     logger().log( '--------------------------------------------------------' )
     s = ' Region                '
-    for m in range( SPI_MASTER_NUMBER_IN_FD ):
-        s = s + '| ' + ('%-9s' % SPI_MASTER_NAMES[m])
+    for m in range( spi.SPI_MASTER_NUMBER_IN_FD ):
+        s = s + '| ' + ('%-9s' % spi.SPI_MASTER_NAMES[m])
     logger().log( s )
     logger().log( '--------------------------------------------------------' )
-    for r in range( SPI_REGION_NUMBER_IN_FD ):
-        s = '%d %-020s ' % (r,SPI_REGION_NAMES[r])
-        for m in range( SPI_MASTER_NUMBER_IN_FD ):
+    for r in range( spi.SPI_REGION_NUMBER_IN_FD ):
+        s = '%d %-020s ' % (r, spi.SPI_REGION_NAMES[r])
+        for m in range( spi.SPI_MASTER_NUMBER_IN_FD ):
             access_s = ''
             mask = (0x1 << r) & 0xFF
             if (flmstrs[m][2] & mask):

--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -41,12 +41,9 @@ import sys
 from collections import namedtuple
 import collections
 
+from chipsec.hal import hal_base, mmio, spi, uefi_platform
 from chipsec.hal.uefi_common import *
-from chipsec.hal.uefi_platform import *
-
 from chipsec.logger import *
-from chipsec.hal.mmio import *
-from chipsec.hal.spi import *
 from chipsec.file import *
 
 
@@ -254,16 +251,16 @@ def identify_EFI_NVRAM( buffer ):
 #
 ########################################################################################################
 
-class UEFI:
-    def __init__( self, cs ):
-        self.cs = cs
+class UEFI(hal_base.HALBase):
+    def __init__(self, cs):
+        super(UEFI, self).__init__(cs)
         self.helper = cs.helper
         #if cs is not None:
         #    self.cs = cs
         #    self.helper = cs.helper
         #else:
         #    self.helper = helper
-        self._FWType = FWType.EFI_FW_TYPE_UEFI
+        self._FWType = uefi_platform.FWType.EFI_FW_TYPE_UEFI
 
     ######################################################################
     # FWType defines platform/BIOS dependent formats like

--- a/chipsec/module_common.py
+++ b/chipsec/module_common.py
@@ -51,8 +51,8 @@ class ModuleResult:
     DEPRECATED = 4
     ERROR   = -1
 
-    
-class BaseModule( object ):
+
+class BaseModule(object):
     def __init__(self):
         self.cs = chipsec.chipset.cs()
         self.logger = chipsec.logger.logger()
@@ -64,7 +64,7 @@ class BaseModule( object ):
         depending whether or not this module is supported in the currently running
         platform.
         To access the currently running platform use
-            
+
         >>> self.cs.get_chipset_id()
         """
         return True
@@ -79,8 +79,8 @@ class BaseModule( object ):
                 self.res = value
         else: # PASSED or SKIPPED or DEPRECATED
             self.res = value
-        
-    def run( self, module_argv ):
+
+    def run(self, module_argv):
         raise NotImplementedError('sub class should overwrite the run() method')
 
 
@@ -88,7 +88,6 @@ MTAG_BIOS       = "BIOS"
 MTAG_SMM        = "SMM"
 MTAG_SECUREBOOT = "SECUREBOOT"
 MTAG_HWCONFIG   = "HWCONFIG"
-
 
 
 ##! [Available Tags]

--- a/chipsec/modules/common/bios_smi.py
+++ b/chipsec/modules/common/bios_smi.py
@@ -33,7 +33,7 @@ References:
 """
 
 from chipsec.module_common import *
-from chipsec.hal.iobar import * 
+from chipsec.hal import iobar
 
 
 TAGS = [MTAG_BIOS,MTAG_SMM]
@@ -42,7 +42,7 @@ class bios_smi(BaseModule):
 
     def __init__(self):
         BaseModule.__init__(self)
-        self.iobar = iobar( self.cs )
+        self.iobar = iobar.IOBAR(self.cs)
 
     def is_supported(self):
         return (self.cs.get_chipset_id() not in chipsec.chipset.CHIPSET_FAMILY_ATOM)
@@ -51,16 +51,16 @@ class bios_smi(BaseModule):
 
         self.logger.start_test( "SMI Events Configuration" )
         
-        if not chipsec.chipset.is_register_defined( self.cs, 'TCO1_CNT' ) or \
-           not chipsec.chipset.is_register_defined( self.cs, 'GEN_PMCON_1' ) or \
-           not chipsec.chipset.is_register_defined( self.cs, 'SMI_EN' ):
+        if not self.cs.is_register_defined( 'TCO1_CNT' ) or \
+           not self.cs.is_register_defined( 'GEN_PMCON_1' ) or \
+           not self.cs.is_register_defined( 'SMI_EN' ):
             self.logger.error( "Couldn't find definition of required configuration registers" )
             return ModuleResult.ERROR
         
         #
         # Checking SMM_BWP first in BIOS control to warn if SMM write-protection of the BIOS is not enabled
         #
-        smm_bwp = chipsec.chipset.get_control( self.cs, 'SmmBiosWriteProtection' )
+        smm_bwp = self.cs.get_control( 'SmmBiosWriteProtection' )
         if 0 == smm_bwp: self.logger.log_bad( "SMM BIOS region write protection has not been enabled (SMM_BWP is not used)\n" )
         else:            self.logger.log_good( "SMM BIOS region write protection is enabled (SMM_BWP is used)\n" )
 
@@ -70,12 +70,8 @@ class bios_smi(BaseModule):
         # Checking if global SMI and TCO SMI are enabled (GBL_SMI_EN and TCO_EN bits in SMI_EN register)
         #
         self.logger.log( "[*] Checking SMI enables.." )
-        #smi_en_reg = chipsec.chipset.read_register( self.cs, 'SMI_EN' )
-        ##chipsec.chipset.print_register( self.cs, 'SMI_EN', smi_en_reg )
-        #tco_en     = chipsec.chipset.get_register_field( self.cs, 'SMI_EN', smi_en_reg, 'TCO_EN' )
-        #gbl_smi_en = chipsec.chipset.get_register_field( self.cs, 'SMI_EN', smi_en_reg, 'GBL_SMI_EN' )
-        tco_en     = chipsec.chipset.get_control( self.cs, 'TCOSMIEnable' )
-        gbl_smi_en = chipsec.chipset.get_control( self.cs, 'GlobalSMIEnable' )
+        tco_en     = self.cs.get_control( 'TCOSMIEnable' )
+        gbl_smi_en = self.cs.get_control( 'GlobalSMIEnable' )
         self.logger.log( "    Global SMI enable: %d" % gbl_smi_en )
         self.logger.log( "    TCO SMI enable   : %d" % tco_en )
 
@@ -92,7 +88,7 @@ class bios_smi(BaseModule):
         #
         # Checking TCO_LOCK
         #
-        tco_lock = chipsec.chipset.get_control( self.cs, 'TCOSMILock')
+        tco_lock = self.cs.get_control( 'TCOSMILock')
         if tco_lock != 1:
             ok = False
             self.logger.log_bad( "TCO SMI event configuration is not locked. TCO SMI events can be disabled" )
@@ -101,7 +97,7 @@ class bios_smi(BaseModule):
         #
         # Checking SMI_LOCK
         #
-        smi_lock = chipsec.chipset.get_control( self.cs, 'SMILock' )
+        smi_lock = self.cs.get_control( 'SMILock' )
         if smi_lock != 1:
             ok = False
             self.logger.log_bad( "SMI events global configuration is not locked. SMI events can be disabled" )

--- a/chipsec/modules/common/bios_ts.py
+++ b/chipsec/modules/common/bios_ts.py
@@ -41,19 +41,19 @@ class bios_ts(chipsec.module_common.BaseModule):
         self.logger.start_test( "BIOS Interface Lock (including Top Swap Mode)" )
 
         bild = 0
-        if chipsec.chipset.is_control_defined( self.cs, 'BiosInterfaceLockDown' ):
-            bild = chipsec.chipset.get_control( self.cs, 'BiosInterfaceLockDown' )
+        if self.cs.is_control_defined( 'BiosInterfaceLockDown' ):
+            bild = self.cs.get_control( 'BiosInterfaceLockDown' )
             self.logger.log( "[*] BiosInterfaceLockDown (BILD) control = %d" % bild )
         else:
             self.logger.error( "BiosInterfaceLockDown (BILD) control is not defined" )
             return ModuleResult.ERROR
 
-        if chipsec.chipset.is_control_defined( self.cs, 'TopSwapStatus' ):
-            tss = chipsec.chipset.get_control( self.cs, 'TopSwapStatus' )
+        if self.cs.is_control_defined( 'TopSwapStatus' ):
+            tss = self.cs.get_control( 'TopSwapStatus' )
             self.logger.log( "[*] BIOS Top Swap mode is %s (TSS = %d)" % ('enabled' if (1==tss) else 'disabled', tss) )
 
-        if chipsec.chipset.is_control_defined( self.cs, 'TopSwap' ):
-            ts  = chipsec.chipset.get_control( self.cs, 'TopSwap' )
+        if self.cs.is_control_defined( 'TopSwap' ):
+            ts  = self.cs.get_control( 'TopSwap' )
             self.logger.log( "[*] RTC TopSwap control (TS) = %x" % ts )
 
         if 0 == bild:

--- a/chipsec/modules/common/bios_wp.py
+++ b/chipsec/modules/common/bios_wp.py
@@ -61,11 +61,11 @@ class bios_wp(BaseModule):
         #chipsec.chipset.print_register(self.cs, 'BC', reg_value)
 
         #ble    = chipsec.chipset.get_register_field(self.cs, 'BC', reg_value, 'BLE')
-        ble = chipsec.chipset.get_control(self.cs, 'BiosLockEnable', with_print=True)
-        #bioswe = chipsec.chipset.get_register_field(self.cs, 'BC', reg_value, 'BIOSWE')
-        bioswe = chipsec.chipset.get_control(self.cs, 'BiosWriteEnable')
+        ble = self.cs.get_control('BiosLockEnable', with_print=True)
+        #bioswe = self.cs.get_register_field('BC', reg_value, 'BIOSWE')
+        bioswe = self.cs.get_control('BiosWriteEnable')
         #smmbwp = chipsec.chipset.get_register_field(self.cs, 'BC', reg_value, 'SMM_BWP')
-        smmbwp = chipsec.chipset.get_control( self.cs, 'SmmBiosWriteProtection' )
+        smmbwp = self.cs.get_control( 'SmmBiosWriteProtection' )
 
         # Is the BIOS flash region write protected?
         write_protected = 0

--- a/chipsec/modules/common/ia32cfg.py
+++ b/chipsec/modules/common/ia32cfg.py
@@ -35,23 +35,23 @@ class ia32cfg(BaseModule):
     def __init__(self):
         BaseModule.__init__(self)
         self.res = ModuleResult.PASSED
-    
+
     def is_supported(self):
         if self.cs.is_atom(): return False
         else: return True
-        
+
     def check_ia32feature_control(self):
         self.logger.start_test( "IA32 Feature Control Lock" )
         self.logger.log( "[*] Verifying IA32_Feature_Control MSR is locked on all logical CPUs.." )
-        
+
         ok = True
         for tid in range(self.cs.msr.get_cpu_thread_count()):
             #feature_cntl = chipsec.chipset.read_register( self.cs, 'IA32_FEATURE_CONTROL', tid )
             #chipsec.chipset.print_register( self.cs, 'IA32_FEATURE_CONTROL', feature_cntl )
-            feature_cntl_lock = chipsec.chipset.get_control( self.cs, 'Ia32FeatureControlLock' )
+            feature_cntl_lock = self.cs.get_control('Ia32FeatureControlLock' )
             self.logger.log( "[*] cpu%d: IA32_Feature_Control Lock = %d" % (tid,feature_cntl_lock) )
             if 0 == feature_cntl_lock: ok = False
-        
+
         if ok:
            self.res = ModuleResult.PASSED
            self.logger.log_passed_check( "IA32_FEATURE_CONTROL MSR is locked on all logical CPUs" )

--- a/chipsec/modules/common/rtclock.py
+++ b/chipsec/modules/common/rtclock.py
@@ -35,14 +35,14 @@ class rtclock(BaseModule):
 
     def is_supported(self):
         return (self.cs.get_chipset_id() in chipsec.chipset.CHIPSET_FAMILY_CORE)
-        
+
     def check_rtclock(self):
         self.logger.start_test( "Protected RTC memory locations" )
 
-        rc_reg = chipsec.chipset.read_register( self.cs, 'RC' )
-        chipsec.chipset.print_register( self.cs, 'RC', rc_reg )
-        ll = chipsec.chipset.get_register_field( self.cs, 'RC', rc_reg, 'LL' )
-        ul = chipsec.chipset.get_register_field( self.cs, 'RC', rc_reg, 'UL' )
+        rc_reg = self.cs.read_register( 'RC' )
+        self.cs.print_register( 'RC', rc_reg )
+        ll = self.cs.get_register_field( 'RC', rc_reg, 'LL' )
+        ul = self.cs.get_register_field( 'RC', rc_reg, 'UL' )
 
         if ll == 1: self.logger.log_good( "Protected bytes (0x38-0x3F) in low 128-byte bank of RTC memory are locked" )
         else:  self.logger.log_bad( "Protected bytes (0x38-0x3F) in low 128-byte bank of RTC memory are not locked" )

--- a/chipsec/modules/common/smm.py
+++ b/chipsec/modules/common/smm.py
@@ -39,20 +39,20 @@ class smm(BaseModule):
     def is_supported(self):
         chipset = self.cs.get_chipset_id()
         return (chipset not in chipsec.chipset.CHIPSET_FAMILY_ATOM) and (chipset not in chipsec.chipset.CHIPSET_FAMILY_XEON)
-  
+
     def check_SMRAMC(self):
         self.logger.start_test( "Compatible SMM memory (SMRAM) Protection" )
-        
-        if not chipsec.chipset.is_register_defined( self.cs, 'PCI0.0.0_SMRAMC'  ) :
+
+        if not self.cs.is_register_defined( 'PCI0.0.0_SMRAMC'  ) :
             self.logger.error( "Couldn't find definition of required registers (PCI0.0.0_SMRAMC)" )
             return ModuleResult.ERROR
-        
-        regval = chipsec.chipset.read_register( self.cs, 'PCI0.0.0_SMRAMC' )
-        g_smrame = chipsec.chipset.get_register_field( self.cs, 'PCI0.0.0_SMRAMC', regval, 'G_SMRAME' )
-        d_open   = chipsec.chipset.get_register_field( self.cs, 'PCI0.0.0_SMRAMC', regval, 'D_OPEN' )
-        d_lock   = chipsec.chipset.get_register_field( self.cs, 'PCI0.0.0_SMRAMC', regval, 'D_LCK' )
-      
-        chipsec.chipset.print_register( self.cs, 'PCI0.0.0_SMRAMC', regval )
+
+        regval = self.cs.read_register( 'PCI0.0.0_SMRAMC' )
+        g_smrame = self.cs.get_register_field( 'PCI0.0.0_SMRAMC', regval, 'G_SMRAME' )
+        d_open   = self.cs.get_register_field( 'PCI0.0.0_SMRAMC', regval, 'D_OPEN' )
+        d_lock   = self.cs.get_register_field( 'PCI0.0.0_SMRAMC', regval, 'D_LCK' )
+
+        self.cs.print_register( 'PCI0.0.0_SMRAMC', regval )
 
         res = ModuleResult.ERROR
         if 1 == g_smrame:

--- a/chipsec/modules/common/smrr.py
+++ b/chipsec/modules/common/smrr.py
@@ -43,15 +43,15 @@ class smrr(BaseModule):
     # Check that SMRR are supported by CPU in IA32_MTRRCAP_MSR[SMRR]
     #
     def check_SMRR_supported(self):
-        mtrrcap_msr_reg = chipsec.chipset.read_register( self.cs, 'MTRRCAP' )
-        if self.logger.VERBOSE: chipsec.chipset.print_register( self.cs, 'MTRRCAP', mtrrcap_msr_reg )
-        smrr = chipsec.chipset.get_register_field( self.cs, 'MTRRCAP', mtrrcap_msr_reg, 'SMRR' )
+        mtrrcap_msr_reg = self.cs.read_register( 'MTRRCAP' )
+        if self.logger.VERBOSE: self.cs.print_register( 'MTRRCAP', mtrrcap_msr_reg )
+        smrr = self.cs.get_register_field( 'MTRRCAP', mtrrcap_msr_reg, 'SMRR' )
         return (1 == smrr)
 
     def check_SMRR(self, do_modify):
-        if not chipsec.chipset.is_register_defined( self.cs, 'MTRRCAP' ) or \
-           not chipsec.chipset.is_register_defined( self.cs, 'IA32_SMRR_PHYSBASE' ) or \
-           not chipsec.chipset.is_register_defined( self.cs, 'IA32_SMRR_PHYSMASK' ):
+        if not self.cs.is_register_defined( 'MTRRCAP' ) or \
+           not self.cs.is_register_defined( 'IA32_SMRR_PHYSBASE' ) or \
+           not self.cs.is_register_defined( 'IA32_SMRR_PHYSMASK' ):
             self.logger.error( "Couldn't find definition of required configuration registers" )
             return ModuleResult.ERROR
 
@@ -72,10 +72,10 @@ class smrr(BaseModule):
         #
         self.logger.log( '' )
         self.logger.log( "[*] Checking SMRR range base programming.." )
-        msr_smrrbase = chipsec.chipset.read_register( self.cs, 'IA32_SMRR_PHYSBASE' )
-        chipsec.chipset.print_register( self.cs, 'IA32_SMRR_PHYSBASE', msr_smrrbase )
-        smrrbase = chipsec.chipset.get_register_field( self.cs, 'IA32_SMRR_PHYSBASE', msr_smrrbase, 'PhysBase', True )
-        smrrtype = chipsec.chipset.get_register_field( self.cs, 'IA32_SMRR_PHYSBASE', msr_smrrbase, 'Type' )
+        msr_smrrbase = self.cs.read_register( 'IA32_SMRR_PHYSBASE' )
+        self.cs.print_register( 'IA32_SMRR_PHYSBASE', msr_smrrbase )
+        smrrbase = self.cs.get_register_field( 'IA32_SMRR_PHYSBASE', msr_smrrbase, 'PhysBase', True )
+        smrrtype = self.cs.get_register_field( 'IA32_SMRR_PHYSBASE', msr_smrrbase, 'Type' )
         self.logger.log( "[*] SMRR range base: 0x%016X" % smrrbase )
 
         if smrrtype in self.cs.Cfg.MemType:
@@ -95,10 +95,10 @@ class smrr(BaseModule):
         #
         self.logger.log( '' )
         self.logger.log( "[*] Checking SMRR range mask programming.." )
-        msr_smrrmask = chipsec.chipset.read_register( self.cs, 'IA32_SMRR_PHYSMASK' )
-        chipsec.chipset.print_register( self.cs, 'IA32_SMRR_PHYSMASK', msr_smrrmask )
-        smrrmask  = chipsec.chipset.get_register_field( self.cs, 'IA32_SMRR_PHYSMASK', msr_smrrmask, 'PhysMask', True )
-        smrrvalid = chipsec.chipset.get_register_field( self.cs, 'IA32_SMRR_PHYSMASK', msr_smrrmask, 'Valid' )
+        msr_smrrmask = self.cs.read_register( 'IA32_SMRR_PHYSMASK' )
+        self.cs.print_register( 'IA32_SMRR_PHYSMASK', msr_smrrmask )
+        smrrmask  = self.cs.get_register_field( 'IA32_SMRR_PHYSMASK', msr_smrrmask, 'PhysMask', True )
+        smrrvalid = self.cs.get_register_field( 'IA32_SMRR_PHYSMASK', msr_smrrmask, 'Valid' )
         self.logger.log( "[*] SMRR range mask: 0x%016X" % smrrmask )
 
         if not ( smrrvalid and (0 != smrrmask) ):
@@ -113,8 +113,8 @@ class smrr(BaseModule):
         self.logger.log( '' )
         self.logger.log( "[*] Verifying that SMRR range base & mask are the same on all logical CPUs.." )
         for tid in range(self.cs.msr.get_cpu_thread_count()):
-            msr_base = chipsec.chipset.read_register( self.cs, 'IA32_SMRR_PHYSBASE', tid )
-            msr_mask = chipsec.chipset.read_register( self.cs, 'IA32_SMRR_PHYSMASK', tid)
+            msr_base = self.cs.read_register( 'IA32_SMRR_PHYSBASE', tid )
+            msr_mask = self.cs.read_register( 'IA32_SMRR_PHYSMASK', tid)
             self.logger.log( "[CPU%d] SMRR_PHYSBASE = %016X, SMRR_PHYSMASK = %016X"% (tid, msr_base, msr_mask) )
             if (msr_base != msr_smrrbase) or (msr_mask != msr_smrrmask):
                 smrr_ok = False

--- a/chipsec/modules/common/spi_desc.py
+++ b/chipsec/modules/common/spi_desc.py
@@ -45,10 +45,10 @@ class spi_desc(BaseModule):
         self.logger.start_test( "SPI Flash Region Access Control" )
 
         res = ModuleResult.PASSED
-        frap = chipsec.chipset.read_register( self.cs, 'FRAP' )
-        chipsec.chipset.print_register( self.cs, 'FRAP', frap )
-        brra = chipsec.chipset.get_register_field( self.cs, 'FRAP', frap, 'BRRA' )
-        brwa = chipsec.chipset.get_register_field( self.cs, 'FRAP', frap, 'BRWA' )
+        frap = self.cs.read_register( 'FRAP' )
+        self.cs.print_register( 'FRAP', frap )
+        brra = self.cs.get_register_field( 'FRAP', frap, 'BRRA' )
+        brwa = self.cs.get_register_field( 'FRAP', frap, 'BRWA' )
 
         self.logger.log("[*] Software access to SPI flash regions: read = 0x%02X, write = 0x%02X" % (brra, brwa) )
         if brwa & (1 << chipsec.hal.spi.FLASH_DESCRIPTOR):

--- a/chipsec/modules/common/spi_fdopss.py
+++ b/chipsec/modules/common/spi_fdopss.py
@@ -36,13 +36,13 @@ class spi_fdopss(BaseModule):
     def check_fd_security_override_strap(self):
         self.logger.start_test( "SPI Flash Descriptor Security Override Pin-Strap" )
 
-        if not chipsec.chipset.is_register_defined( self.cs, 'HSFS' ):
+        if not self.cs.is_register_defined( 'HSFS' ):
             self.logger.error( "Couldn't find definition of required configuration registers (HSFS)" )
             return ModuleResult.ERROR
 
-        hsfs_reg = chipsec.chipset.read_register( self.cs, 'HSFS' )
-        chipsec.chipset.print_register( self.cs, 'HSFS', hsfs_reg )
-        fdopss = chipsec.chipset.get_register_field( self.cs, 'HSFS', hsfs_reg, 'FDOPSS' )
+        hsfs_reg = self.cs.read_register( 'HSFS' )
+        self.cs.print_register( 'HSFS', hsfs_reg )
+        fdopss = self.cs.get_register_field( 'HSFS', hsfs_reg, 'FDOPSS' )
 
         if 0 != fdopss:
             self.logger.log_passed_check( "SPI Flash Descriptor Security Override is disabled" )

--- a/chipsec/modules/common/spi_lock.py
+++ b/chipsec/modules/common/spi_lock.py
@@ -34,7 +34,7 @@ TAGS = [MTAG_BIOS]
 class spi_lock(BaseModule):
 
     def __init__(self):
-        BaseModule.__init__(self)
+        super(spi_lock, self).__init__()
 
     def is_supported(self):
         return True
@@ -46,7 +46,7 @@ class spi_lock(BaseModule):
         #hsfs_reg = chipsec.chipset.read_register( self.cs, 'HSFS' )
         #chipsec.chipset.print_register( self.cs, 'HSFS', hsfs_reg )
         #flockdn = chipsec.chipset.get_register_field( self.cs, 'HSFS', hsfs_reg, 'FLOCKDN' )
-        flockdn = chipsec.chipset.get_control(self.cs, 'FlashLockDown', with_print=True)
+        flockdn = self.cs.get_control('FlashLockDown', with_print=True)
 
         if 1 == flockdn:
             spi_lock_res = ModuleResult.PASSED

--- a/chipsec/modules/common/uefi/access_uefispec.py
+++ b/chipsec/modules/common/uefi/access_uefispec.py
@@ -29,7 +29,6 @@ Returns failure if variable attributes are not as defined in `table 11 "Global V
 from chipsec.module_common import *
 from chipsec.file          import *
 from chipsec.hal.uefi      import *
-import chipsec.chipset
 
 TAGS = [MTAG_BIOS]
 TAGS += [MTAG_SECUREBOOT]

--- a/chipsec/modules/memconfig.py
+++ b/chipsec/modules/memconfig.py
@@ -70,9 +70,9 @@ class memconfig(BaseModule):
         all_locked = True
 
         for r in regs:
-            d = chipsec.chipset.get_register_def( self.cs, r )
-            v = chipsec.chipset.read_register( self.cs, r )
-            locked = chipsec.chipset.get_register_field( self.cs, r, v, memmap_registers[r] )
+            d = self.cs.get_register_def( r )
+            v = self.cs.read_register( r )
+            locked = self.cs.get_register_field( r, v, memmap_registers[r] )
             if locked == 1:
                 self.logger.log_good( "%-20s = 0x%016X - LOCKED   - %s" % (r, v, d['desc']) )
             else:

--- a/chipsec/modules/remap.py
+++ b/chipsec/modules/remap.py
@@ -27,7 +27,6 @@ Check Memory Remapping Configuration
 """
 
 from chipsec.module_common import *
-import chipsec.chipset
 
 _MODULE_NAME = 'remap'
 
@@ -48,19 +47,19 @@ class remap(BaseModule):
     def check_remap_config(self):
         self.logger.start_test( "Memory Remapping Configuration" )
 
-        if not chipsec.chipset.is_register_defined( self.cs, 'PCI0.0.0_REMAPBASE'  ) or \
-           not chipsec.chipset.is_register_defined( self.cs, 'PCI0.0.0_REMAPLIMIT' ) or \
-           not chipsec.chipset.is_register_defined( self.cs, 'PCI0.0.0_TOUUD'      ) or \
-           not chipsec.chipset.is_register_defined( self.cs, 'PCI0.0.0_TOLUD'      ) or \
-           not chipsec.chipset.is_register_defined( self.cs, 'PCI0.0.0_TSEGMB'     ):
+        if not self.cs.is_register_defined( 'PCI0.0.0_REMAPBASE'  ) or \
+           not self.cs.is_register_defined( 'PCI0.0.0_REMAPLIMIT' ) or \
+           not self.cs.is_register_defined( 'PCI0.0.0_TOUUD'      ) or \
+           not self.cs.is_register_defined( 'PCI0.0.0_TOLUD'      ) or \
+           not self.cs.is_register_defined( 'PCI0.0.0_TSEGMB'     ):
             self.logger.error( "Couldn't find definition of required registers (REMAP*, TOLUD, TOUUD, TSEGMB)" )
             return ModuleResult.ERROR
 
-        remapbase  = chipsec.chipset.read_register( self.cs, 'PCI0.0.0_REMAPBASE' )
-        remaplimit = chipsec.chipset.read_register( self.cs, 'PCI0.0.0_REMAPLIMIT' )
-        touud      = chipsec.chipset.read_register( self.cs, 'PCI0.0.0_TOUUD' )
-        tolud      = chipsec.chipset.read_register( self.cs, 'PCI0.0.0_TOLUD' )
-        tsegmb     = chipsec.chipset.read_register( self.cs, 'PCI0.0.0_TSEGMB' )
+        remapbase  = self.cs.read_register( 'PCI0.0.0_REMAPBASE' )
+        remaplimit = self.cs.read_register( 'PCI0.0.0_REMAPLIMIT' )
+        touud      = self.cs.read_register( 'PCI0.0.0_TOUUD' )
+        tolud      = self.cs.read_register( 'PCI0.0.0_TOLUD' )
+        tsegmb     = self.cs.read_register( 'PCI0.0.0_TSEGMB' )
         self.logger.log( "[*] Registers:" )
         self.logger.log( "[*]   TOUUD     : 0x%016X" % touud )
         self.logger.log( "[*]   REMAPLIMIT: 0x%016X" % remaplimit )

--- a/chipsec/modules/smm_dma.py
+++ b/chipsec/modules/smm_dma.py
@@ -29,7 +29,6 @@ This module examines the configuration and locking of SMRAM range configuration 
 """
 
 from chipsec.module_common import *
-import chipsec.chipset
 
 _MODULE_NAME = 'smm_dma'
 
@@ -49,29 +48,29 @@ class smm_dma(BaseModule):
         else: return True
 
     def check_tseg_locks(self):
-        tseg_base_lock = chipsec.chipset.get_control(self.cs, 'TSEGBaseLock')
-        tseg_limit_lock = chipsec.chipset.get_control(self.cs, 'TSEGLimitLock')
-        
+        tseg_base_lock = self.cs.get_control('TSEGBaseLock')
+        tseg_limit_lock = self.cs.get_control('TSEGLimitLock')
+
         if tseg_base_lock and tseg_limit_lock:
             self.logger.log_good( "TSEG range is locked" )
             return ModuleResult.PASSED
         else:
             self.logger.log_bad( "TSEG range is not locked" )
             return ModuleResult.FAILED
-        
+
     def check_tseg_config(self):
         res = ModuleResult.FAILED
         (tseg_base,  tseg_limit,  tseg_size ) = self.cs.cpu.get_TSEG()
         (smram_base, smram_limit, smram_size) = self.cs.cpu.get_SMRR_SMRAM()
         self.logger.log("[*] TSEG      : 0x%016X - 0x%016X (size = 0x%08X)"   % (tseg_base,  tseg_limit,  tseg_size ))      
         self.logger.log("[*] SMRR range: 0x%016X - 0x%016X (size = 0x%08X)\n" % (smram_base, smram_limit, smram_size))
-        
+
         self.logger.log( "[*] checking TSEG range configuration.." )
         if (0 == smram_base) and (0 == smram_limit):
             res = ModuleResult.WARNING
             self.logger.log_warn_check( "TSEG is properly configured but can't determine if it covers entire SMRAM" )
-            
-        else:            
+
+        else:
             if (tseg_base <= smram_base) and (smram_limit <= tseg_limit):
             #if (tseg_base == smram_base) and (tseg_size == smram_size):
                 self.logger.log_good( "TSEG range covers entire SMRAM" )

--- a/chipsec/modules/tools/cpu/sinkhole.py
+++ b/chipsec/modules/tools/cpu/sinkhole.py
@@ -29,7 +29,7 @@ The Memory Sinkhole by Christopher Domas: https://www.blackhat.com/docs/us-15/ma
 """
 
 from chipsec.module_common import *
-import chipsec.hal.cpu
+from chipsec.hal import cpu
 import chipsec.helper.oshelper
 
 TAGS = [MTAG_SMM]
@@ -38,7 +38,7 @@ class sinkhole(BaseModule):
 
     def __init__(self):
         BaseModule.__init__(self)
-        self._cpu = chipsec.hal.cpu.CPU( self.cs )
+        self._cpu = cpu.CPU(self.cs)
 
 
     def is_supported(self):
@@ -46,9 +46,9 @@ class sinkhole(BaseModule):
         return (self.cs.helper.is_windows() or self.cs.helper.is_linux())
 
     def check_LAPIC_SMRR_overlap( self ):
-        if not chipsec.chipset.is_register_defined( self.cs, 'IA32_APIC_BASE' ) or \
-           not chipsec.chipset.is_register_defined( self.cs, 'IA32_SMRR_PHYSBASE' ) or \
-           not chipsec.chipset.is_register_defined( self.cs, 'IA32_SMRR_PHYSMASK' ):
+        if not self.cs.is_register_defined( 'IA32_APIC_BASE' ) or \
+           not self.cs.is_register_defined( 'IA32_SMRR_PHYSBASE' ) or \
+           not self.cs.is_register_defined( 'IA32_SMRR_PHYSMASK' ):
             self.logger.error( "Couldn't find definition of required configuration registers" )
             return ModuleResult.ERROR
 
@@ -58,15 +58,15 @@ class sinkhole(BaseModule):
             self.logger.log_skipped_check("CPU does not support SMRR range protection of SMRAM")
             return ModuleResult.SKIPPED
 
-        smrr_physbase_msr = chipsec.chipset.read_register( self.cs, 'IA32_SMRR_PHYSBASE', 0 )
-        apic_base_msr     = chipsec.chipset.read_register( self.cs, 'IA32_APIC_BASE', 0 )
-        chipsec.chipset.print_register( self.cs, 'IA32_APIC_BASE', apic_base_msr )
-        chipsec.chipset.print_register( self.cs, 'IA32_SMRR_PHYSBASE', smrr_physbase_msr )
+        smrr_physbase_msr = self.cs.read_register( 'IA32_SMRR_PHYSBASE', 0 )
+        apic_base_msr     = self.cs.read_register( 'IA32_APIC_BASE', 0 )
+        self.cs.print_register( 'IA32_APIC_BASE', apic_base_msr )
+        self.cs.print_register( 'IA32_SMRR_PHYSBASE', smrr_physbase_msr )
 
-        smrrbase  = chipsec.chipset.get_register_field( self.cs, 'IA32_SMRR_PHYSBASE', smrr_physbase_msr, 'PhysBase' )
-        smrr_base = chipsec.chipset.get_register_field( self.cs, 'IA32_SMRR_PHYSBASE', smrr_physbase_msr, 'PhysBase', True )
-        apicbase  = chipsec.chipset.get_register_field( self.cs, 'IA32_APIC_BASE', apic_base_msr, 'APICBase' )
-        apic_base = chipsec.chipset.get_register_field( self.cs, 'IA32_APIC_BASE', apic_base_msr, 'APICBase', True )
+        smrrbase  = self.cs.get_register_field( 'IA32_SMRR_PHYSBASE', smrr_physbase_msr, 'PhysBase' )
+        smrr_base = self.cs.get_register_field( 'IA32_SMRR_PHYSBASE', smrr_physbase_msr, 'PhysBase', True )
+        apicbase  = self.cs.get_register_field( 'IA32_APIC_BASE', apic_base_msr, 'APICBase' )
+        apic_base = self.cs.get_register_field( 'IA32_APIC_BASE', apic_base_msr, 'APICBase', True )
 
         self.logger.log( "[*] Local APIC Base: 0x%016X" % apic_base )
         self.logger.log( "[*] SMRR Base      : 0x%016X" % smrr_base )
@@ -75,22 +75,22 @@ class sinkhole(BaseModule):
         self.logger.log( "    writing 0x%X to IA32_APIC_BASE[APICBase].." % smrrbase )
         self.logger.log_important( "NOTE: The system may hang or process may crash when running this test. In that case, the mitigation to this issue is likely working but we may not be handling the exception generated.")
         try:
-            chipsec.chipset.write_register_field( self.cs, 'IA32_APIC_BASE', 'APICBase', smrrbase, preserve_field_position=False, cpu_thread=0 )
+            self.cs.write_register_field( 'IA32_APIC_BASE', 'APICBase', smrrbase, preserve_field_position=False, cpu_thread=0 )
             ex = False
             self.logger.log_bad( "Was able to modify IA32_APIC_BASE" )
         except chipsec.helper.oshelper.HWAccessViolationError:
             ex = True
             self.logger.log_good( "Could not modify IA32_APIC_BASE" )
 
-        apic_base_msr_new = chipsec.chipset.read_register( self.cs, 'IA32_APIC_BASE', 0 )
+        apic_base_msr_new = self.cs.read_register( 'IA32_APIC_BASE', 0 )
         self.logger.log( "[*] new IA32_APIC_BASE: 0x%016X" % apic_base_msr_new )
-        #chipsec.chipset.print_register( self.cs, 'IA32_APIC_BASE', apic_base_msr_new )
-        
+        #self.cs.print_register( 'IA32_APIC_BASE', apic_base_msr_new )
+
         if apic_base_msr_new == apic_base_msr and ex:
             res = ModuleResult.PASSED
             self.logger.log_passed_check( "CPU does not seem to have SMM memory sinkhole vulnerability" )
         else:
-            chipsec.chipset.write_register( self.cs, 'IA32_APIC_BASE', apic_base_msr, 0 )
+            self.cs.write_register( 'IA32_APIC_BASE', apic_base_msr, 0 )
             self.logger.log( "[*] Restored original value 0x%016X" % apic_base_msr )
             res = ModuleResult.FAILED
             self.logger.log_failed_check( "CPU is succeptible to SMM memory sinkhole vulnerability" )
@@ -104,4 +104,4 @@ class sinkhole(BaseModule):
     def run( self, module_argv ):
         self.logger.start_test( "x86 SMM Memory Sinkhole" )
         return self.check_LAPIC_SMRR_overlap()
-        
+

--- a/chipsec/modules/tools/vmm/vbox/vbox_crash_apicbase.py
+++ b/chipsec/modules/tools/vmm/vbox/vbox_crash_apicbase.py
@@ -40,11 +40,11 @@ class vbox_crash_apicbase (BaseModule):
         tid = 0
         #(eax, edx) = self.cs.msr.read_msr( tid, 0x1B )
         #self.cs.msr.write_msr( tid, 0x1B, eax, 0xDEADBEEF )
-        apicbase_msr = chipsec.chipset.read_register( self.cs, 'IA32_APIC_BASE', tid )
-        chipsec.chipset.print_register( self.cs, 'IA32_APIC_BASE', apicbase_msr )
+        apicbase_msr = self.cs.read_register( 'IA32_APIC_BASE', tid )
+        self.cs.print_register( 'IA32_APIC_BASE', apicbase_msr )
         apicbase_msr = 0xDEADBEEF00000000 | (apicbase_msr & 0xFFFFFFFF)
         self.logger.log( "[*] writing 0x%016X to IA32_APIC_BASE MSR.." % apicbase_msr )
-        chipsec.chipset.write_register( self.cs, 'IA32_APIC_BASE', apicbase_msr, tid )
+        self.cs.write_register( 'IA32_APIC_BASE', apicbase_msr, tid )
 
         # If we are here, then we are fine ;)
         self.logger.log_passed_check( "VMM/Host OS didn't crash (not vulnerable)" )

--- a/chipsec/utilcmd/cmos_cmd.py
+++ b/chipsec/utilcmd/cmos_cmd.py
@@ -53,7 +53,7 @@ class CMOSCommand(BaseCommand):
             return
 
         try:
-            _cmos = CMOS(  )
+            _cmos = CMOS(self.cs)
         except CmosRuntimeError, msg:
             print msg
             return

--- a/chipsec/utilcmd/io_cmd.py
+++ b/chipsec/utilcmd/io_cmd.py
@@ -30,7 +30,7 @@ __version__ = '1.0'
 import time
 
 import chipsec_util
-import chipsec.hal.iobar
+from chipsec.hal import iobar
 from chipsec.command import BaseCommand
 
 # Port I/O
@@ -58,8 +58,8 @@ class PortIOCommand(BaseCommand):
             return
 
         try:
-            _iobar = chipsec.hal.iobar.iobar( self.cs )
-        except chipsec.hal.iobar.IOBARRuntimeError, msg:
+            _iobar = iobar.IOBAR( self.cs )
+        except iobar.IOBARRuntimeError, msg:
             print msg
             return
 

--- a/chipsec/utilcmd/iommu_cmd.py
+++ b/chipsec/utilcmd/iommu_cmd.py
@@ -33,8 +33,7 @@ import chipsec_util
 
 from chipsec.logger     import *
 from chipsec.file       import *
-from chipsec.hal.iommu  import *
-import chipsec.hal.acpi
+from chipsec.hal import acpi, iommu
 from chipsec.command    import BaseCommand
 
 
@@ -68,37 +67,37 @@ class IOMMUCommand(BaseCommand):
             return
         op = self.argv[2]
         t = time.time()
-        
+
         try:
-            _iommu = iommu( self.cs )
+            _iommu = iommu.IOMMU(self.cs)
         except IOMMUError, msg:
             print msg
             return
-            
+
         if ( 'list' == op ):
             self.logger.log( "[CHIPSEC] Enumerating supported IOMMU engines.." )
-            self.logger.log( IOMMU_ENGINES.keys() )
+            self.logger.log( iommu.IOMMU_ENGINES.keys() )
         elif ( 'config' == op or 'status' == op or 'enable' == op or 'disable' == op ):
             if len(self.argv) > 3:
-                if self.argv[3] in IOMMU_ENGINES.keys():
+                if self.argv[3] in iommu.IOMMU_ENGINES.keys():
                     _iommu_engines = [ self.argv[3] ]
                 else:
                     self.logger.error( "IOMMU name %s not recognized. Run 'iommu list' command for supported IOMMU names" % self.argv[3] )
                     return
             else:
-                _iommu_engines = IOMMU_ENGINES.keys()
+                _iommu_engines = iommu.IOMMU_ENGINES.keys()
 
             if 'config' == op:
 
                 try:
-                    _acpi  = chipsec.hal.acpi.ACPI( self.cs )
-                except chipsec.hal.acpi.AcpiRuntimeError, msg:
+                    _acpi  = acpi.ACPI( self.cs )
+                except acpi.AcpiRuntimeError, msg:
                     print msg
-                    return      
+                    return
 
-                if _acpi.is_ACPI_table_present( chipsec.hal.acpi.ACPI_TABLE_SIG_DMAR ):
+                if _acpi.is_ACPI_table_present(acpi.ACPI_TABLE_SIG_DMAR):
                     self.logger.log( "[CHIPSEC] Dumping contents of DMAR ACPI table..\n" )
-                    _acpi.dump_ACPI_table( chipsec.hal.acpi.ACPI_TABLE_SIG_DMAR )
+                    _acpi.dump_ACPI_table(acpi.ACPI_TABLE_SIG_DMAR)
                 else:
                     self.logger.log( "[CHIPSEC] Couldn't find DMAR ACPI table\n" )
 
@@ -111,7 +110,7 @@ class IOMMUCommand(BaseCommand):
         else:
             print IOMMUCommand.__doc__
             return
-        
+
         self.logger.log( "[CHIPSEC] (iommu) time elapsed %.3f" % (time.time()-t) )
 
 

--- a/chipsec/utilcmd/mmcfg_cmd.py
+++ b/chipsec/utilcmd/mmcfg_cmd.py
@@ -31,7 +31,7 @@ __version__ = '1.0'
 import time
 
 from chipsec.command    import BaseCommand
-from chipsec.hal.mmio   import *
+from chipsec.hal import mmio
 
 
 # Access to Memory Mapped PCIe Configuration Space (MMCFG)
@@ -52,10 +52,11 @@ class MMCfgCommand(BaseCommand):
 
     def run(self):
         t = time.time()
+        _mmio = mmio.MMIO(self.cs)
 
         if 2 == len(self.argv):
-            #pciexbar = get_PCIEXBAR_base_address( self.cs )
-            pciexbar = get_MMCFG_base_address( self.cs )
+            #pciexbar = _mmio.get_PCIEXBAR_base_address()
+            pciexbar = _mmio.get_MMCFG_base_address()
             self.logger.log( "[CHIPSEC] Memory Mapped Config Base: 0x%016X" % pciexbar )
             return
         elif 6 > len(self.argv):
@@ -86,11 +87,11 @@ class MMCfgCommand(BaseCommand):
 
         if 8 == len(self.argv):
             value = int(self.argv[7], 16)
-            write_mmcfg_reg( self.cs, bus, device, function, offset, width, value )
+            _mmio.write_mmcfg_reg(bus, device, function, offset, width, value )
             #_cs.pci.write_mmcfg_reg( bus, device, function, offset, width, value )
             self.logger.log( "[CHIPSEC] writing MMCFG register (%02d:%02d.%d + 0x%02X): 0x%X" % (bus, device, function, offset, value) )
         else:
-            value = read_mmcfg_reg( self.cs, bus, device, function, offset, width )
+            value = _mmio.read_mmcfg_reg(bus, device, function, offset, width )
             #value = _cs.pci.read_mmcfg_reg( bus, device, function, offset, width )
             self.logger.log( "[CHIPSEC] reading MMCFG register (%02d:%02d.%d + 0x%02X): 0x%X" % (bus, device, function, offset, value) )
 

--- a/chipsec/utilcmd/mmio_cmd.py
+++ b/chipsec/utilcmd/mmio_cmd.py
@@ -31,7 +31,7 @@ import chipsec_util
 from chipsec.logger     import *
 from chipsec.file       import *
 
-from chipsec.hal.mmio   import *
+from chipsec.hal import mmio
 from chipsec.command    import BaseCommand
 
 
@@ -63,6 +63,7 @@ class MMIOCommand(BaseCommand):
 
     def run(self):
         t = time.time()
+        _mmio = mmio.MMIO(self.cs)
 
         if len(self.argv) < 3:
             print MMIOCommand.__doc__
@@ -72,16 +73,16 @@ class MMIOCommand(BaseCommand):
         t = time.time()
 
         if ( 'list' == op ):
-            list_MMIO_BARs( self.cs )
+            _mmio.list_MMIO_BARs()
         elif ( 'dump' == op ):
             bar = self.argv[3].upper()
             self.logger.log( "[CHIPSEC] Dumping %s MMIO space.." % bar )
-            dump_MMIO_BAR( self.cs, bar )
+            _mmio.dump_MMIO_BAR(bar)
         elif ( 'read' == op ):
             bar   = self.argv[3].upper()
             off   = int(self.argv[4],16)
             width = int(self.argv[5],16) if len(self.argv) == 6 else 4
-            reg = read_MMIO_BAR_reg( self.cs, bar, off, width )
+            reg = _mmio.read_MMIO_BAR_reg(bar, off, width)
             self.logger.log( "[CHIPSEC] Read %s + 0x%X: 0x%08X" % (bar,off,reg) )
         elif ( 'write' == op ):
             bar   = self.argv[3].upper()
@@ -90,7 +91,7 @@ class MMIOCommand(BaseCommand):
             if len(self.argv) == 7:
                 reg = int(self.argv[6],16)
                 self.logger.log( "[CHIPSEC] Write %s + 0x%X: 0x%08X" % (bar,off,reg) )
-                write_MMIO_BAR_reg( self.cs, bar, off, reg, width )
+                _mmio.write_MMIO_BAR_reg(bar, off, reg, width)
             else:
                 print MMIOCommand.__doc__
                 return

--- a/chipsec/utilcmd/spd_cmd.py
+++ b/chipsec/utilcmd/spd_cmd.py
@@ -26,9 +26,7 @@ __version__ = '1.0'
 import time
 
 from chipsec.command     import BaseCommand
-from chipsec.hal.smbus   import *
-from chipsec.hal.spd     import *
-
+from chipsec.hal import smbus, spd
 
 class SPDCommand(BaseCommand):
     """
@@ -57,8 +55,8 @@ class SPDCommand(BaseCommand):
             return
 
         try:
-            _smbus = SMBus( self.cs )
-            _spd   = SPD( _smbus )
+            _smbus = smbus.SMBus( self.cs )
+            _spd   = spd.SPD( _smbus )
         except BaseException, msg:
             print msg
             return
@@ -71,7 +69,7 @@ class SPDCommand(BaseCommand):
             return
         #smbus.display_SMBus_info()
 
-        dev_addr = SPD_SMBUS_ADDRESS
+        dev_addr = spd.SPD_SMBUS_ADDRESS
 
         if( 'detect' == op ):
 
@@ -82,7 +80,7 @@ class SPDCommand(BaseCommand):
 
             if len(self.argv) > 3:
                 dev = self.argv[3].upper()
-                dev_addr = chipsec.hal.spd.SPD_DIMM_ADDRESSES[ dev ] if dev in chipsec.hal.spd.SPD_DIMM_ADDRESSES else int(self.argv[3],16)
+                dev_addr = spd.SPD_DIMM_ADDRESSES[ dev ] if dev in spd.SPD_DIMM_ADDRESSES else int(self.argv[3],16)
                 if not _spd.isSPDPresent( dev_addr ):
                     self.logger.log( "[CHIPSEC] SPD for DIMM 0x%X is not found" % dev_addr )
                     return
@@ -95,7 +93,7 @@ class SPDCommand(BaseCommand):
 
             if len(self.argv) > 3:
                 dev = self.argv[3].upper()
-                dev_addr = chipsec.hal.spd.SPD_DIMM_ADDRESSES[ dev ] if dev in chipsec.hal.spd.SPD_DIMM_ADDRESSES else int(self.argv[3],16)
+                dev_addr = spd.SPD_DIMM_ADDRESSES[ dev ] if dev in spd.SPD_DIMM_ADDRESSES else int(self.argv[3],16)
             if not _spd.isSPDPresent( dev_addr ):
                 self.logger.log( "[CHIPSEC] SPD for DIMM 0x%X is not found" % dev_addr )
                 return


### PR DESCRIPTION
Clean up the dependencies between HAL modules and chipset.py. The previous imports were hiding circular dependencies because most of the HAL modules were relying on the global `chipset` object. By using a parent class, all the reference to `chipsec.chipset` are removed in favour of `self.cs`.

Fix util commands and modules accordingly.

A large chunk of module methods from chipset.py and mmio.py are moved to object methods (i.e., fix the indentation). It might be useful to review this PR by ignoring the space changes (i.e., `git diff -w HEAD^` or  adding `?w=1` to the github pull request URL)