### PR TITLE
Disable support for the RWE driver by default.

### DIFF
--- a/chipsec/helper/helpers.py
+++ b/chipsec/helper/helpers.py
@@ -26,5 +26,6 @@ from chipsec.helper.efi import *
 from chipsec.helper.linux import *
 from chipsec.helper.osx import *
 from chipsec.helper.win import *
-from chipsec.helper.rwe import *
+# WARNING: Use of RWE driver has known issues. Experimental use only.
+#from chipsec.helper.rwe import *
 


### PR DESCRIPTION
Because of known issues using the RWE driver in chipsec it is being
disabled by default.  It can be enabled manually for experimental
development.

Signed-off-by: Erik Bjorge <erik.c.bjorge@intel.com>