### PR TITLE
Adding ability to specify PCH

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -367,8 +367,8 @@ class Chipset:
         self.helper.start(start_driver, driver_exists)
         logger().log( '[CHIPSEC] API mode: %s' % ('using OS native API (not using CHIPSEC kernel module)' if self.use_native_api() else 'using CHIPSEC kernel module API') )
 
+        self.vid, self.did, self.pch_vid, self.pch_did = self.detect_platform()
         if platform_code is None:
-            self.vid, self.did, self.pch_vid, self.pch_did = self.detect_platform()
             if VID_INTEL != self.vid:
                 _unknown_platform = True
         else:

--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -233,8 +233,8 @@ PCH_ID_1xx      = 10001
 PCH_ID_2xx      = 10002
 
 PCH_CODE_PREFIX = 'PCH_'
-PCH_CODE_1xx    = 'PCH_1xx'
-PCH_CODE_2xx    = 'PCH_2xx'
+PCH_CODE_1xx    = 'PCH_1XX'
+PCH_CODE_2xx    = 'PCH_2XX'
 
 pch_dictionary = {
 # 100 series PCH
@@ -264,6 +264,7 @@ except :
     pass
 
 Chipset_Code = dict( [(Chipset_Dictionary[ _did ]['code'], _did) for _did in Chipset_Dictionary] )
+pch_codes = dict([(pch_dictionary[_did]['code'], _did) for _did in pch_dictionary])
 
 def print_supported_chipsets():
     codes_dict = collections.defaultdict(list)
@@ -361,7 +362,7 @@ class Chipset:
             if logger().DEBUG: logger().error("pci.read_dword couldn't read PCH VID/DID")
         return (vid, did, pch_vid, pch_did)
 
-    def init( self, platform_code, start_driver, driver_exists=False ):
+    def init( self, platform_code, req_pch_code, start_driver, driver_exists=False ):
 
         _unknown_platform = False
         self.helper.start(start_driver, driver_exists)
@@ -373,11 +374,11 @@ class Chipset:
                 _unknown_platform = True
         else:
             self.vid = VID_INTEL
-            self.code = platform_code.lower()
             if Chipset_Code.has_key( platform_code ):
                 self.did = Chipset_Code[ platform_code ]
             else:
                 _unknown_platform = True
+                self.vid = 0xFFFF
                 self.did = 0xFFFF
 
         if Chipset_Dictionary.has_key( self.did ):
@@ -388,6 +389,14 @@ class Chipset:
         else:
             _unknown_platform = True
             self.longname   = 'UnknownPlatform'
+
+        if req_pch_code is not None:
+            self.pch_vid = VID_INTEL
+            if pch_codes.has_key(req_pch_code):
+                self.pch_did = pch_codes[req_pch_code]
+            else:
+                self.pch_vid = 0xFFFF
+                self.pch_did = 0xFFFF
 
         if self.pch_vid == VID_INTEL and pch_dictionary.has_key(self.pch_did):
             data_dict           = pch_dictionary[self.pch_did]

--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -170,6 +170,7 @@ class ChipsecMain:
         self._module               = None
         self._module_argv          = None
         self._platform             = None
+        self._pch                  = None
         self._driver_exists        = False
         self._no_driver            = False
         self._unkownPlatform       = True
@@ -469,6 +470,8 @@ class ChipsecMain:
 
     def usage(self):
         known_chipsets = "[ " + " | ".join(chipset.Chipset_Code) + " ]"
+        known_pch = "[ " + " | ".join(chipset.pch_codes) + " ]"
+        max_line_length = max(len(known_chipsets), len(known_pch)) + 1
         print "\n- Command Line Usage\n\t``# %.65s [options]``\n" % sys.argv[0]
         print "Options\n-------"
         print "====================== ====================================================="
@@ -479,9 +482,11 @@ class ChipsecMain:
         print "-l --log                output to log file"
         print "====================== ====================================================="
         print "\nAdvanced Options\n----------------"
-        print "======================== " + "=" * (len(known_chipsets) + 1)
+        print "======================== " + "=" * max_line_length
         print "-p --platform             explicitly specify platform code. Should be among the supported platforms:"
         print "                          %s" % known_chipsets
+        print "   --pch                  explicitly specify PCH code. Should be among the supported PCH:"
+        print "                          {}".format(known_pch)
         print "-n --no_driver            chipsec won't need kernel mode functions so don't load chipsec driver"
         print "-i --ignore_platform      run chipsec even if the platform is not recognized"
         print "-j --json                 specify filename for JSON output."
@@ -491,7 +496,7 @@ class ChipsecMain:
         print "-I --include              specify additional path to load modules from"
         print "   --failfast             fail on any exception and exit (don't mask exceptions)"
         print "   --no_time              don't log timestamps"
-        print "======================== " + "=" * (len(known_chipsets) + 1)
+        print "======================== " + "=" * max_line_length
         print "\nExit Code\n---------"
         print "CHIPSEC returns an integer exit code:\n"
         print "- Exit code is 0:       all modules ran successfully and passed"
@@ -512,9 +517,9 @@ class ChipsecMain:
         """
         try:
             opts, args = getopt.getopt(self.argv, "ip:m:ho:vda:nl:t:j:x:I:",
-            ["ignore_platform", "platform=", "module=", "help", "output=",
+            ["ignore_platform", "platform=", "pch=", "module=", "help", "output=",
               "verbose", "debug", "module_args=", "no_driver", "log=",
-              "moduletype=", "json=", "xml=","list_tags", "include", "failfast","no_time"])
+              "moduletype=", "json=", "xml=", "list_tags", "include", "failfast","no_time"])
         except getopt.GetoptError, err:
             print str(err)
             self.usage()
@@ -534,6 +539,8 @@ class ChipsecMain:
                 self._output = a
             elif o in ("-p", "--platform"):
                 self._platform = a.upper()
+            elif o in ("--pch"):
+                self._pch = a.upper()
             elif o in ("-m", "--module"):
                 #_module = a.lower()
                 self._module = a
@@ -586,7 +593,7 @@ class ChipsecMain:
             return ExitCode.EXCEPTION
 
         try:
-            self._cs.init( self._platform, (not self._no_driver), self._driver_exists )
+            self._cs.init( self._platform, self._pch, (not self._no_driver), self._driver_exists )
         except chipset.UnknownChipsetError , msg:
             logger().error( "Platform is not supported (%s)." % str(msg) )
             if self._unkownPlatform:

--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -70,6 +70,7 @@ class ChipsecUtil:
         self.CHIPSEC_LOADED_AS_EXE = True if (hasattr(sys, "frozen") or hasattr(sys, "importers")) else False
 
         self._platform       = None
+        self._pch            = None
         self._unkownPlatform = True
         self._no_driver      = False
 
@@ -90,6 +91,7 @@ class ChipsecUtil:
         Shows the list of available command line extensions
         """
         from chipsec.chipset import Chipset_Code
+        from chipsec.chipset import pch_codes
         logger().log("\nUsage:"
                      "\n\nchipsec_util.py [options] <command>"
                      "\n\nOptions:"
@@ -97,9 +99,11 @@ class ChipsecUtil:
                      "\n-d --debug            show debug output"
                      "\n-l --log              output to log file"
                      "\n-p --platform         platform code. Should be among the supported platforms:"
-                     "\n                      %s"
+                     "\n                      {}"
+                     "\n   --pch              PCH code. Should be among the supported PCH:"
+                     "\n                      {}"
                      "\n-n --no_driver        don't load chipsec kernel module"
-                     "\n-i --ignore_platform  run chipsec even if the platform is not recognized"  % Chipset_Code.keys())
+                     "\n-i --ignore_platform  run chipsec even if the platform is not recognized".format(Chipset_Code.keys(), pch_codes.keys()))
         logger().log("\nAll numeric values are in hex. <width> can be one of {1, byte, 2, word, 4, dword}")
 
         if command is None or command not in self.commands:
@@ -127,7 +131,7 @@ class ChipsecUtil:
     def parse_args(self):
         import getopt
         try:
-            opts, args = getopt.getopt(self.argv, "ip:h:vdnl:", ["ignore_platform", "platform=", "help=", "verbose", "debug", "no_driver", "log="])
+            opts, args = getopt.getopt(self.argv, "ip:h:vdnl:", ["ignore_platform", "platform=", "help=", "verbose", "debug", "no_driver", "log=", "pch="])
         except getopt.GetoptError, err:
             logger().error(str(err))
             self.chipsec_util_help()
@@ -145,6 +149,8 @@ class ChipsecUtil:
                 self.help_cmd  = a
             elif o in ("-p", "--platform"):
                 self._platform = a.upper()
+            elif o in ("--pch"):
+                self._pch = a.upper()
             elif o in ("-i", "--ignore_platform"):
                 self._unkownPlatform = False
                 logger().log( "[*] Ignoring unsupported platform warning and continue execution" )
@@ -210,7 +216,7 @@ class ChipsecUtil:
             comm = self.commands[cmd](self.argv, cs = self._cs)
 
             try:
-                self._cs.init( self._platform, comm.requires_driver() and not self._no_driver)
+                self._cs.init( self._platform, self._pch, comm.requires_driver() and not self._no_driver)
             except UnknownChipsetError, msg:
                 logger().warn("*******************************************************************")
                 logger().warn("* Unknown platform!")


### PR DESCRIPTION
Added the ability to select the PCH being used on a platform using the --pch <code> command line option.
Enabled auto detection of the PCH even when -p option is used.