### PR TITLE
Call parent Helper __init__ for OSX helper

### DIFF
--- a/chipsec/helper/osx/helper.py
+++ b/chipsec/helper/osx/helper.py
@@ -44,6 +44,7 @@ class OSXHelper(Helper):
     DRIVER_NAME = "chipsec.kext"
 
     def __init__(self):
+        super(OSXHelper, self).__init__()
         self.os_system  = platform.system()
         self.os_release = platform.release()
         self.os_version = platform.version()


### PR DESCRIPTION
Partial fix for #143.