### PR TITLE
Workaround for module errors on macOS

### DIFF
--- a/chipsec/helper/oshelper.py
+++ b/chipsec/helper/oshelper.py
@@ -166,6 +166,8 @@ class OsHelper:
     def is_win8_or_greater( self ):
         win8_or_greater = self.is_windows() and ( self.os_release.startswith('8') or ('2008Server' in self.os_release) or ('2012Server' in self.os_release) )
         return win8_or_greater
+    def is_macos( self ):
+        return ('darwin' == self.os_system.lower())
 
 
     #################################################################################################

--- a/chipsec/helper/osx/helper.py
+++ b/chipsec/helper/osx/helper.py
@@ -197,14 +197,48 @@ class OSXHelper(Helper):
         return chipsec.file.read_file( OutputFileName )
 
 
-
     def get_tool_info( self, tool_type ):
         raise NotImplementedError()
 
-    def read_io_port(self):
+    #########################################################
+    # EFI Runtime API
+    #########################################################
+
+    # @TODO: macOS helper doesn't support EFI runtime API yet
+    def EFI_supported(self):
+        return False
+
+    # Placeholders for EFI Variable API
+
+    def delete_EFI_variable(self, name, guid):
+        raise NotImplementedError()
+    def native_delete_EFI_variable(self, name, guid):
         raise NotImplementedError()
 
-    def write_io_port(self):
+    def list_EFI_variables(self):
+        raise NotImplementedError()
+    def native_list_EFI_variables(self):
+        raise NotImplementedError()
+
+    def get_EFI_variable(self, name, guid, attrs=None):
+        raise NotImplementedError()
+    def native_get_EFI_variable(self, name, guid, attrs=None):
+        raise NotImplementedError()
+
+    def set_EFI_variable(self, name, guid, data, datasize, attrs=None):
+        raise NotImplementedError()
+    def native_set_EFI_variable(self, name, guid, data, datasize, attrs=None):
+        raise NotImplementedError()
+
+
+    #########################################################
+    # Port I/O
+    #########################################################
+
+    def read_io_port(self, io_port, size):
+        raise NotImplementedError()
+
+    def write_io_port(self, io_port, value, size):
         raise NotImplementedError()
 
     def read_cr(self, cpu_thread_id, cr_number):

--- a/chipsec/modules/common/bios_smi.py
+++ b/chipsec/modules/common/bios_smi.py
@@ -45,7 +45,10 @@ class bios_smi(BaseModule):
         self.iobar = iobar.IOBAR(self.cs)
 
     def is_supported(self):
-        return (self.cs.get_chipset_id() not in chipsec.chipset.CHIPSET_FAMILY_ATOM)
+        # @TODO: currently, this module cannot run on macOS
+        if self.cs.helper.is_macos(): return False
+
+        return (not self.cs.is_atom())
 
     def check_SMI_locks(self):
 

--- a/chipsec/modules/common/ia32cfg.py
+++ b/chipsec/modules/common/ia32cfg.py
@@ -37,8 +37,10 @@ class ia32cfg(BaseModule):
         self.res = ModuleResult.PASSED
 
     def is_supported(self):
-        if self.cs.is_atom(): return False
-        else: return True
+        # @TODO: currently, this module cannot run on macOS
+        if self.cs.helper.is_macos(): return False
+
+        return (not self.cs.is_atom())
 
     def check_ia32feature_control(self):
         self.logger.start_test( "IA32 Feature Control Lock" )

--- a/chipsec/modules/common/smrr.py
+++ b/chipsec/modules/common/smrr.py
@@ -37,6 +37,8 @@ class smrr(BaseModule):
         BaseModule.__init__(self)
 
     def is_supported(self):
+        # @TODO: currently, this module cannot run on macOS
+        if self.cs.helper.is_macos(): return False
         return True
 
     #

--- a/chipsec/modules/smm_dma.py
+++ b/chipsec/modules/smm_dma.py
@@ -43,6 +43,8 @@ class smm_dma(BaseModule):
         BaseModule.__init__(self)
 
     def is_supported(self):
+        # @TODO: currently, this module cannot run on macOS
+        if self.cs.helper.is_macos(): return False
         if self.cs.is_atom(): return False
         if self.cs.is_server(): return False
         else: return True


### PR DESCRIPTION
- added is_macos()
- calling is_macos in modules which require functionality not yet
implemented by osx helper such as MSR, port IO and EFI variables
- added EFI_supported always returning False in osx helper to skip
modules requiring EFI runtime API