### PR TITLE
Fix for issue #363

### DIFF
--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -544,6 +544,13 @@ int __weak phys_mem_access_prot_allowed(struct file *file,
         return 1;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,4)
+int valid_mmap_phys_addr_range(unsigned long pfn, size_t size)
+{
+	return 1;
+}
+#endif
+
 #ifndef ARCH_HAS_VALID_PHYS_ADDR_RANGE
 static inline int valid_phys_addr_range(phys_addr_t addr, size_t count)
 {


### PR DESCRIPTION
Defined function valid_mmap_phys_addr_range within linux driver if
kernel version is greater than 4.15.4