### PR TITLE
Linux driver: Fix IOCTL_WRMMIO for x86_64

### DIFF
--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -1530,7 +1530,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 
         case IOCTL_WRMMIO:
 	{
-        unsigned long addr, value;
+        unsigned long addr, value, first, second;
         char *ioaddr;
 		
         numargs = 3;
@@ -1558,8 +1558,11 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 				break;
             case 8:
             #ifdef __x86_64__
-                iowrite32( ( value >> 32 ) & 0xFFFFFFFF, ioaddr );
-                iowrite32( value & 0xFFFFFFFF, ioaddr + 4 );
+                first = value & 0xFFFFFFFF;
+                second = (value >> 32) & 0xFFFFFFFF;
+
+                iowrite32(first, ioaddr);
+                iowrite32(second, ioaddr + 4);
             #endif
                 break;
 		}


### PR DESCRIPTION
This patch fixes IOCTL_WRMMIO so that the high and low halves of the 8-byte MMIO
value are written to the appropriate addresses.