### PR TITLE
fix compile issue on fedora26 where there is no symbol errorHandling

### DIFF
--- a/chipsec_tools/compression/EfiCompressor.c
+++ b/chipsec_tools/compression/EfiCompressor.c
@@ -138,7 +138,7 @@ ParseObject(
   return EFI_SUCCESS;
 }
 
-inline void 
+void 
 errorHandling(
   VOID* SrcBuf,
   VOID* DstBuf


### PR DESCRIPTION
Tested on Fedora26 and Ubuntu 16.04. Previously noticed a failure when doing setup.py build_ext -i on Fedora26. This avoids that issue.
