### PR TITLE
Fixed error reporting when warnings are found.

### DIFF
--- a/chipsec/modules/debugenabled.py
+++ b/chipsec/modules/debugenabled.py
@@ -1,6 +1,7 @@
 #CHIPSEC: Platform Security Assessment Framework
 #Copyright (c) 2018, Eclypsium, Inc.
-# 
+#Copyright (c) 2018, Intel Corporation
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; Version 2.
@@ -12,7 +13,7 @@
 #
 
 """
-This module checks if the system has debug features turned on, 
+This module checks if the system has debug features turned on,
 specifically the Direct Connect Interface (DCI).
 
 This module checks the following bits:
@@ -50,7 +51,7 @@ DCI_CONTROL_REG_OFFSET = 0x4
 HDCIEN_MASK = 0b00000000000000000000000000010000
 IA32_DEBUG_INTERFACE_DEBUGENABLE_MASK = 0b00000000000000000000000000000001
 IA32_DEBUG_INTERFACE_DEBUGELOCK_MASK = 0b01000000000000000000000000000000
-IA32_DEBUG_INTERFACE_DEBUGEOCCURED_MASK = 0b10000000000000000000000000000000 
+IA32_DEBUG_INTERFACE_DEBUGEOCCURED_MASK = 0b10000000000000000000000000000000
 
 CPUID_IA32_DEBUG_INTERFACE_SUPPORTED_BIT11_MASK = 0b00000000000000000000100000000000
 
@@ -75,18 +76,18 @@ class debugenabled(chipsec.module_common.BaseModule):
 
 
     def check_dci( self ):
-        TestFail = False;
+        TestFail = ModuleResult.PASSED
         self.logger.log('[X] Checking DCI register status')
         value = self.cs.msgbus.mm_msgbus_reg_read(P2SB_DCI_PORT_ID,DCI_CONTROL_REG_OFFSET)
         if self.logger.VERBOSE: self.logger.log('[*] DCI Control Register = 0x%X' % value )
         HDCIEN = ((value & HDCIEN_MASK) == HDCIEN_MASK)
         if HDCIEN:
-            TestFail = True;
+            TestFail = ModuleResult.FAILED
         return TestFail
 
     def check_cpu_debug_enable( self ):
         self.logger.log('[X] Checking IA32_DEBUG_INTERFACE msr status')
-        TestFail = False;
+        TestFail = ModuleResult.PASSED
         for tid in range(self.cs.msr.get_cpu_thread_count()):
             (eax, edx) = self.cs.helper.read_msr( tid, IA32_DEBUG_INTERFACE_MSR )
             if self.logger.VERBOSE: self.logger.log('[cpu%d] RDMSR( 0x%x ): EAX = 0x%08X, EDX = 0x%08X' % (tid, IA32_DEBUG_INTERFACE_MSR, eax, edx) )
@@ -95,11 +96,11 @@ class debugenabled(chipsec.module_common.BaseModule):
             IA32_DEBUG_INTERFACE_DEBUGEOCCURED = ((IA32_DEBUG_INTERFACE_DEBUGEOCCURED_MASK & eax) == IA32_DEBUG_INTERFACE_DEBUGEOCCURED_MASK)
             if edx == EDX_ENABLE_STATE: #Sanity check only EAX matters
                 if (IA32_DEBUG_INTERFACE_DEBUGENABLE) or (IA32_DEBUG_INTERFACE_DEBUGELOCK):
-                    if self.logger.VERBOSE: 
-                        self.logger.log('IA32_DEBUG_INTERFACE_DEBUGENABLE ==' + str(IA32_DEBUG_INTERFACE_DEBUGENABLE));
-                        self.logger.log('IA32_DEBUG_INTERFACE_DEBUGELOCK ==' + str(IA32_DEBUG_INTERFACE_DEBUGELOCK));
-                        self.logger.log('IA32_DEBUG_INTERFACE_DEBUGEOCCURED ==' + str(IA32_DEBUG_INTERFACE_DEBUGEOCCURED));
-                    TestFail = True;
+                    if self.logger.VERBOSE:
+                        self.logger.log('IA32_DEBUG_INTERFACE_DEBUGENABLE ==' + str(IA32_DEBUG_INTERFACE_DEBUGENABLE))
+                        self.logger.log('IA32_DEBUG_INTERFACE_DEBUGELOCK ==' + str(IA32_DEBUG_INTERFACE_DEBUGELOCK))
+                        self.logger.log('IA32_DEBUG_INTERFACE_DEBUGEOCCURED ==' + str(IA32_DEBUG_INTERFACE_DEBUGEOCCURED))
+                    TestFail = ModuleResult.FAILED
                 if IA32_DEBUG_INTERFACE_DEBUGEOCCURED:
                         TestFail = ModuleResult.WARNING
         return TestFail
@@ -108,40 +109,37 @@ class debugenabled(chipsec.module_common.BaseModule):
         if len(module_argv) > 2:
             self.logger.error('Not expecting any arguments')
             return ModuleResult.ERROR
-        returned_result = ModuleResult.PASSED;
+        returned_result = ModuleResult.PASSED
         self.logger.start_test('Debug features test')
-        script_pa = None   
-        dci_test_fail = False;
-        cpu_debug_test_fail = True;
-        
-        cpu_debug_test_fail = self.check_cpu_debug_enable();
+        script_pa = None
+        dci_test_fail = ModuleResult.PASSED
+        cpu_debug_test_fail = ModuleResult.PASSED
+
+        cpu_debug_test_fail = self.check_cpu_debug_enable()
+        if (cpu_debug_test_fail == ModuleResult.FAILED):
+            self.logger.log_bad('CPU IA32_DEBUG_INTERFACE is enabled')
+        elif cpu_debug_test_fail == ModuleResult.WARNING:
+            self.logger.log_warning('Debug Occured bit set in IA32_DEBUG_INTERFACE msr')
+        else:
+            self.logger.log_good('CPU IA32_DEBUG_INTERFACE is disabled')
+
         current_platform_id = self.cs.get_chipset_id()
         dci_supported = (current_platform_id == chipsec.chipset.CHIPSET_ID_CFL) | (current_platform_id == chipsec.chipset.CHIPSET_ID_KBL) | (current_platform_id == chipsec.chipset.CHIPSET_ID_SKL)
         if (dci_supported):
             dci_test_fail = self.check_dci()
-            if (dci_test_fail == True):
-                if self.logger.VERBOSE: self.logger.log_failed('DCI Debug is enabled')
-                returned_result = ModuleResult.FAILED
+            if (dci_test_fail == ModuleResult.FAILED):
+                self.logger.log_bad('DCI Debug is enabled')
             else:
-                if self.logger.VERBOSE: self.logger.log_passed_check('DCI Debug is disabled')
-                returned_result = ModuleResult.PASSED
-        
-        if (cpu_debug_test_fail == True):
-            if self.logger.VERBOSE: self.logger.log_failed('CPU IA32_DEBUG_INTERFACE is enabled')
+                self.logger.log_good('DCI Debug is disabled')
+
+        if (dci_test_fail == ModuleResult.FAILED or cpu_debug_test_fail == ModuleResult.FAILED):
+            self.logger.log_failed_check('One or more of the debug checks have failed and a debug feature is enabled')
             returned_result = ModuleResult.FAILED
+        elif (dci_test_fail == ModuleResult.WARNING or cpu_debug_test_fail == ModuleResult.WARNING):
+            self.logger.log_warn_check('An unexpected debug state was discovered on this platform')
+            returned_result = ModuleResult.WARNING
         else:
-            if cpu_debug_test_fail == ModuleResult.WARNING:
-                self.logger.log_warning('Debug Occured bit set in IA32_DEBUG_INTERFACE msr')
-                returned_result = ModuleResult.WARNING
-            else:
-                returned_result = ModuleResult.PASSED
-                if self.logger.VERBOSE: self.logger.log_passed_check('CPU IA32_DEBUG_INTERFACE is disabled')
-        if (dci_test_fail | cpu_debug_test_fail): 
-            self.logger.log_failed_check('One or more of the debug checks have failed and a debug feature is enabled')        
-        else: 
             self.logger.log_passed_check('All checks have successfully passed')
             returned_result = ModuleResult.PASSED
-            
-        return returned_result
 
-        
+        return returned_result


### PR DESCRIPTION
Discovered that the warning path was not working as expected. Showed
failed in log message but warning in summary.

Signed-off-by: Erik Bjorge <erik.c.bjorge@intel.com>