### PR TITLE
Fixed exception when running tools.smm.smm_ptr in UEFI Shell.

### DIFF
--- a/chipsec/helper/efi/efihelper.py
+++ b/chipsec/helper/efi/efihelper.py
@@ -138,7 +138,7 @@ class EfiHelper(Helper):
 
     def alloc_phys_mem( self, length, max_pa ):
         # temporary WA using malloc
-        va = edk2.allocphysmem(length, max_pa)
+        va = edk2.allocphysmem(length, max_pa)[0]
         pa = self.va2pa(va)
         return (va, pa)
 


### PR DESCRIPTION
Exception was caused by efi.allocphysmem returning a tuple but the
helper code was expecting a numeric value.  Updated UEFI helper code to
select the correct value in the tuple.

Signed-off-by: Erik Bjorge <erik.c.bjorge@intel.com>