### PR TITLE
Add unittest.main() to each tests

### DIFF
--- a/tests/software/test_cmos.py
+++ b/tests/software/test_cmos.py
@@ -1,4 +1,7 @@
+import unittest
+
 from tests.software import mock_helper, util
+
 
 class TestCMOSChipsecUtil(util.TestChipsecUtil):
     """Test the CMOS commands exposed by chipsec_utils."""
@@ -21,3 +24,5 @@ class TestCMOSChipsecUtil(util.TestChipsecUtil):
 
         self._chipsec_util("cmos dump", CMOSHelper)
 
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/software/test_desc.py
+++ b/tests/software/test_desc.py
@@ -1,4 +1,7 @@
+import unittest
+
 from tests.software import mock_helper, util
+
 
 class TestDescChipsecUtil(util.TestChipsecUtil):
     """Test the Desc commands (gdt, idt, ldt) exposed by chipsec_utils."""
@@ -15,3 +18,6 @@ class TestDescChipsecUtil(util.TestChipsecUtil):
 
         self._chipsec_util("gdt 0", GDTHelper)
         self.assertIn("# of entries    : 4", self.log)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/software/test_msr.py
+++ b/tests/software/test_msr.py
@@ -1,4 +1,7 @@
+import unittest
+
 from tests.software import mock_helper, util
+
 
 class TestMSRChipsecUtil(util.TestChipsecUtil):
     """Test the MSR commands exposed by chipsec_utils."""
@@ -20,3 +23,5 @@ class TestMSRChipsecUtil(util.TestChipsecUtil):
         self._assertLogValue("EAX", "00001234")
         self._assertLogValue("EDX", "0000CDEF")
 
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/software/test_platform.py
+++ b/tests/software/test_platform.py
@@ -1,7 +1,14 @@
-from tests.software import mock_helper, util
+import unittest
+
+from tests.software import util
+
 
 class TestPlatformChipsecUtil(util.TestChipsecUtil):
     """Test the platform commands exposed by chipsec_utils."""
 
     def test_platform(self):
         self._chipsec_util("platform")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/software/test_spi.py
+++ b/tests/software/test_spi.py
@@ -1,7 +1,9 @@
 import os
 import tempfile
+import unittest
 
 from tests.software import mock_helper, util
+
 
 class TestSPIChipsecUtil(util.TestChipsecUtil):
     """Test the SPI commands exposed by chipsec_utils."""
@@ -30,3 +32,6 @@ class TestSPIChipsecUtil(util.TestChipsecUtil):
         self.assertEqual(os.stat(rom_file).st_size, 0x3000)
         os.remove(rom_file)
 
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/software/util.py
+++ b/tests/software/util.py
@@ -1,5 +1,4 @@
 import os
-import struct
 import tempfile
 import unittest
 
@@ -9,6 +8,7 @@ import chipsec_util
 from chipsec import logger
 from chipsec import chipset
 from chipsec.helper import oshelper
+
 
 class TestChipsecUtil(unittest.TestCase):
     """Test the commands exposed by chipsec_utils.
@@ -61,6 +61,5 @@ class TestChipsecUtil(unittest.TestCase):
         Assert that at least one line exists within the log which matches the
         expression: name [:=] value.
         """
-        self.assertRegexpMatches(self.log,
-                                 r'(^|\W){}\s*[:=]\s*{}($|\W)'.format(name, value))
-
+        exp = r'(^|\W){}\s*[:=]\s*{}($|\W)'
+        self.assertRegexpMatches(self.log, exp.format(name, value))


### PR DESCRIPTION
Add `unittest.main()` call within each tests so each file may be executed directly. Also, fix style issues reported by flake8 (i.e., wrong spaces and over 80 characters lines)