### PR TITLE
add DKMS support

### DIFF
--- a/chipsec/defines.py
+++ b/chipsec/defines.py
@@ -33,6 +33,9 @@
 __version__ = '1.0'
 
 import struct
+import os
+
+import chipsec.file
 
 BIT0 = 0x0001
 BIT1 = 0x0002
@@ -169,3 +172,12 @@ def unpack1(string, size):
 class ToolType:
     TIANO_COMPRESS = 1
     LZMA_COMPRESS  = 2
+
+def get_version():
+    chipsec_folder = os.path.abspath(chipsec.file.get_main_dir())
+    version_file = os.path.join( chipsec_folder , "chipsec", "VERSION" )
+    if os.path.exists( version_file ):
+        with open(version_file, "r") as verFile:
+            version = verFile.read()
+            return version
+ 

--- a/chipsec/helper/linux/helper.py
+++ b/chipsec/helper/linux/helper.py
@@ -107,12 +107,6 @@ class LinuxHelper(Helper):
 ###############################################################################################
 # Driver/service management functions
 ###############################################################################################
-    def get_currect_kernel_version(self):
-        return subprocess.check_output("uname -r", shell=True)
-
-    def get_architecture(self):
-        return subprocess.check_output("uname -m", shell=True)
-
     def get_version(self):
         chipsec_folder = os.path.abspath(chipsec.file.get_main_dir())
         version_file = os.path.join( chipsec_folder , "chipsec", "VERSION" )
@@ -122,10 +116,8 @@ class LinuxHelper(Helper):
                 return version
    
     def get_dkms_module_location(self):
-        kernel_dir  = self.get_currect_kernel_version().strip()
-        arch_dir    = self.get_architecture().strip()
         version     = self.get_version()
-        return os.path.join( self.DKMS_DIR, self.MODULE_NAME, version , kernel_dir, arch_dir, "module", "chipsec.ko" )
+        return os.path.join( self.DKMS_DIR, self.MODULE_NAME, version , self.os_release, self.os_machine, "module", "chipsec.ko" )
 
 
     # This function load CHIPSEC driver

--- a/chipsec/helper/linux/helper.py
+++ b/chipsec/helper/linux/helper.py
@@ -129,7 +129,7 @@ class LinuxHelper(Helper):
             #check DKMS modules location
             driver_path = self.get_dkms_module_location()
             if not os.path.exists(driver_path):
-                logger().error("Cannot find chipsec.ko module")
+                raise Exception("Cannot find chipsec.ko module")
         subprocess.check_output( [ "insmod", driver_path, a1 ] )
         uid = gid = 0
         os.chown(self.DEVICE_NAME, uid, gid)

--- a/chipsec/helper/linux/helper.py
+++ b/chipsec/helper/linux/helper.py
@@ -107,16 +107,9 @@ class LinuxHelper(Helper):
 ###############################################################################################
 # Driver/service management functions
 ###############################################################################################
-    def get_version(self):
-        chipsec_folder = os.path.abspath(chipsec.file.get_main_dir())
-        version_file = os.path.join( chipsec_folder , "chipsec", "VERSION" )
-        if os.path.exists( version_file ):
-            with open(version_file, "r") as verFile:
-                version = verFile.read()
-                return version
    
     def get_dkms_module_location(self):
-        version     = self.get_version()
+        version     = defines.get_version()
         return os.path.join( self.DKMS_DIR, self.MODULE_NAME, version , self.os_release, self.os_machine, "module", "chipsec.ko" )
 
 

--- a/drivers/linux/dkms.conf
+++ b/drivers/linux/dkms.conf
@@ -1,0 +1,9 @@
+MAKE="make -C . KERNELDIR=/lib/modules/${kernelver}/build"
+CLEAN="make clean -C ."
+BUILT_MODULE_NAME=chipsec
+BUILT_MODULE_LOCATION=.
+PACKAGE_NAME=chipsec
+DEST_MODULE_LOCATION="/extra"
+PACKAGE_VERSION=1.2.5
+REMAKE_INITRD=no
+AUTOINSTALL=no


### PR DESCRIPTION
added support DKMS:
- added dkms.conf file with configuration for DKMS (without module installation) 
- updated linux helper. First it checks default location of the driver: chipsec/helper/linux/chipsec.ko if driver is not there helper tries to find it in DKMS modules storage. if driver there helper uses it from that location, if not then helper didn't find driver and informs about it by logger().error. 