### PR TITLE
Fix decompression issue #269

### DIFF
--- a/chipsec/helper/linux/helper.py
+++ b/chipsec/helper/linux/helper.py
@@ -1050,7 +1050,7 @@ class LinuxHelper(Helper):
         if CompressionType == 0: # not compressed
             shutil.copyfile( CompressedFileName, OutputFileName )
         elif CompressionType == 0x01:
-            data = self.decompress_data( [ EFI, Tiano ], CompressedFileData )
+            data = self.decompress_data( [ Tiano, EFI ], CompressedFileData )
         elif CompressionType == 0x02:
             data = self.decompress_data( [ LZMA, Tiano, EFI ] , CompressedFileData )
         if CompressionType != 0x00:

--- a/chipsec_tools/compression/Tiano/Decompress.c
+++ b/chipsec_tools/compression/Tiano/Decompress.c
@@ -68,9 +68,6 @@ typedef struct {
   UINT16  mBadTableFlag;
   UINT16  mBadAlgorithm;
 
-  size_t mMPTTableSize;
-  size_t mCTableSize;
-
   UINT16  mLeft[2 * NC - 1];
   UINT16  mRight[2 * NC - 1];
   UINT8   mCLen[NC];
@@ -173,8 +170,7 @@ MakeTable (
   IN  UINT16        NumOfChar,
   IN  UINT8         *BitLen,
   IN  UINT16        TableBits,
-  OUT UINT16        *Table,
-  IN  size_t        TableSize 
+  OUT UINT16        *Table
   )
 /*++
 
@@ -201,6 +197,7 @@ Returns:
   UINT16  Weight[17];
   UINT16  Start[18];
   UINT16  *Pointer;
+  UINT16  TableSize;
   UINT16  Index3;
   UINT16  Index;
   UINT16  Len;
@@ -209,6 +206,8 @@ Returns:
   UINT16  Avail;
   UINT16  NextCode;
   UINT16  Mask;
+
+  TableSize = (UINT16) (1U << TableBits);
 
   for (Index = 1; Index <= 16; Index++) {
     Count[Index] = 0;
@@ -244,13 +243,7 @@ Returns:
   Index = (UINT16) (Start[TableBits + 1] >> JuBits);
 
   if (Index != 0) {
-    Index3 = (UINT16) (1U << TableBits);
-    while (Index != Index3) {
-      if(Index >= TableSize)
-      {
-        Sd->mBadAlgorithm = 1;
-        return (UINT16) BAD_TABLE;
-      }
+    while (Index != TableSize) {
       Table[Index++] = 0;
     }
   }
@@ -285,7 +278,7 @@ Returns:
 
       while (Index != 0) {
         if (*Pointer == 0) {
-          Sd->mRight[Avail]                     = Sd->mLeft[Avail] = 0;
+          Sd->mRight[Avail] = Sd->mLeft[Avail] = 0;
           *Pointer = Avail++;
         }
 
@@ -448,7 +441,7 @@ Returns:
     Sd->mPTLen[Index++] = 0;
   }
 
-  return MakeTable (Sd, nn, Sd->mPTLen, 8, Sd->mPTTable, Sd->mMPTTableSize);
+  return MakeTable (Sd, nn, Sd->mPTLen, 8, Sd->mPTTable);
 }
 
 STATIC
@@ -542,7 +535,7 @@ Returns: (VOID)
     Sd->mCLen[Index++] = 0;
   }
 
-  MakeTable (Sd, NC, Sd->mCLen, 12, Sd->mCTable, Sd->mCTableSize);
+  MakeTable (Sd, NC, Sd->mCLen, 12, Sd->mCTable);
 
   return ;
 }
@@ -797,9 +790,6 @@ Returns:
   Sd->mDstBase  = Dst;
   Sd->mCompSize = CompSize;
   Sd->mOrigSize = DstSize;
-
-  Sd->mMPTTableSize = MPTTABLESIZE;
-  Sd->mCTableSize   = MCTABLESIZE;
 
   //
   // Fill the first BITBUFSIZ bits

--- a/chipsec_tools/compression/Tiano/Decompress.c
+++ b/chipsec_tools/compression/Tiano/Decompress.c
@@ -246,7 +246,7 @@ Returns:
   if (Index != 0) {
     Index3 = (UINT16) (1U << TableBits);
     while (Index != Index3) {
-      if(Index > TableSize)
+      if(Index >= TableSize)
       {
         Sd->mBadAlgorithm = 1;
         return (UINT16) BAD_TABLE;
@@ -270,14 +270,13 @@ Returns:
     if (Len <= TableBits) {
 
       for (Index = Start[Len]; Index < NextCode; Index++) {
-        if(Index > TableSize)
+        if(Index >= TableSize)
         {
           Sd->mBadAlgorithm = 1;
           return (UINT16) BAD_TABLE;
-        }
+        } 
         Table[Index] = Char;
       }
-
     } else {
 
       Index3  = Start[Len];

--- a/chipsec_tools/compression/Tiano/TianoCompress.c
+++ b/chipsec_tools/compression/Tiano/TianoCompress.c
@@ -1664,7 +1664,7 @@ INT32
 MakeTree (
   IN  INT32            NParm,
   IN  UINT16  FreqParm[],
-  OUT UINT8   LenParm[ ],
+  OUT UINT8   LenParm [],
   OUT UINT16  CodeParm[]
   )
 /*++


### PR DESCRIPTION
Fix for the issue and some other small things.

Basically, as Alex said, when you swap the decompression algorithms order:

_chipsec/helper/linux/helper.py_

    data = self.decompress_data( [ Tiano, EFI ], CompressedFileData )

You have to check for overflow to check if the algorithm is correct for that file and then return and error code to inform that the algorithm was correct:

_chipsec_tools/compression/Tiano/Decompress.c_

    if (DataIdx > Sd->mOrigSize) {
        Sd->mBadAlgorithm = 1;
        return;
        }

Then:

    if (Sd->mBadTableFlag != 0 || Sd->mBadAlgorithm != 0) {
    //
    // Something wrong with the source
    //
        Status = EFI_INVALID_PARAMETER;
   }

Until here it is as Alex proposed. The hidden thing was that there is also an overflow in the mPTTable buffer in the Scratch struct (when the algorithm is wrong) which was stepping into the malloc header of the Destination buffer. This was causing a crash when you attempted to free the *Destination bacause the header was corrupt.

    Status = Extract((VOID *)SrcBuf, SrcDataSize, (VOID **)&DstBuf, &DstDataSize, type);
    if (Status != EFI_SUCCESS) {
        PyErr_SetString(PyExc_Exception, "Failed to decompress\n");
        errorHandling(SrcBuf, DstBuf);    //<--- CRASH
        return NULL;
   }
 So, if we expand the mPTTable buffer to withstand this wrong data filling, we have the problem solved.

The other changes are pretty self explanatory, if you have questions just ask.
Fede.