### PR TITLE
Move to Trusty for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: trusty
 python:
   - "2.7"
 


### PR DESCRIPTION
[Recent update](https://blog.travis-ci.com/2017-05-04-precise-image-updates) to the default Precise image on Travis have failed the current building process. This patch move to the more [recent Trusty](https://docs.travis-ci.com/user/trusty-ci-environment/) environment where the build works fine.