### PR TITLE
Revert "Change linux READ/WRITE Physical Memory Functionality"

### DIFF
--- a/chipsec/helper/linux/helper.py
+++ b/chipsec/helper/linux/helper.py
@@ -80,8 +80,6 @@ IOCTL_WRMMIO                   = 0x13
 IOCTL_VA2PA                    = 0x14
 IOCTL_MSGBUS_SEND_MESSAGE      = 0x15
 IOCTL_FREE_PHYSMEM             = 0x16
-IOCTL_READ_PHYSMEM             = 0x17
-IOCTL_WRITE_PHYSMEM            = 0x18
 
 LZMA  = efi_compressor.LzmaDecompress
 Tiano = efi_compressor.TianoDecompress
@@ -345,9 +343,8 @@ class LinuxHelper(Helper):
     def write_phys_mem(self, phys_address_hi, phys_address_lo, length, newval):
         if newval is None: return None
         addr = (phys_address_hi << 32) | phys_address_lo
-        in_buf = struct.pack('2'+self._pack,addr,length)+str(newval)
-        out_buf = self.ioctl(IOCTL_WRITE_PHYSMEM, in_buf)
-        return
+        self.dev_fh.seek(addr)
+        return self.__mem_block(length, newval)
 
     def native_write_phys_mem(self, phys_address_hi, phys_address_lo, length, newval):
         if newval is None: return None
@@ -360,12 +357,8 @@ class LinuxHelper(Helper):
 
     def read_phys_mem(self, phys_address_hi, phys_address_lo, length):
         addr = (phys_address_hi << 32) | phys_address_lo
-        in_buf = struct.pack( '3'+self._pack,addr,length,0 )
-        if len(in_buf) < length:
-            in_buf += (length - len(in_buf)) * 'A'
-        out_buf = self.ioctl(IOCTL_READ_PHYSMEM, in_buf)
-        ret = struct.unpack(str(length)+'s', out_buf)
-        return ret[0]
+        self.dev_fh.seek(addr)
+        return self.__mem_block(length)
 
     def native_read_phys_mem(self, phys_address_hi, phys_address_lo, length):
         if self.devmem_available():

--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -1254,68 +1254,6 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 
         break;
     }
-
-	case IOCTL_READ_PHYSMEM:
-	{
-		// IN params : physical address, length
-		// OUT params : ptr to buffer
-		printk( KERN_INFO "[chipsec] > READMEM\n");
-
-		uint64_t NumberofBytes = 0;
-		phys_addr_t pa;
-		void *va; 
-
-		numargs = 3;
-
-		if(copy_from_user((void*)ptrbuf, (void*)ioctl_param, (sizeof(long) * numargs)) > 0)
-		{
-			printk( KERN_ALERT "[chipsec] ERROR: STATUS_INVALID_PARAMETER\n" );
-			break;
-		}
-
-		pa = ptr[0];
-		va = phys_to_virt(pa);
-		NumberofBytes = ptr[1];
-		
-		if ( pa == NULL || va == NULL )
-		{
-			printk( KERN_ALERT "[chipsec] ERROR: MEMORY is not allocated");
-			break;
- 		}
-
-		if ( copy_to_user((void*)ioctl_param,va,NumberofBytes) > 0){
-			printk( KERN_ALERT "[chipsec] ERROR: STATUS_UNSUCCESSFUL - could not read all memory");
-		}
-		break;
-	}
-
-	case IOCTL_WRITE_PHYSMEM:
-	{
-		// IN params : physical address, length, ptr to buffer
-		// OUT params : length
-		printk( KERN_INFO "[chipsec] > WRITEMEM\n");
-
-		uint64_t 	NumberofBytes = 0;
-		phys_addr_t 	pa;
-		void 		*va;
-		void		*buffer; 
-
-		numargs = 3;
-
-		if(copy_from_user((void*)ptrbuf, (void*)ioctl_param, (sizeof(long) * numargs)) > 0)
-		{
-			printk( KERN_ALERT "[chipsec] ERROR: STATUS_INVALID_PARAMETER\n" );
-			break;
-		}
-
-		pa = ptr[0];
-		va = phys_to_virt(pa);
-		NumberofBytes = ptr[1];
-		buffer = ioctl_param + (sizeof(long) * 2);
-		//printk ( KERN_INFO "Buffer %p\n",buffer );
-		copy_from_user( va, buffer, NumberofBytes );
-		break;
-	}
    
 #ifdef EFI_NOT_READY
 	case IOCTL_GET_EFIVAR:

--- a/drivers/linux/include/chipsec.h
+++ b/drivers/linux/include/chipsec.h
@@ -46,8 +46,6 @@ chipsec@intel.com
 #define IOCTL_VA2PA                    _IOWR(0, 0x14, int*)
 #define IOCTL_MSGBUS_SEND_MESSAGE      _IOWR(0, 0x15, int*)
 #define IOCTL_FREE_PHYSMEM             _IOWR(0, 0x16, int*)
-#define IOCTL_READ_PHYSMEM             _IOWR(0, 0x17, int*)
-#define IOCTL_WRITE_PHYSMEM            _IOWR(0, 0x18, int*)
 
 //
 // SoC IOSF Message Bus constants


### PR DESCRIPTION
This reverts commit 3c1c6906f9adf242c8a0863c28bea23ecf77da76.

The driver change was missing error handling.  Even after adding error handling other issues exist when running existing tests such as common.smrr.  Reverting for now.

Signed-off-by: Erik Bjorge <erik.c.bjorge@intel.com>