### PR TITLE
Add native_write_pci_reg to Linux helper

### DIFF
--- a/chipsec/defines.py
+++ b/chipsec/defines.py
@@ -158,6 +158,14 @@ SIZE2FORMAT = {
     8: 'Q'
 }
 
+def pack1(value, size):
+    """Shortcut to pack a single value into a string based on its size."""
+    return struct.pack(SIZE2FORMAT[size], value)
+
+def unpack1(string, size):
+    """Shortcut to unpack a single value from a string based on its size."""
+    return struct.unpack(SIZE2FORMAT[size], string)[0]
+
 class ToolType:
-  TIANO_COMPRESS = 1
-  LZMA_COMPRESS  = 2
+    TIANO_COMPRESS = 1
+    LZMA_COMPRESS  = 2


### PR DESCRIPTION
Also includes two aliases `pack1` and `unpack1` to easily convert values
in the helpers.