### PR TITLE
Rwe fixups

### DIFF
--- a/chipsec/helper/helpers.py
+++ b/chipsec/helper/helpers.py
@@ -25,8 +25,6 @@ import chipsec.file
 from chipsec.helper.efi import *
 from chipsec.helper.linux import *
 from chipsec.helper.osx import *
-if os.path.isfile("C:\\Windows\\System32\\drivers\\chipsec_hlpr.sys") or os.path.isfile(os.path.join( chipsec.file.get_main_dir(), "chipsec", "helper", "win", "win7_" + platform.machine().lower(), "chipsec_hlpr.sys")):
-    from chipsec.helper.win import *
-elif (os.path.isfile(os.path.join("C:\\Windows\\System32\\drivers\\RwDrv.sys")) or os.path.isfile(os.path.join( chipsec.file.get_main_dir(), "chipsec", "helper", "rwe", "win7_" + platform.machine().lower(), "RwDrv.sys" ))):
-    from chipsec.helper.rwe import *
+from chipsec.helper.win import *
+from chipsec.helper.rwe import *
 

--- a/chipsec/helper/helpers.py
+++ b/chipsec/helper/helpers.py
@@ -22,6 +22,6 @@
 from chipsec.helper.efi import *
 from chipsec.helper.linux import *
 from chipsec.helper.osx import *
-#from chipsec.helper.rwe import *
+from chipsec.helper.rwe import *
 from chipsec.helper.win import *
 

--- a/chipsec/helper/helpers.py
+++ b/chipsec/helper/helpers.py
@@ -19,9 +19,14 @@
 #chipsec@intel.com
 #
 
+import os, platform
+import chipsec.file
+
 from chipsec.helper.efi import *
 from chipsec.helper.linux import *
 from chipsec.helper.osx import *
-from chipsec.helper.rwe import *
-from chipsec.helper.win import *
+if os.path.isfile("C:\\Windows\\System32\\drivers\\chipsec_hlpr.sys") or os.path.isfile(os.path.join( chipsec.file.get_main_dir(), "chipsec", "helper", "win", "win7_" + platform.machine().lower(), "chipsec_hlpr.sys")):
+    from chipsec.helper.win import *
+elif (os.path.isfile(os.path.join("C:\\Windows\\System32\\drivers\\RwDrv.sys")) or os.path.isfile(os.path.join( chipsec.file.get_main_dir(), "chipsec", "helper", "rwe", "win7_" + platform.machine().lower(), "RwDrv.sys" ))):
+    from chipsec.helper.rwe import *
 

--- a/chipsec/helper/rwe/__init__.py
+++ b/chipsec/helper/rwe/__init__.py
@@ -20,7 +20,8 @@
 #
 
 import platform, os
-if "windows" == platform.system().lower() and (os.path.isfile(os.path.join("C:\\Windows\\System32\\drivers\\RwDrv.sys")) or os.path.isfile(os.path.join(os.getcwd(), "win7_amd64\RwDrv.sys"))):
+
+if "windows" == platform.system().lower():
     __all__ = [ "rwehelper" ]
 else:
     __all__ = [ ]

--- a/chipsec/helper/rwe/__init__.py
+++ b/chipsec/helper/rwe/__init__.py
@@ -21,8 +21,6 @@
 
 import platform, os
 if "windows" == platform.system().lower() and (os.path.isfile(os.path.join("C:\\Windows\\System32\\drivers\\RwDrv.sys")) or os.path.isfile(os.path.join(os.getcwd(), "win7_amd64\RwDrv.sys"))):
-    print "rwe"
     __all__ = [ "rwehelper" ]
 else:
-    print "no rwe"
     __all__ = [ ]

--- a/chipsec/helper/rwe/__init__.py
+++ b/chipsec/helper/rwe/__init__.py
@@ -20,7 +20,9 @@
 #
 
 import platform, os
-if "windows" == platform.system().lower() and os.environ.has_key("USERWE"):
+if "windows" == platform.system().lower() and (os.path.isfile(os.path.join("C:\\Windows\\System32\\drivers\\RwDrv.sys")) or os.path.isfile(os.path.join(os.getcwd(), "win7_amd64\RwDrv.sys"))):
+    print "rwe"
     __all__ = [ "rwehelper" ]
 else:
+    print "no rwe"
     __all__ = [ ]

--- a/chipsec/helper/rwe/rwehelper.py
+++ b/chipsec/helper/rwe/rwehelper.py
@@ -72,10 +72,11 @@ kernel32 = windll.kernel32
 
 drv_hndl_error_msg = "Cannot open rwe driver handle. Make sure rwe driver is installed and started if you are using option -e (see README)"
 
-DRIVER_FILE_NAME = "RwDrv.sys"
-DEVICE_FILE      = "\\\\.\\RwDrv"
-SERVICE_NAME     = "RwDrv"
-DISPLAY_NAME     = "RwDrv"
+DRIVER_FILE_PATHS   = ["C:\\Windows\\System32\\drivers", os.path.join( chipsec.file.get_main_dir(), "chipsec", "helper", "rwe", "win7_" + platform.machine().lower())] 
+DRIVER_FILE_NAME    = "RwDrv.sys"
+DEVICE_FILE         = "\\\\.\\RwDrv"
+SERVICE_NAME        = "RwDrv"
+DISPLAY_NAME        = "RwDrv"
 
 CHIPSEC_INSTALL_PATH = os.path.join(sys.prefix, "Lib\site-packages\chipsec")
 
@@ -247,7 +248,8 @@ class RweHelper(Helper):
 
     def __init__(self):
         super(RweHelper, self).__init__()
-        import platform
+
+        import platform, os
         self.os_system  = platform.system()
         self.os_release = platform.release()
         self.os_version = platform.version()
@@ -257,14 +259,23 @@ class RweHelper(Helper):
             win_ver = "win7_" + self.os_machine.lower()
             if ("5" == self.os_release): win_ver = "winxp"
             if logger().HAL: logger().log( "[helper] OS: %s %s %s" % (self.os_system, self.os_release, self.os_version) )
-            if logger().HAL: logger().log( "[helper] Using 'helper/win/%s' path for driver" % win_ver )
 
         self.use_existing_service = False
 
-        self.driver_path    = None
         self.win_ver        = win_ver
         self.driver_handle  = None
         self.device_file    = pywintypes.Unicode(DEVICE_FILE)
+
+        # check DRIVER_FILE_PATHS for the DRIVER_FILE_NAME
+        self.driver_path    = None
+        for path in DRIVER_FILE_PATHS:
+            driver_path = os.path.join(path, DRIVER_FILE_NAME)
+            if os.path.isfile(driver_path): 
+                self.driver_path = driver_path
+                if logger().HAL: logger().log("[helper] found driver in %s" % driver_path)
+        if self.driver_path == None: 
+            if logger().HAL: logger().log("[helper] RWE Driver Not Found")
+            raise DriverNotFound
 
         c_int_p = POINTER(c_int)
 
@@ -354,17 +365,7 @@ class RweHelper(Helper):
             handle_winerror(fn, msg, hr)
 
         if logger().VERBOSE: logger().log( "[helper] service control manager opened (handle = 0x%08x)" % hscm )
-
-        driver_path = os.path.join( chipsec.file.get_main_dir(), "chipsec", "helper", "rwe", self.win_ver, DRIVER_FILE_NAME )
-        if not os.path.isfile( driver_path ):
-            driver_path = os.path.join("C:\\", "Windows","System32","drivers", DRIVER_FILE_NAME)
-            if logger().VERBOSE: logger().log( "[helper] Did not find local RWE driver. Trying %s" % driver_path )
-        if os.path.isfile( driver_path ):
-            self.driver_path = driver_path
-            if logger().VERBOSE: logger().log( "[helper] driver path: '%s'" % os.path.abspath(self.driver_path) )
-        else:
-            logger().error( "could not locate driver file '%.256s'" % driver_path )
-            return False
+        if logger().VERBOSE: logger().log( "[helper] driver path: '%s'" % os.path.abspath(self.driver_path) )
 
         try:
             hs = win32service.CreateService(
@@ -375,7 +376,7 @@ class RweHelper(Helper):
                  win32service.SERVICE_KERNEL_DRIVER,
                  win32service.SERVICE_DEMAND_START,
                  win32service.SERVICE_ERROR_NORMAL,
-                 os.path.abspath(driver_path),
+                 os.path.abspath(self.driver_path),
                  None, 0, u"", None, None )
             if hs:
                 if logger().VERBOSE: logger().log( "[helper] service '%s' created (handle = 0x%08x)" % (SERVICE_NAME,hs) )

--- a/chipsec/helper/rwe/rwehelper.py
+++ b/chipsec/helper/rwe/rwehelper.py
@@ -72,7 +72,7 @@ kernel32 = windll.kernel32
 
 drv_hndl_error_msg = "Cannot open rwe driver handle. Make sure rwe driver is installed and started if you are using option -e (see README)"
 
-DRIVER_FILE_PATHS   = ["C:\\Windows\\System32\\drivers", os.path.join( chipsec.file.get_main_dir(), "chipsec", "helper", "rwe", "win7_" + platform.machine().lower())] 
+DRIVER_FILE_PATHS   = [os.path.join("C:\\", "Windows", "System32", "drivers"), os.path.join( chipsec.file.get_main_dir(), "chipsec", "helper", "rwe", "win7_" + platform.machine().lower())] 
 DRIVER_FILE_NAME    = "RwDrv.sys"
 DEVICE_FILE         = "\\\\.\\RwDrv"
 SERVICE_NAME        = "RwDrv"

--- a/chipsec/helper/win/__init__.py
+++ b/chipsec/helper/win/__init__.py
@@ -29,7 +29,7 @@
 
 import platform, os
 
-if "windows" == platform.system().lower() and os.path.isfile(os.path.join(os.getcwd(), "win7_amd64\chipsec_hlpr.sys")):
+if "windows" == platform.system().lower():
     __all__ = [ "win32helper" ]
 else:
     __all__ = []

--- a/chipsec/helper/win/__init__.py
+++ b/chipsec/helper/win/__init__.py
@@ -27,8 +27,9 @@
 #
 ##################################################################################
 
-import platform
-if "windows" == platform.system().lower():
+import platform, os
+
+if "windows" == platform.system().lower() and os.path.isfile(os.path.join(os.getcwd(), "win7_amd64\chipsec_hlpr.sys")):
     __all__ = [ "win32helper" ]
 else:
     __all__ = []

--- a/chipsec/helper/win/win32helper.py
+++ b/chipsec/helper/win/win32helper.py
@@ -353,6 +353,8 @@ class Win32Helper(Helper):
         if logger().VERBOSE: logger().log( "[helper] service control manager opened (handle = 0x%08x)" % hscm )
 
         driver_path = os.path.join( chipsec.file.get_main_dir(), "chipsec", "helper", "win", self.win_ver, DRIVER_FILE_NAME )
+        if not os.path.isfile( driver_path ):
+            driver_path = os.path.join("C:\\Windows\\System32\\drivers\\RwDrv.sys"
         if os.path.isfile( driver_path ):
             self.driver_path = driver_path
             if logger().VERBOSE: logger().log( "[helper] driver path: '%s'" % os.path.abspath(self.driver_path) )

--- a/chipsec/helper/win/win32helper.py
+++ b/chipsec/helper/win/win32helper.py
@@ -73,6 +73,7 @@ kernel32 = windll.kernel32
 
 drv_hndl_error_msg = "Cannot open chipsec driver handle. Make sure chipsec driver is installed and started if you are using option -e (see README)"
 
+DRIVER_FILE_PATHS = [ "C:\\Windows\\System32\\drivers", os.path.join( chipsec.file.get_main_dir(), "chipsec", "helper", "win", "win7_" + platform.machine().lower()) ]
 DRIVER_FILE_NAME = "chipsec_hlpr.sys"
 DEVICE_FILE      = "\\\\.\\chipsec_hlpr"
 SERVICE_NAME     = "chipsec"
@@ -244,7 +245,8 @@ class Win32Helper(Helper):
 
     def __init__(self):
         super(Win32Helper, self).__init__()
-        import platform
+
+        import platform, os
         self.os_system  = platform.system()
         self.os_release = platform.release()
         self.os_version = platform.version()
@@ -254,14 +256,23 @@ class Win32Helper(Helper):
             win_ver = "win7_" + self.os_machine.lower()
             if ("5" == self.os_release): win_ver = "winxp"
             if logger().HAL: logger().log( "[helper] OS: %s %s %s" % (self.os_system, self.os_release, self.os_version) )
-            if logger().HAL: logger().log( "[helper] Using 'helper/win/%s' path for driver" % win_ver )
 
         self.use_existing_service = False
 
-        self.driver_path    = None
         self.win_ver        = win_ver
         self.driver_handle  = None
         self.device_file    = pywintypes.Unicode(DEVICE_FILE)
+
+        # check DRIVER_FILE_PATHS for the DRIVER_FILE_NAME
+        self.driver_path    = None
+        for path in DRIVER_FILE_PATHS:
+            driver_path = os.path.join(path, DRIVER_FILE_NAME)
+            if os.path.isfile(driver_path): 
+                self.driver_path = driver_path
+                if logger().HAL: logger().log("[helper] found driver in %s" % driver_path)
+        if self.driver_path == None: 
+            if logger().HAL: logger().log("[helper] CHIPSEC Windows Driver Not Found")
+            raise DriverNotFound
 
         c_int_p = POINTER(c_int)
 
@@ -351,16 +362,7 @@ class Win32Helper(Helper):
             handle_winerror(fn, msg, hr)
 
         if logger().VERBOSE: logger().log( "[helper] service control manager opened (handle = 0x%08x)" % hscm )
-
-        driver_path = os.path.join( chipsec.file.get_main_dir(), "chipsec", "helper", "win", self.win_ver, DRIVER_FILE_NAME )
-        if not os.path.isfile( driver_path ):
-            driver_path = os.path.join( "C:\\Windows\\System32\\drivers", DRIVER_FILE_NAME)
-        if os.path.isfile( driver_path ):
-            self.driver_path = driver_path
-            if logger().VERBOSE: logger().log( "[helper] driver path: '%s'" % os.path.abspath(self.driver_path) )
-        else:
-            logger().error( "could not locate driver file '%.256s'" % driver_path )
-            return False
+        if logger().VERBOSE: logger().log( "[helper] driver path: '%s'" % os.path.abspath(self.driver_path) )
 
         try:
             hs = win32service.CreateService(
@@ -371,7 +373,7 @@ class Win32Helper(Helper):
                  win32service.SERVICE_KERNEL_DRIVER,
                  win32service.SERVICE_DEMAND_START,
                  win32service.SERVICE_ERROR_NORMAL,
-                 os.path.abspath(driver_path),
+                 os.path.abspath(self.driver_path),
                  None, 0, u"", None, None )
             if hs:
                 if logger().VERBOSE: logger().log( "[helper] service '%s' created (handle = 0x%08x)" % (SERVICE_NAME,hs) )

--- a/chipsec/helper/win/win32helper.py
+++ b/chipsec/helper/win/win32helper.py
@@ -73,7 +73,7 @@ kernel32 = windll.kernel32
 
 drv_hndl_error_msg = "Cannot open chipsec driver handle. Make sure chipsec driver is installed and started if you are using option -e (see README)"
 
-DRIVER_FILE_PATHS = [ "C:\\Windows\\System32\\drivers", os.path.join( chipsec.file.get_main_dir(), "chipsec", "helper", "win", "win7_" + platform.machine().lower()) ]
+DRIVER_FILE_PATHS = [ os.path.join( "C:\\", "Windows", "System32", "drivers"), os.path.join( chipsec.file.get_main_dir(), "chipsec", "helper", "win", "win7_" + platform.machine().lower()) ]
 DRIVER_FILE_NAME = "chipsec_hlpr.sys"
 DEVICE_FILE      = "\\\\.\\chipsec_hlpr"
 SERVICE_NAME     = "chipsec"

--- a/chipsec/helper/win/win32helper.py
+++ b/chipsec/helper/win/win32helper.py
@@ -354,7 +354,7 @@ class Win32Helper(Helper):
 
         driver_path = os.path.join( chipsec.file.get_main_dir(), "chipsec", "helper", "win", self.win_ver, DRIVER_FILE_NAME )
         if not os.path.isfile( driver_path ):
-            driver_path = os.path.join("C:\\Windows\\System32\\drivers\\RwDrv.sys"
+            driver_path = os.path.join( "C:\\Windows\\System32\\drivers", DRIVER_FILE_NAME)
         if os.path.isfile( driver_path ):
             self.driver_path = driver_path
             if logger().VERBOSE: logger().log( "[helper] driver path: '%s'" % os.path.abspath(self.driver_path) )


### PR DESCRIPTION
Currently, if you use the RWE driver, it's a little annoying to remember to set an environment variable. Instead, we can just look to see which driver is actually present underneath the helper directory. For RWE we also look in the system drivers directory so that if RWE is installed, the driver can be found in the default location.

Additionally, if you try to use decode or whitelist, the RWE helper is missing decompress methods. This just copies them from the regular windows helper.
