### PR TITLE
chipsec/cfg: add missing mm_msgbus to register type validation

### DIFF
--- a/chipsec/cfg/chipsec_cfg.xsd
+++ b/chipsec/cfg/chipsec_cfg.xsd
@@ -117,6 +117,7 @@
     <xs:enumeration value="pcicfg" />
     <xs:enumeration value="mmcfg" />
     <xs:enumeration value="msgbus" />
+    <xs:enumeration value="mm_msgbus" />
   </xs:restriction>
 </xs:simpleType>
 


### PR DESCRIPTION
Without this change Coffe Lake XML validation fails.

Signed-off-by: Piotr Król <piotr.krol@3mdeb.com>