### PR TITLE
Fix the range check in bios_wp.py

### DIFF
--- a/chipsec/modules/common/bios_wp.py
+++ b/chipsec/modules/common/bios_wp.py
@@ -106,7 +106,7 @@ class bios_wp(BaseModule):
                     # overlap bottom
                     start,end = area
                     if base <= start and limit >= start:
-                        if limit > end:
+                        if limit >= end:
                             areas_to_protect.remove(area)
                         else:
                             areas_to_protect.remove(area)
@@ -115,7 +115,7 @@ class bios_wp(BaseModule):
 
                     # overlap top
                     elif base <= end and limit >= end:
-                        if base < start:
+                        if base <= start:
                             areas_to_protect.remove(area)
                         else:
                             areas_to_protect.remove(area)


### PR DESCRIPTION
This patch is a bug fix.

bios_wp.py checked protection ranges if they protect the BIOS range or not.
However, when a protection range was same as the BIOS range, the result was wrong.