### PR TITLE
Merge FREGx definitions

### DIFF
--- a/chipsec/cfg/common.xml
+++ b/chipsec/cfg/common.xml
@@ -258,34 +258,6 @@
       <field name="BMRAG" bit="16" size="8" desc="BIOS Master Read Access Grant"/>
       <field name="BMWAG" bit="24" size="8" desc="BIOS Master Write Access Grant"/>
     </register>
-    <register name="FREG0_FLASHD" type="mmio" bar="SPIBAR" offset="0x54" size="4" desc="Flash Region 0 (Flash Descriptor)">
-      <field name="RB" bit="0"  size="12" desc="Region Base"/>
-      <field name="RL" bit="16" size="12" desc="Region Limit"/>
-    </register>
-    <register name="FREG1_BIOS" type="mmio" bar="SPIBAR" offset="0x58" size="4" desc="Flash Region 1 (BIOS)">
-      <field name="RB" bit="0"  size="12" desc="Region Base"/>
-      <field name="RL" bit="16" size="12" desc="Region Limit"/>
-    </register>
-    <register name="FREG2_ME" type="mmio" bar="SPIBAR" offset="0x5C" size="4" desc="Flash Region 2 (ME)">
-      <field name="RB" bit="0"  size="12" desc="Region Base"/>
-      <field name="RL" bit="16" size="12" desc="Region Limit"/>
-    </register>
-    <register name="FREG3_GBE" type="mmio" bar="SPIBAR" offset="0x60" size="4" desc="Flash Region 3 (GBe)">
-      <field name="RB" bit="0"  size="12" desc="Region Base"/>
-      <field name="RL" bit="16" size="12" desc="Region Limit"/>
-    </register>
-    <register name="FREG4_PD" type="mmio" bar="SPIBAR" offset="0x64" size="4" desc="Flash Region 4 (Platform Data)">
-      <field name="RB" bit="0"  size="12" desc="Region Base"/>
-      <field name="RL" bit="16" size="12" desc="Region Limit"/>
-    </register>
-    <register name="FREG5" type="mmio" bar="SPIBAR" offset="0x68" size="4" desc="Flash Region 5">
-      <field name="RB" bit="0"  size="12" desc="Region Base"/>
-      <field name="RL" bit="16" size="12" desc="Region Limit"/>
-    </register>
-    <register name="FREG6" type="mmio" bar="SPIBAR" offset="0x6C" size="4" desc="Flash Region 6">
-      <field name="RB" bit="0"  size="12" desc="Region Base"/>
-      <field name="RL" bit="16" size="12" desc="Region Limit"/>
-    </register>
     <register name="PR0" type="mmio" bar="SPIBAR" offset="0x74" size="4" desc="Protected Range 0">
       <field name="PRB" bit="0"  size="13" desc="Protected Range Base"/>
       <field name="RPE" bit="15" size="1"  desc="Read Protection Enabled"/>
@@ -393,23 +365,31 @@
       <field name="CPUSL"   bit="8"  size="8" desc="Processor Strap Length"/>
       <field name="ICCRIBA" bit="16" size="8" desc="ICC Register Init Base Address"/>
     </register>
-    <register name="FLREG0" type="mmio" bar="FRBA" offset="0x0" size="4" desc="Flash Region 0 (Flash Descriptor) Register">
+    <register name="FLREG0" type="mmio" bar="SPIBAR" offset="0x54" size="4" desc="Flash Region 0 (Flash Descriptor) Register">
       <field name="RB"      bit="0"  size="13" desc="Region Base"/>
       <field name="RL"      bit="16" size="13" desc="Region Limit"/>
     </register>
-    <register name="FLREG1" type="mmio" bar="FRBA" offset="0x4" size="4" desc="Flash Region 1 (BIOS) Register">
+    <register name="FLREG1" type="mmio" bar="SPIBAR" offset="0x58" size="4" desc="Flash Region 1 (BIOS) Register">
       <field name="RB"      bit="0"  size="13" desc="Region Base"/>
       <field name="RL"      bit="16" size="13" desc="Region Limit"/>
     </register>
-    <register name="FLREG2" type="mmio" bar="FRBA" offset="0x8" size="4" desc="Flash Region 2 (Intel ME) Register">
+    <register name="FLREG2" type="mmio" bar="SPIBAR" offset="0x5c" size="4" desc="Flash Region 2 (Intel ME) Register">
       <field name="RB"      bit="0"  size="13" desc="Region Base"/>
       <field name="RL"      bit="16" size="13" desc="Region Limit"/>
     </register>
-    <register name="FLREG3" type="mmio" bar="FRBA" offset="0xC" size="4" desc="Flash Region 3 (GBe) Register">
+    <register name="FLREG3" type="mmio" bar="SPIBAR" offset="0x60" size="4" desc="Flash Region 3 (GBe) Register">
       <field name="RB"      bit="0"  size="13" desc="Region Base"/>
       <field name="RL"      bit="16" size="13" desc="Region Limit"/>
     </register>
-    <register name="FLREG4" type="mmio" bar="FRBA" offset="0x10" size="4" desc="Flash Region 4 (Platform Data) Register">
+    <register name="FLREG4" type="mmio" bar="SPIBAR" offset="0x64" size="4" desc="Flash Region 4 (Platform Data) Register">
+      <field name="RB"      bit="0"  size="13" desc="Region Base"/>
+      <field name="RL"      bit="16" size="13" desc="Region Limit"/>
+    </register>
+    <register name="FLREG5" type="mmio" bar="SPIBAR" offset="0x68" size="4" desc="Flash Region 5">
+      <field name="RB"      bit="0"  size="13" desc="Region Base"/>
+      <field name="RL"      bit="16" size="13" desc="Region Limit"/>
+    </register>
+    <register name="FLREG6" type="mmio" bar="SPIBAR" offset="0x70" size="4" desc="Flash Region 6">
       <field name="RB"      bit="0"  size="13" desc="Region Base"/>
       <field name="RL"      bit="16" size="13" desc="Region Limit"/>
     </register>

--- a/chipsec/cfg/kbl.xml
+++ b/chipsec/cfg/kbl.xml
@@ -204,27 +204,39 @@
       <field name="FCPUSBA" bit="0"  size="8" desc="Flash CPU Strap Base Address"/>
       <field name="CPUSL"   bit="8"  size="8" desc="CPU Strap Length"/>
     </register>
-    <register name="FLREG0" type="mmio" bar="FRBA" offset="0x0" size="4" desc="Flash Region 0 (Flash Descriptor) Register">
+    <register name="FLREG0" type="mmio" bar="SPIBAR" offset="0x54" size="4" desc="Flash Region 0 (Flash Descriptor) Register">
       <field name="RB"      bit="0"  size="15" desc="Region Base"/>
       <field name="RL"      bit="16" size="15" desc="Region Limit"/>
     </register>
-    <register name="FLREG1" type="mmio" bar="FRBA" offset="0x4" size="4" desc="Flash Region 1 (BIOS) Register">
+    <register name="FLREG1" type="mmio" bar="SPIBAR" offset="0x58" size="4" desc="Flash Region 1 (BIOS) Register">
       <field name="RB"      bit="0"  size="15" desc="Region Base"/>
       <field name="RL"      bit="16" size="15" desc="Region Limit"/>
     </register>
-    <register name="FLREG2" type="mmio" bar="FRBA" offset="0x8" size="4" desc="Flash Region 2 (Intel ME) Register">
+    <register name="FLREG2" type="mmio" bar="SPIBAR" offset="0x5c" size="4" desc="Flash Region 2 (Intel ME) Register">
       <field name="RB"      bit="0"  size="15" desc="Region Base"/>
       <field name="RL"      bit="16" size="15" desc="Region Limit"/>
     </register>
-    <register name="FLREG3" type="mmio" bar="FRBA" offset="0xC" size="4" desc="Flash Region 3 (GBe) Register">
+    <register name="FLREG3" type="mmio" bar="SPIBAR" offset="0x60" size="4" desc="Flash Region 3 (GBe) Register">
       <field name="RB"      bit="0"  size="15" desc="Region Base"/>
       <field name="RL"      bit="16" size="15" desc="Region Limit"/>
     </register>
-    <register name="FLREG4" type="mmio" bar="FRBA" offset="0x10" size="4" desc="Flash Region 4 (Platform Data) Register">
+    <register name="FLREG4" type="mmio" bar="SPIBAR" offset="0x64" size="4" desc="Flash Region 4 (Platform Data) Register">
       <field name="RB"      bit="0"  size="15" desc="Region Base"/>
       <field name="RL"      bit="16" size="15" desc="Region Limit"/>
     </register>
-    <register name="FLREG8" type="mmio" bar="FRBA" offset="0x20" size="4" desc="Flash Region 8 (Embedded Controller) Register">
+    <register name="FLREG5" type="mmio" bar="SPIBAR" offset="0x68" size="4" desc="Flash Region 5 Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG6" type="mmio" bar="SPIBAR" offset="0x6c" size="4" desc="Flash Region 6 Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG7" type="mmio" bar="SPIBAR" offset="0x70" size="4" desc="Flash Region 7 Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG8" type="mmio" bar="SPIBAR" offset="0x74" size="4" desc="Flash Region 8 (Embedded Controller) Register">
       <field name="RB"      bit="0"  size="15" desc="Region Base"/>
       <field name="RL"      bit="16" size="15" desc="Region Limit"/>
     </register>

--- a/chipsec/cfg/skl.xml
+++ b/chipsec/cfg/skl.xml
@@ -210,27 +210,39 @@
       <field name="FCPUSBA" bit="0"  size="8" desc="Flash CPU Strap Base Address"/>
       <field name="CPUSL"   bit="8"  size="8" desc="CPU Strap Length"/>
     </register>
-    <register name="FLREG0" type="mmio" bar="FRBA" offset="0x0" size="4" desc="Flash Region 0 (Flash Descriptor) Register">
+    <register name="FLREG0" type="mmio" bar="SPIBAR" offset="0x54" size="4" desc="Flash Region 0 (Flash Descriptor) Register">
       <field name="RB"      bit="0"  size="15" desc="Region Base"/>
       <field name="RL"      bit="16" size="15" desc="Region Limit"/>
     </register>
-    <register name="FLREG1" type="mmio" bar="FRBA" offset="0x4" size="4" desc="Flash Region 1 (BIOS) Register">
+    <register name="FLREG1" type="mmio" bar="SPIBAR" offset="0x58" size="4" desc="Flash Region 1 (BIOS) Register">
       <field name="RB"      bit="0"  size="15" desc="Region Base"/>
       <field name="RL"      bit="16" size="15" desc="Region Limit"/>
     </register>
-    <register name="FLREG2" type="mmio" bar="FRBA" offset="0x8" size="4" desc="Flash Region 2 (Intel ME) Register">
+    <register name="FLREG2" type="mmio" bar="SPIBAR" offset="0x5c" size="4" desc="Flash Region 2 (Intel ME) Register">
       <field name="RB"      bit="0"  size="15" desc="Region Base"/>
       <field name="RL"      bit="16" size="15" desc="Region Limit"/>
     </register>
-    <register name="FLREG3" type="mmio" bar="FRBA" offset="0xC" size="4" desc="Flash Region 3 (GBe) Register">
+    <register name="FLREG3" type="mmio" bar="SPIBAR" offset="0x60" size="4" desc="Flash Region 3 (GBe) Register">
       <field name="RB"      bit="0"  size="15" desc="Region Base"/>
       <field name="RL"      bit="16" size="15" desc="Region Limit"/>
     </register>
-    <register name="FLREG4" type="mmio" bar="FRBA" offset="0x10" size="4" desc="Flash Region 4 (Platform Data) Register">
+    <register name="FLREG4" type="mmio" bar="SPIBAR" offset="0x64" size="4" desc="Flash Region 4 (Platform Data) Register">
       <field name="RB"      bit="0"  size="15" desc="Region Base"/>
       <field name="RL"      bit="16" size="15" desc="Region Limit"/>
     </register>
-    <register name="FLREG8" type="mmio" bar="FRBA" offset="0x20" size="4" desc="Flash Region 8 (Embedded Controller) Register">
+    <register name="FLREG5" type="mmio" bar="SPIBAR" offset="0x68" size="4" desc="Flash Region 5 Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG6" type="mmio" bar="SPIBAR" offset="0x6c" size="4" desc="Flash Region 6 Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG7" type="mmio" bar="SPIBAR" offset="0x70" size="4" desc="Flash Region 7 Register">
+      <field name="RB"      bit="0"  size="15" desc="Region Base"/>
+      <field name="RL"      bit="16" size="15" desc="Region Limit"/>
+    </register>
+    <register name="FLREG8" type="mmio" bar="SPIBAR" offset="0x74" size="4" desc="Flash Region 8 (Embedded Controller) Register">
       <field name="RB"      bit="0"  size="15" desc="Region Base"/>
       <field name="RL"      bit="16" size="15" desc="Region Limit"/>
     </register>

--- a/chipsec/hal/spi.py
+++ b/chipsec/hal/spi.py
@@ -106,13 +106,13 @@ FREG7               = 7
 EMBEDDED_CONTROLLER = 8
 
 SPI_REGION = {
- FLASH_DESCRIPTOR   : 'FREG0_FLASHD',
- BIOS               : 'FREG1_BIOS',
- ME                 : 'FREG2_ME',
- GBE                : 'FREG3_GBE',
- PLATFORM_DATA      : 'FREG4_PD',
- FREG5              : 'FREG5',
- FREG6              : 'FREG6'
+ FLASH_DESCRIPTOR   : 'FLREG0',
+ BIOS               : 'FLREG1',
+ ME                 : 'FLREG2',
+ GBE                : 'FLREG3',
+ PLATFORM_DATA      : 'FLREG4',
+ FREG5              : 'FLREG5',
+ FREG6              : 'FLREG6'
 }
 
 SPI_REGION_NAMES = {


### PR DESCRIPTION
With 2aa81af, the definitions of flash registers started to be duplicated. When using a live dump (`chipsec_util.py spi dump`), the `common.xml` definitions were still used. On SkyLake and KabyLake, the incorrect size of FREG.RB was then loaded (13 bits instead of 15).

This commit unifies the definitions. That is, FREG0_FLASHD is replaced by FLREG0. This does not affect `spidesc` as only the fields are used and not the bar attribute of the registers.