### PR TITLE
Memlock workaround for Atom processors on UEFI Shell

### DIFF
--- a/chipsec/modules/common/memlock.py
+++ b/chipsec/modules/common/memlock.py
@@ -47,9 +47,11 @@ class memlock(chipsec.module_common.BaseModule):
         BaseModule.__init__(self)
 
     def is_supported(self):
-        current_platform_id = self.cs.get_chipset_id()
-        supported = True
-        return supported
+        # Workaround for Atom based processors.  Accessing this MSR on these systems
+        # causes a GP fault and can't be caught in UEFI Shell.
+        if self.cs.get_chipset_id() in chipsec.chipset.CHIPSET_FAMILY_ATOM:
+            return False
+        return True
         
     def check_MSR_LT_LOCK_MEMORY( self ):
         self.logger.log( "[X] Checking MSR_LT_LOCK_MEMORY status" )


### PR DESCRIPTION
When accessing this MSR from the UEFI Shell the system will hang.
Skipping this test when running on Atom processors.

Signed-off-by: Erik Bjorge <erik.c.bjorge@intel.com>