### PR TITLE
Prevent stack overflow when processing malformed compressed blobs

### DIFF
--- a/chipsec_tools/compression/Tiano/Decompress.c
+++ b/chipsec_tools/compression/Tiano/Decompress.c
@@ -260,7 +260,7 @@ Returns:
   for (Char = 0; Char < NumOfChar; Char++) {
 
     Len = BitLen[Char];
-    if (Len == 0) {
+    if (Len == 0 || Len >= 17) {
       continue;
     }
 


### PR DESCRIPTION
The CHIPSEC version of the Efi/Tiano Decompress function is missing a Len >= 17 check in MakeTable().

When the decompression function is running without the check present, malformed compressed blobs can result in reads and writes outside of the Start[] local stack variable allocation.

Here's an example of triggering this memory corruption issue with a small wrapper to load a file and call the decompression function:

$ ./dec sync/fuzzer09/crashes/id:000029,sig:11,src:000424,op:havoc,rep:2
*** stack smashing detected ***: <unknown> terminated
Aborted
$ xxd  sync/fuzzer09/crashes/id:000029,sig:11,src:000424,op:havoc,rep:2
00000000: 2500 0000 8811 0000 0611 73ed f469 baff  %.........s..i..
00000010: ff9a f7c0 4079 596c bb44 a5f5 3496 4fb6  ....@yYl.D..4.O.
00000020: ffff ff80 ffff ffff 87c9 38ff ec7a 8056  ..........8..z.V
00000030: f7c0 4079 596c be95 a5f5 3496            ..@yYl....4.
$
