### PR TITLE
Fix extra argument

### DIFF
--- a/chipsec/helper/linux/helper.py
+++ b/chipsec/helper/linux/helper.py
@@ -91,7 +91,7 @@ class MemoryMapping(mmap.mmap):
     This subclass keeps tracks of the start and end of the mapping.
     """
     def __init__(self, fileno, length, flags, prot, offset):
-        super(MemoryMapping, self).__init__(self, fileno, length, flags, prot,
+        super(MemoryMapping, self).__init__(fileno, length, flags, prot,
                                             offset=offset)
         self.start = offset
         self.end = offset + length


### PR DESCRIPTION
The self argument is a duplicate (super(...) will insert `self` as the first argument to any method -- just like an instance would).

Note: I suspect, but too lazy to check, that mmap.mmap.__init__ is a no-op, since otherwise this bug would have caused obvious runtime errors.