### PR TITLE
Updated processing of variables with cert/key information

### DIFF
--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2016, Intel Corporation
+#Copyright (c) 2010-2018, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License

--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -85,14 +85,16 @@ def parse_script( script, log_script=False ):
 ########################################################################################################
 
 
-EFI_VAR_NAME_PK               = 'PK'
-EFI_VAR_NAME_KEK              = 'KEK'
-EFI_VAR_NAME_db               = 'db'
-EFI_VAR_NAME_dbx              = 'dbx'
-EFI_VAR_NAME_SecureBoot       = 'SecureBoot'
-EFI_VAR_NAME_SetupMode        = 'SetupMode'
-EFI_VAR_NAME_CustomMode       = 'CustomMode'
-EFI_VAR_NAME_SignatureSupport = 'SignatureSupport'
+EFI_VAR_NAME_PK                 = 'PK'
+EFI_VAR_NAME_KEK                = 'KEK'
+EFI_VAR_NAME_db                 = 'db'
+EFI_VAR_NAME_dbx                = 'dbx'
+EFI_VAR_NAME_SecureBoot         = 'SecureBoot'
+EFI_VAR_NAME_SetupMode          = 'SetupMode'
+EFI_VAR_NAME_CustomMode         = 'CustomMode'
+EFI_VAR_NAME_SignatureSupport   = 'SignatureSupport'
+EFI_VAR_NAME_certdb             = 'certdb'
+EFI_VAR_NAME_AuthVarKeyDatabase = 'AuthVarKeyDatabase'
 
 #
 # \MdePkg\Include\Guid\ImageAuthentication.h
@@ -130,7 +132,7 @@ EFI_VAR_NAME_SignatureSupport: EFI_GLOBAL_VARIABLE_GUID
 SECURE_BOOT_KEY_VARIABLES  = (EFI_VAR_NAME_PK, EFI_VAR_NAME_KEK, EFI_VAR_NAME_db, EFI_VAR_NAME_dbx)
 SECURE_BOOT_VARIABLES      = (EFI_VAR_NAME_SecureBoot, EFI_VAR_NAME_SetupMode) + SECURE_BOOT_KEY_VARIABLES
 SECURE_BOOT_VARIABLES_ALL  = (EFI_VAR_NAME_CustomMode, EFI_VAR_NAME_SignatureSupport) + SECURE_BOOT_VARIABLES
-AUTHENTICATED_VARIABLES    = ('AuthVarKeyDatabase', 'certdb') + SECURE_BOOT_KEY_VARIABLES
+AUTHENTICATED_VARIABLES    = (EFI_VAR_NAME_AuthVarKeyDatabase, EFI_VAR_NAME_certdb) + SECURE_BOOT_KEY_VARIABLES
 
 
 def get_auth_attr_string( attr ):
@@ -226,9 +228,12 @@ def decode_EFI_variables( efi_vars, nvram_pth ):
             attr_str = get_attr_string( attrs )
             var_fname = os.path.join( nvram_pth, '%s_%s_%s_%d.bin' % (name, guid, attr_str.strip(), n) )
             write_file( var_fname, data )
-            #if name in SECURE_BOOT_VARIABLES:
-            if name in AUTHENTICATED_VARIABLES:
-                parse_efivar_file( var_fname, data )
+            if name in SECURE_BOOT_VARIABLES:
+                parse_efivar_file(var_fname, data, SECURE_BOOT_SIG_VAR)
+            elif name == EFI_VAR_NAME_certdb:
+                parse_efivar_file(var_fname, data, AUTH_SIG_VAR)
+            elif name == EFI_VAR_NAME_AuthVarKeyDatabase:
+                parse_efivar_file(var_fname, data, ESAL_SIG_VAR)
             n = n+1
 
 

--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -228,7 +228,7 @@ def decode_EFI_variables( efi_vars, nvram_pth ):
             attr_str = get_attr_string( attrs )
             var_fname = os.path.join( nvram_pth, '%s_%s_%s_%d.bin' % (name, guid, attr_str.strip(), n) )
             write_file( var_fname, data )
-            if name in SECURE_BOOT_VARIABLES:
+            if name in SECURE_BOOT_KEY_VARIABLES:
                 parse_efivar_file(var_fname, data, SECURE_BOOT_SIG_VAR)
             elif name == EFI_VAR_NAME_certdb:
                 parse_efivar_file(var_fname, data, AUTH_SIG_VAR)

--- a/chipsec/hal/uefi_common.py
+++ b/chipsec/hal/uefi_common.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2016, Intel Corporation
+#Copyright (c) 2010-2018, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License

--- a/chipsec/hal/uefi_common.py
+++ b/chipsec/hal/uefi_common.py
@@ -913,6 +913,7 @@ AUTH_SIG_VAR        = 2
 ESAL_SIG_VAR        = 3
 
 def parse_efivar_file(fname, var=None, var_type=SECURE_BOOT_SIG_VAR):
+    logger().log('Processing certs in file: {}'.format(fname))
     if not var:
         var = read_file( fname )
     var_path = fname + '.dir'
@@ -923,7 +924,7 @@ def parse_efivar_file(fname, var=None, var_type=SECURE_BOOT_SIG_VAR):
     elif var_type == AUTH_SIG_VAR:
         parse_auth_var(var, var_path)
     else:
-        logger().warn('Unsupported variable type requested.')
+        logger().warn('Unsupported variable type requested: {}'.format(var_type))
 
 
 ########################################################################################################

--- a/chipsec/hal/uefi_common.py
+++ b/chipsec/hal/uefi_common.py
@@ -908,6 +908,30 @@ def parse_auth_var(db, decode_dir):
 
     return entries
 
+ESAL_SIG_SIZE = 256
+
+def parse_esal_var(db, decode_dir):
+    entries = []
+    dof = 0
+    nsig = 0
+    db_size = len(db)
+
+    # Check to see how many signatures exist
+    if db_size < ESAL_SIG_SIZE:
+        logger().log('No signatures present.')
+        return entries
+
+    # Extract signatures
+    while dof + ESAL_SIG_SIZE <= db_size:
+        key_data = db[dof:dof+ESAL_SIG_SIZE]
+        entries.append(key_data)
+        key_file_name = os.path.join(decode_dir,'AuthVarKeyDatabase-cert-{:02X}.bin'.format(nsig))
+        write_file(key_file_name, key_data)
+        dof += ESAL_SIG_SIZE
+        nsig += 1
+
+    return entries
+
 SECURE_BOOT_SIG_VAR = 1
 AUTH_SIG_VAR        = 2
 ESAL_SIG_VAR        = 3
@@ -923,6 +947,8 @@ def parse_efivar_file(fname, var=None, var_type=SECURE_BOOT_SIG_VAR):
         parse_sb_db(var, var_path)
     elif var_type == AUTH_SIG_VAR:
         parse_auth_var(var, var_path)
+    elif var_type == ESAL_SIG_VAR:
+        parse_esal_var(var, var_path)
     else:
         logger().warn('Unsupported variable type requested: {}'.format(var_type))
 


### PR DESCRIPTION
Not all cert/key variables have the same format.  Added individual processing routines for each variable format.  Additionally updated missing GUIDs for cert/key/hash types.