### PR TITLE
handle mmio writes of size != 4

### DIFF
--- a/chipsec/helper/efi/efihelper.py
+++ b/chipsec/helper/efi/efihelper.py
@@ -180,7 +180,8 @@ class EfiHelper(Helper):
         if size == 4:
             return edk2.writemem_dword( phys_address, value )
         else:
-            logger().error( '[efi] unsupported size %d by write_mmio_reg' % size )
+            buf = struct.pack(size*"B", value)
+            edk2.writemem( phys_address, buf, size )
         
     #
     # PCIe configuration access


### PR DESCRIPTION
Try to resolve #174 by implementing mmio writes of other sizes as buffer of single byte writes. Seems to work on uefi shell on mac when I tried it.