### PR TITLE
SPI flash descriptor parsing improved

### DIFF
--- a/chipsec/cfg/common.xml
+++ b/chipsec/cfg/common.xml
@@ -414,53 +414,6 @@
       <field name="MRWA"    bit="24" size="8" desc="Master Region Write Access"/>
     </register>
 
-    <!--
-    <register name="FLMAP0" type="mmio" bar="FDBAR" offset="0x14" size="4" desc="Flash Map 0 Register">
-      <field name="FCBA"    bit="0"  size="8" desc="Flash Component Base Address"/>
-      <field name="NC"      bit="8"  size="2" desc="Number of Components"/>
-      <field name="FRBA"    bit="16" size="8" desc="Flash Region Base Address"/>
-    </register>
-    <register name="FLMAP1" type="mmio" bar="FDBAR" offset="0x18" size="4" desc="Flash Map 1 Register">
-      <field name="FMBA"    bit="0"  size="8" desc="Flash Master Base Address"/>
-      <field name="NM"      bit="8"  size="3" desc="Number of Masters"/>
-      <field name="FPSBA"   bit="16" size="8" desc="Flash PCH Strap Base Address"/>
-      <field name="PSL"     bit="24" size="8" desc="PCH Strap Length"/>
-    </register>
-    <register name="FLMAP2" type="mmio" bar="FDBAR" offset="0x1C" size="4" desc="Flash Map 2 Register">
-      <field name="FCPUSBA" bit="0"  size="8" desc="Flash CPU Strap Base Address"/>
-      <field name="CPUSL"   bit="8"  size="8" desc="CPU Strap Length"/>
-      <field name="RIL"     bit="24" size="8" desc="Register Init Length"/>
-    </register>
-    <register name="FLREG0" type="mmio" bar="FRBA" offset="0x0" size="4" desc="Flash Region 0 (Flash Descriptor) Register">
-      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
-      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
-    </register>
-    <register name="FLREG1" type="mmio" bar="FRBA" offset="0x4" size="4" desc="Flash Region 1 (BIOS) Register">
-      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
-      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
-    </register>
-    <register name="FLREG2" type="mmio" bar="FRBA" offset="0x8" size="4" desc="Flash Region 2 (Intel ME) Register">
-      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
-      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
-    </register>
-    <register name="FLREG3" type="mmio" bar="FRBA" offset="0xC" size="4" desc="Flash Region 3 (GBe) Register">
-      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
-      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
-    </register>
-    <register name="FLREG4" type="mmio" bar="FRBA" offset="0x10" size="4" desc="Flash Region 4 (Platform Data) Register">
-      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
-      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
-    </register>
-    <register name="FLREG8" type="mmio" bar="FRBA" offset="0x20" size="4" desc="Flash Region 8 (Embedded Controller) Register">
-      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
-      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
-    </register>
-    <register name="FLMSTR1" type="mmio" bar="FMBA" offset="0x0" size="4" desc="Flash Master 1">
-      <field name="MRRA"    bit="8"  size="12" desc="Master Region Read Access"/>
-      <field name="MRWA"    bit="20" size="12" desc="Master Region Write Access"/>
-    </register>
-    -->
-
     <!-- PCH Root Complex Register Base -->
     <register name="RC" type="mmio" bar="RCBA" offset="0x3400" size="4" desc="RTC Configuration">
       <field name="UE"  bit="2" size="1" desc="Upper 128 Byte Enable"/>

--- a/chipsec/cfg/common.xml
+++ b/chipsec/cfg/common.xml
@@ -371,6 +371,96 @@
       <field name="UEO"   bit="8"  size="8" desc="Upper Erase Opcode"/>
     </register>
 
+    <!-- SPI Flash Descriptor registers -->
+    <register name="FLMAP0" type="mmio" bar="FDBAR" offset="0x14" size="4" desc="Flash Map 0 Register">
+      <field name="FCBA"    bit="0"  size="8" desc="Flash Component Base Address"/>
+      <field name="NC"      bit="8"  size="2" desc="Number of Components"/>
+      <field name="FRBA"    bit="16" size="8" desc="Flash Region Base Address"/>
+      <field name="NR"      bit="24" size="3" desc="Number of Regions"/>
+    </register>
+    <register name="FLMAP1" type="mmio" bar="FDBAR" offset="0x18" size="4" desc="Flash Map 1 Register">
+      <field name="FMBA"    bit="0"  size="8" desc="Flash Master Base Address"/>
+      <field name="NM"      bit="8"  size="2" desc="Number of Masters"/>
+      <field name="FPSBA"   bit="16" size="8" desc="Flash PCH Strap Base Address"/>
+      <field name="PSL"     bit="24" size="8" desc="PCH Strap Length"/>
+    </register>
+    <register name="FLMAP2" type="mmio" bar="FDBAR" offset="0x1C" size="4" desc="Flash Map 2 Register">
+      <field name="FCPUSBA" bit="0"  size="8" desc="Flash CPU Strap Base Address"/>
+      <field name="CPUSL"   bit="8"  size="8" desc="Processor Strap Length"/>
+      <field name="ICCRIBA" bit="16" size="8" desc="ICC Register Init Base Address"/>
+    </register>
+    <register name="FLREG0" type="mmio" bar="FRBA" offset="0x0" size="4" desc="Flash Region 0 (Flash Descriptor) Register">
+      <field name="RB"      bit="0"  size="13" desc="Region Base"/>
+      <field name="RL"      bit="16" size="13" desc="Region Limit"/>
+    </register>
+    <register name="FLREG1" type="mmio" bar="FRBA" offset="0x4" size="4" desc="Flash Region 1 (BIOS) Register">
+      <field name="RB"      bit="0"  size="13" desc="Region Base"/>
+      <field name="RL"      bit="16" size="13" desc="Region Limit"/>
+    </register>
+    <register name="FLREG2" type="mmio" bar="FRBA" offset="0x8" size="4" desc="Flash Region 2 (Intel ME) Register">
+      <field name="RB"      bit="0"  size="13" desc="Region Base"/>
+      <field name="RL"      bit="16" size="13" desc="Region Limit"/>
+    </register>
+    <register name="FLREG3" type="mmio" bar="FRBA" offset="0xC" size="4" desc="Flash Region 3 (GBe) Register">
+      <field name="RB"      bit="0"  size="13" desc="Region Base"/>
+      <field name="RL"      bit="16" size="13" desc="Region Limit"/>
+    </register>
+    <register name="FLREG4" type="mmio" bar="FRBA" offset="0x10" size="4" desc="Flash Region 4 (Platform Data) Register">
+      <field name="RB"      bit="0"  size="13" desc="Region Base"/>
+      <field name="RL"      bit="16" size="13" desc="Region Limit"/>
+    </register>
+    <register name="FLMSTR1" type="mmio" bar="FMBA" offset="0x0" size="4" desc="Flash Master 1">
+      <field name="MRRA"    bit="16" size="8" desc="Master Region Read Access"/>
+      <field name="MRWA"    bit="24" size="8" desc="Master Region Write Access"/>
+    </register>
+
+    <!--
+    <register name="FLMAP0" type="mmio" bar="FDBAR" offset="0x14" size="4" desc="Flash Map 0 Register">
+      <field name="FCBA"    bit="0"  size="8" desc="Flash Component Base Address"/>
+      <field name="NC"      bit="8"  size="2" desc="Number of Components"/>
+      <field name="FRBA"    bit="16" size="8" desc="Flash Region Base Address"/>
+    </register>
+    <register name="FLMAP1" type="mmio" bar="FDBAR" offset="0x18" size="4" desc="Flash Map 1 Register">
+      <field name="FMBA"    bit="0"  size="8" desc="Flash Master Base Address"/>
+      <field name="NM"      bit="8"  size="3" desc="Number of Masters"/>
+      <field name="FPSBA"   bit="16" size="8" desc="Flash PCH Strap Base Address"/>
+      <field name="PSL"     bit="24" size="8" desc="PCH Strap Length"/>
+    </register>
+    <register name="FLMAP2" type="mmio" bar="FDBAR" offset="0x1C" size="4" desc="Flash Map 2 Register">
+      <field name="FCPUSBA" bit="0"  size="8" desc="Flash CPU Strap Base Address"/>
+      <field name="CPUSL"   bit="8"  size="8" desc="CPU Strap Length"/>
+      <field name="RIL"     bit="24" size="8" desc="Register Init Length"/>
+    </register>
+    <register name="FLREG0" type="mmio" bar="FRBA" offset="0x0" size="4" desc="Flash Region 0 (Flash Descriptor) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG1" type="mmio" bar="FRBA" offset="0x4" size="4" desc="Flash Region 1 (BIOS) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG2" type="mmio" bar="FRBA" offset="0x8" size="4" desc="Flash Region 2 (Intel ME) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG3" type="mmio" bar="FRBA" offset="0xC" size="4" desc="Flash Region 3 (GBe) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG4" type="mmio" bar="FRBA" offset="0x10" size="4" desc="Flash Region 4 (Platform Data) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG8" type="mmio" bar="FRBA" offset="0x20" size="4" desc="Flash Region 8 (Embedded Controller) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLMSTR1" type="mmio" bar="FMBA" offset="0x0" size="4" desc="Flash Master 1">
+      <field name="MRRA"    bit="8"  size="12" desc="Master Region Read Access"/>
+      <field name="MRWA"    bit="20" size="12" desc="Master Region Write Access"/>
+    </register>
+    -->
+
     <!-- PCH Root Complex Register Base -->
     <register name="RC" type="mmio" bar="RCBA" offset="0x3400" size="4" desc="RTC Configuration">
       <field name="UE"  bit="2" size="1" desc="Upper 128 Byte Enable"/>

--- a/chipsec/cfg/kbl.xml
+++ b/chipsec/cfg/kbl.xml
@@ -176,6 +176,51 @@
     <!-- PMC MMIO registers (7th Generation Intel(R) Processor Families I/O for U/Y-Platforms, Vol. 2, section 4.3) -->
     <register name="PM_CFG" type="mmio" bar="PWRMBASE" offset="0x18" size="4" desc="Power Management Configuration Reg 1"/>
 
+    <!-- SPI Flash Descriptor registers -->
+    <register name="FLMAP0" type="mmio" bar="FDBAR" offset="0x14" size="4" desc="Flash Map 0 Register">
+      <field name="FCBA"    bit="0"  size="8" desc="Flash Component Base Address"/>
+      <field name="NC"      bit="8"  size="2" desc="Number of Components"/>
+      <field name="FRBA"    bit="16" size="8" desc="Flash Region Base Address"/>
+    </register>
+    <register name="FLMAP1" type="mmio" bar="FDBAR" offset="0x18" size="4" desc="Flash Map 1 Register">
+      <field name="FMBA"    bit="0"  size="8" desc="Flash Master Base Address"/>
+      <field name="NM"      bit="8"  size="3" desc="Number of Masters"/>
+      <field name="FPSBA"   bit="16" size="8" desc="Flash PCH Strap Base Address"/>
+      <field name="PSL"     bit="24" size="8" desc="PCH Strap Length"/>
+    </register>
+    <register name="FLMAP2" type="mmio" bar="FDBAR" offset="0x1C" size="4" desc="Flash Map 2 Register">
+      <field name="FCPUSBA" bit="0"  size="8" desc="Flash CPU Strap Base Address"/>
+      <field name="CPUSL"   bit="8"  size="8" desc="CPU Strap Length"/>
+    </register>
+    <register name="FLREG0" type="mmio" bar="FRBA" offset="0x0" size="4" desc="Flash Region 0 (Flash Descriptor) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG1" type="mmio" bar="FRBA" offset="0x4" size="4" desc="Flash Region 1 (BIOS) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG2" type="mmio" bar="FRBA" offset="0x8" size="4" desc="Flash Region 2 (Intel ME) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG3" type="mmio" bar="FRBA" offset="0xC" size="4" desc="Flash Region 3 (GBe) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG4" type="mmio" bar="FRBA" offset="0x10" size="4" desc="Flash Region 4 (Platform Data) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG8" type="mmio" bar="FRBA" offset="0x20" size="4" desc="Flash Region 8 (Embedded Controller) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLMSTR1" type="mmio" bar="FMBA" offset="0x0" size="4" desc="Flash Master 1">
+      <field name="MRRA"    bit="8"  size="12" desc="Master Region Read Access"/>
+      <field name="MRWA"    bit="20" size="12" desc="Master Region Write Access"/>
+    </register>
+
     <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
     <!-- I/O registers (I/O ports)    -->
     <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->

--- a/chipsec/cfg/skl.xml
+++ b/chipsec/cfg/skl.xml
@@ -181,6 +181,50 @@
     <!-- PMC MMIO registers (6th Generation Intel(R) Processor I/O Datasheet for U/Y-Platforms, Vol. 2, section 4.3) -->
     <register name="PM_CFG" type="mmio" bar="PWRMBASE" offset="0x18" size="4" desc="Power Management Configuration Reg 1"/>
     
+    <!-- SPI Flash Descriptor registers -->
+    <register name="FLMAP0" type="mmio" bar="FDBAR" offset="0x14" size="4" desc="Flash Map 0 Register">
+      <field name="FCBA"    bit="0"  size="8" desc="Flash Component Base Address"/>
+      <field name="NC"      bit="8"  size="2" desc="Number of Components"/>
+      <field name="FRBA"    bit="16" size="8" desc="Flash Region Base Address"/>
+    </register>
+    <register name="FLMAP1" type="mmio" bar="FDBAR" offset="0x18" size="4" desc="Flash Map 1 Register">
+      <field name="FMBA"    bit="0"  size="8" desc="Flash Master Base Address"/>
+      <field name="NM"      bit="8"  size="3" desc="Number of Masters"/>
+      <field name="FPSBA"   bit="16" size="8" desc="Flash PCH Strap Base Address"/>
+      <field name="PSL"     bit="24" size="8" desc="PCH Strap Length"/>
+    </register>
+    <register name="FLMAP2" type="mmio" bar="FDBAR" offset="0x1C" size="4" desc="Flash Map 2 Register">
+      <field name="FCPUSBA" bit="0"  size="8" desc="Flash CPU Strap Base Address"/>
+      <field name="CPUSL"   bit="8"  size="8" desc="CPU Strap Length"/>
+    </register>
+    <register name="FLREG0" type="mmio" bar="FRBA" offset="0x0" size="4" desc="Flash Region 0 (Flash Descriptor) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG1" type="mmio" bar="FRBA" offset="0x4" size="4" desc="Flash Region 1 (BIOS) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG2" type="mmio" bar="FRBA" offset="0x8" size="4" desc="Flash Region 2 (Intel ME) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG3" type="mmio" bar="FRBA" offset="0xC" size="4" desc="Flash Region 3 (GBe) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG4" type="mmio" bar="FRBA" offset="0x10" size="4" desc="Flash Region 4 (Platform Data) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG8" type="mmio" bar="FRBA" offset="0x20" size="4" desc="Flash Region 8 (Embedded Controller) Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLMSTR1" type="mmio" bar="FMBA" offset="0x0" size="4" desc="Flash Master 1">
+      <field name="MRRA"    bit="8"  size="12" desc="Master Region Read Access"/>
+      <field name="MRWA"    bit="20" size="12" desc="Master Region Write Access"/>
+    </register>
 
     <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
     <!-- I/O registers (I/O ports)    -->

--- a/chipsec/hal/spi.py
+++ b/chipsec/hal/spi.py
@@ -94,51 +94,59 @@ SPI_HSFSTS_FDOPSS_MASK  = (1 << 13)
 # Flash Regions
 #
 
-SPI_REGION_NUMBER       = 7
-SPI_REGION_NUMBER_IN_FD = 5
+SPI_REGION_NUMBER       = 9
+SPI_REGION_NUMBER_IN_FD = 9
 
-FLASH_DESCRIPTOR  = 0
-BIOS              = 1
-ME                = 2
-GBE               = 3
-PLATFORM_DATA     = 4
-FREG5             = 5
-FREG6             = 6
+FLASH_DESCRIPTOR    = 0
+BIOS                = 1
+ME                  = 2
+GBE                 = 3
+PLATFORM_DATA       = 4
+FREG5               = 5
+FREG6               = 6
+FREG7               = 7
+EMBEDDED_CONTROLLER = 8
 
 SPI_REGION = {
- FLASH_DESCRIPTOR  : 'FREG0_FLASHD',
- BIOS              : 'FREG1_BIOS',
- ME                : 'FREG2_ME',
- GBE               : 'FREG3_GBE',
- PLATFORM_DATA     : 'FREG4_PD',
- FREG5             : 'FREG5',
- FREG6             : 'FREG6'
+ FLASH_DESCRIPTOR   : 'FREG0_FLASHD',
+ BIOS               : 'FREG1_BIOS',
+ ME                 : 'FREG2_ME',
+ GBE                : 'FREG3_GBE',
+ PLATFORM_DATA      : 'FREG4_PD',
+ FREG5              : 'FREG5_RSVD',
+ FREG6              : 'FREG6_RSVD',
+ FREG7              : 'FREG7_RSVD',
+ EMBEDDED_CONTROLLER: 'FREG8_EC'
 }
 
 SPI_REGION_NAMES = {
- FLASH_DESCRIPTOR  : 'Flash Descriptor',
- BIOS              : 'BIOS',
- ME                : 'Intel ME',
- GBE               : 'GBe',
- PLATFORM_DATA     : 'Platform Data',
- FREG5             : 'Flash Region 5',
- FREG6             : 'Flash Region 6'
+ FLASH_DESCRIPTOR   : 'Flash Descriptor',
+ BIOS               : 'BIOS',
+ ME                 : 'Intel ME',
+ GBE                : 'GBe',
+ PLATFORM_DATA      : 'Platform Data',
+ FREG5              : 'Flash Region 5',
+ FREG6              : 'Flash Region 6',
+ FREG7              : 'Flash Region 7',
+ EMBEDDED_CONTROLLER: 'Embedded Controller'
 }
 
 #
 # Flash Descriptor Master Defines
 #
 
-SPI_MASTER_NUMBER_IN_FD = 3
+SPI_MASTER_NUMBER_IN_FD = 4
 
 MASTER_HOST_CPU_BIOS    = 0
 MASTER_ME               = 1
 MASTER_GBE              = 2
+MASTER_EC               = 3
 
 SPI_MASTER_NAMES = {
- MASTER_HOST_CPU_BIOS : 'CPU/BIOS',
+ MASTER_HOST_CPU_BIOS : 'CPU',
  MASTER_ME            : 'ME',
- MASTER_GBE           : 'GBe'
+ MASTER_GBE           : 'GBe',
+ MASTER_EC            : 'EC'
 }
 
 

--- a/chipsec/hal/spi.py
+++ b/chipsec/hal/spi.py
@@ -113,10 +113,8 @@ SPI_REGION = {
  ME                 : 'FREG2_ME',
  GBE                : 'FREG3_GBE',
  PLATFORM_DATA      : 'FREG4_PD',
- FREG5              : 'FREG5_RSVD',
- FREG6              : 'FREG6_RSVD',
- FREG7              : 'FREG7_RSVD',
- EMBEDDED_CONTROLLER: 'FREG8_EC'
+ FREG5              : 'FREG5',
+ FREG6              : 'FREG6'
 }
 
 SPI_REGION_NAMES = {

--- a/chipsec/utilcmd/decode_cmd.py
+++ b/chipsec/utilcmd/decode_cmd.py
@@ -89,7 +89,7 @@ class DecodeCommand(BaseCommand):
         rom = f[fd_off:]
         # Decoding Flash Descriptor
         #self.logger.LOG_COMPLETE_FILE_NAME = os.path.join( pth, 'flash_descriptor.log' )
-        #parse_spi_flash_descriptor( fd )
+        #parse_spi_flash_descriptor( self.cs, fd )
 
         # Decoding SPI Flash Regions
         # flregs[r] = (r,SPI_REGION_NAMES[r],flreg,base,limit,notused)
@@ -117,7 +117,7 @@ class DecodeCommand(BaseCommand):
                 if spi.FLASH_DESCRIPTOR == idx:
                     # Decoding Flash Descriptor
                     self.logger.set_log_file( os.path.join( pth, fname + '.log' ) )
-                    spi_descriptor.parse_spi_flash_descriptor( region_data )
+                    spi_descriptor.parse_spi_flash_descriptor( self.cs, region_data )
                 elif spi.BIOS == idx:
                     # Decoding EFI Firmware Volumes
                     self.logger.set_log_file( os.path.join( pth, fname + '.log' ) )

--- a/chipsec/utilcmd/spidesc_cmd.py
+++ b/chipsec/utilcmd/spidesc_cmd.py
@@ -50,7 +50,7 @@ class SPIDescCommand(BaseCommand):
 
         t = time.time()
         fd = read_file( fd_file )
-        if type(fd) == str: parse_spi_flash_descriptor( fd )
+        if type(fd) == str: parse_spi_flash_descriptor( self.cs, fd )
         self.logger.log( "\n[CHIPSEC] (spidesc) time elapsed %.3f" % (time.time()-t) )
 
 commands = { 'spidesc': SPIDescCommand }


### PR DESCRIPTION
Format of SPI flash descriptor depends is platform dependent. In order to parse it, we now use platform XML config.