### PR TITLE
fix exception when reading physical memory

### DIFF
--- a/chipsec/helper/linux/helper.py
+++ b/chipsec/helper/linux/helper.py
@@ -364,7 +364,7 @@ class LinuxHelper(Helper):
         if len(in_buf) < length:
             in_buf += (length - len(in_buf)) * 'A'
         out_buf = self.ioctl(IOCTL_READ_PHYSMEM, in_buf)
-        ret = struct.unpack(str(length)+'s', out_buf)
+        ret = struct.unpack(str(length)+'s', out_buf[:length])
         return ret[0]
 
     def native_read_phys_mem(self, phys_address_hi, phys_address_lo, length):


### PR DESCRIPTION
Previously, testing chipsec_util to read physical memory would give the following error:
  File ".../chipsec/chipsec/helper/linux/helper.py", line 371, in read_phys_mem
    ret = struct.unpack(str(length)+'s', outstr)
struct.error: unpack requires a string argument of length 16
