### PR TITLE
Deb Packaging Updates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,17 @@
-chipsec (1.3.0-1) UNRELEASED; urgency=medium
+chipsec (1.3.5-1) UNRELEASED; urgency=medium
 
+  * revision bump to match source version
+  * Modify control to only build amd64 and i386
+
+ -- Jeff Lane <jeff@ubuntu.com>  Thu, 15 Feb 2018 10:39:15 -0500
+
+chipsec (1.3.0-1) unstable; urgency=medium
+
+  [ Tim Brown ]
   * Cleaned up PR
   * Fixed dependencies
 
- -- Tim Brown <timb@nth-dimension.org.uk>  Mon, 27 Mar 2017 08:34:07 +0100
+ -- Jeff Lane <jeff@ubuntu.com>  Thu, 15 Feb 2018 10:39:07 -0500
 
 chipsec (1.2.5-3) UNRELEASED; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -7,14 +7,14 @@ Standards-Version: 3.9.1
 Homepage: https://github.com/chipsec/chipsec
 
 Package: chipsec
-Architecture: any
+Architecture: amd64 i386
 Depends: ${python:Depends}, ${shlibs:Depends}, ${misc:Depends}
 Recommends: chipsec-dkms
 Description: Platform Security Assessment Framework 
  CHIPSEC: Platform Security Assessment Framework
 
 Package: chipsec-dkms
-Architecture: any
+Architecture: amd64 i386
 Depends: ${shlibs:Depends}, ${misc:Depends}, dkms, nasm
 Description: Platform Security Assessment Framework - module building source
  This package contains source code for the low-level drivers

--- a/debian/control
+++ b/debian/control
@@ -7,14 +7,14 @@ Standards-Version: 3.9.1
 Homepage: https://github.com/chipsec/chipsec
 
 Package: chipsec
-Architecture: amd64 i386
+Architecture: amd64
 Depends: ${python:Depends}, ${shlibs:Depends}, ${misc:Depends}
 Recommends: chipsec-dkms
 Description: Platform Security Assessment Framework 
  CHIPSEC: Platform Security Assessment Framework
 
 Package: chipsec-dkms
-Architecture: amd64 i386
+Architecture: amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}, dkms, nasm
 Description: Platform Security Assessment Framework - module building source
  This package contains source code for the low-level drivers


### PR DESCRIPTION
Updated version in debian/changelog to match source code version
 * When package was built, running chipsec failed because the dkms stuff was installed to a directory based on the package version (1.3.0) but the binary was looking in a directory called 1.3.5.

Updated debian/control to only build amd64
 *  Because chipsec_tools/linux/:  LzmaCompress.bin  TianoCompress.bin
    are x86_64 binaries, there's no reason to build debs for anything else.