### PR TITLE
Added command-line options support to chipsec_util

### DIFF
--- a/tests/software/util.py
+++ b/tests/software/util.py
@@ -63,11 +63,11 @@ class TestChipsecUtil(unittest.TestCase):
         """
         oshelper.Helper.registry = [(helper_class.__name__, helper_class)]
         chipsec_util._cs = chipset.cs()
-        util = chipsec_util.ChipsecUtil()
+        util = chipsec_util.ChipsecUtil(arg.split())
         util.VERBOSE = True
         logger.logger().HAL = True
         util.set_logfile(self.log_file)
-        err_code = util.main(["chipsec_utils.py"] + arg.split())
+        err_code = util.main()
         logger.logger().close()
         self.log = open(self.log_file).read()
         self.assertEqual(err_code, 0)


### PR DESCRIPTION
This PR adds supports for command-line options in chipsec_util.py

- Now chipsec_util can be invoked with both old format, e.g. "chipsec_util uefi var-list" and the new one "chipsec_util --platform skl --verbose --no_driver uefi var-list"
- General cleanup of chipsec_util.py