### PR TITLE
Fixed missing shutil import.

### DIFF
--- a/chipsec/helper/osx/helper.py
+++ b/chipsec/helper/osx/helper.py
@@ -22,6 +22,7 @@ import platform
 import struct
 import subprocess
 import sys
+import shutil
 
 import chipsec
 from chipsec.helper.oshelper import OsHelperError, Helper, HWAccessViolationError, UnimplementedAPIError, UnimplementedNativeAPIError

--- a/chipsec/helper/win/win32helper.py
+++ b/chipsec/helper/win/win32helper.py
@@ -47,6 +47,7 @@ import re
 import errno
 import traceback
 import time
+import shutil
 from threading import Lock
 from collections import namedtuple
 from ctypes import *


### PR DESCRIPTION
Only an issue with compression type 0 so I was not able to replicate the failure.  The import is missing.

Signed-off-by: Erik Bjorge <erik.c.bjorge@intel.com>