### PR TITLE
Do not catch exception in chipset initialization

### DIFF
--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -174,9 +174,6 @@ class ChipsecUtil:
                 logger().warn("* Platform dependent functionality will likely be incorrect")
                 logger().warn("* Error Message: \"%s\"" % str(msg))
                 logger().warn("*******************************************************************")
-            except (None,Exception) , msg:
-                logger().error(str(msg))
-                sys.exit(-1)
 
             logger().log( "[CHIPSEC] Executing command '%s' with args %s\n" % (cmd,argv[2:]) )
             comm.run()


### PR DESCRIPTION
If an exception is raised when initializing the chipset in chipsec_utils.py, only a succinct error message is displayed. This makes it hard for debugging when trouble shooting where the exception is coming from. If this is not a ChipsetUnknownError, let the exception bubble up.