### PR TITLE
Fixed driver load issue for UEFI variable commands in Windows

### DIFF
--- a/chipsec/utilcmd/uefi_cmd.py
+++ b/chipsec/utilcmd/uefi_cmd.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2015, Intel Corporation
+#Copyright (c) 2010-2018, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -75,8 +75,15 @@ class UEFICommand(BaseCommand):
         # No driver required when printing the util documentation
         if len(self.argv) < 3:
             return False
-        op = self.argv[2]
-        return (op in ('tables','s3bootscript'))
+        # Always load the driver unless native mode is requested
+        load_driver = True
+        if '-n' in self.argv:
+            self.argv.remove('-n')
+            load_driver = False
+        # Driver is always required for these specific commands to run
+        if len(self.argv) >= 3 and self.argv[2] in ('tables','s3bootscript'):
+            load_driver = True
+        return load_driver
 
     def run(self):
         _uefi = UEFI( self.cs )


### PR DESCRIPTION
Changed to load the driver by default.  Allowed the addition of -n
to specify native mode.

Signed-off-by: Erik Bjorge <erik.c.bjorge@intel.com>