### PR TITLE
Add support for checking if ME Manufacturing Mode is enabled

### DIFF
--- a/chipsec/cfg/common.xml
+++ b/chipsec/cfg/common.xml
@@ -211,6 +211,12 @@
       <field name="SPD_WD"     bit="4" size="1"/>
     </register>
 
+    <!-- ME Host Firmware Status https://github.com/coreboot/coreboot/blob/master/src/southbridge/intel/*/{pch,me}.h -->
+    <register name="HFS" type="pcicfg" bus="0" dev="0x16" fun="0" offset="0x40" size="4" desc="ME Host Firmware Status">
+      <field name="MFG_MODE"   bit="4" size="1" desc="ME Manufacturing Mode" />
+      <field name="FW_INIT_COMPLETE"   bit="9" size="1" desc="ME Firmware Initialization Complete" />
+      <field name="UPDATE_IN_PROGRESS"   bit="11" size="1" desc="ME Update In Progress" />
+    </register>
 
     <!-- Memory-Mapped I/O (MMIO) Registers -->
 

--- a/chipsec/modules/common/me_mfg_mode.py
+++ b/chipsec/modules/common/me_mfg_mode.py
@@ -1,0 +1,103 @@
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2018, Eclypsium, Inc.
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+This module checks that ME Manufacturing mode is not enabled
+
+References:
+https://blog.ptsecurity.com/2018/10/intel-me-manufacturing-mode-macbook.html
+
+https://github.com/coreboot/coreboot/blob/master/src/soc/intel/*/include/soc/pci_devs.h
+
+	#define PCH_DEV_SLOT_CSE        0x16
+	#define  PCH_DEVFN_CSE          _PCH_DEVFN(CSE, 0)
+	#define  PCH_DEV_CSE            _PCH_DEV(CSE, 0)
+
+https://github.com/coreboot/coreboot/blob/master/src/soc/intel/apollolake/cse.c
+
+	fwsts1 = dump_status(1, PCI_ME_HFSTS1);
+
+	 /* Minimal decoding is done here in order to call out most important
+           pieces. Manufacturing mode needs to be locked down prior to shipping
+           the product so it's called out explicitly. */
+        printk(BIOS_DEBUG, "ME: Manufacturing Mode      : %s\n",
+                (fwsts1 & (1 << 0x4)) ? "YES" : "NO");
+
+https://github.com/coreboot/coreboot/blob/master/src/southbridge/intel/*/pch.h
+
+	#define PCH_ME_DEV                PCI_DEV(0, 0x16, 0)
+
+https://github.com/coreboot/coreboot/blob/master/src/southbridge/intel/*/me.h
+
+	struct me_hfs {
+	        u32 working_state: 4;
+	        u32 mfg_mode: 1;
+	        u32 fpt_bad: 1;
+	        u32 operation_state: 3;
+	        u32 fw_init_complete: 1;
+	        u32 ft_bup_ld_flr: 1;
+	        u32 update_in_progress: 1;
+	        u32 error_code: 4;
+	        u32 operation_mode: 4;
+	        u32 reserved: 4;
+	        u32 boot_options_present: 1;
+	        u32 ack_data: 3;
+	        u32 bios_msg_ack: 4;
+	} __packed;
+
+https://github.com/coreboot/coreboot/blob/master/src/southbridge/intel/*/me_status.c
+
+	 printk(BIOS_DEBUG, "ME: Manufacturing Mode      : %s\n",
+               hfs->mfg_mode ? "YES" : "NO");
+
+This module checks the following:
+- HFS.MFG_MODE BDF: 0:22:0 offset 0x40 - Bit [4]
+
+The module returns the following results:
+FAILED : HFS.MFG_MODE is set
+PASSED : HFS.MFG_MODE is not set.
+
+Hardware registers used:
+HFS
+"""
+
+from chipsec.module_common import *
+
+class me_mfg_mode(BaseModule):
+
+    def __init__(self):
+        BaseModule.__init__(self)
+
+    def is_supported(self):
+        return self.cs.is_device_enabled("MEI1")
+
+    def check_me_mfg_mode(self):
+        self.logger.start_test( "ME Manufacturing Mode" )
+
+        me_mfg_mode_res = ModuleResult.FAILED
+        me_hfs_reg = self.cs.read_register( 'HFS' )
+        me_mfg_mode = self.cs.get_register_field( 'HFS', me_hfs_reg, 'MFG_MODE' )
+
+        if 0 == me_mfg_mode:
+            me_mfg_mode_res = ModuleResult.PASSED
+            self.logger.log_passed_check( "ME is not in Manufacturing Mode" )
+        else:
+            self.logger.log_failed_check( "ME is in Manufacturing Mode" )
+
+        return me_mfg_mode_res
+
+    def run( self, module_argv ):
+        return self.check_me_mfg_mode()


### PR DESCRIPTION
There have been vulnerabilities recently identified where some production systems are shipped to customers with ME Manufacturing Mode still enabled:
https://blog.ptsecurity.com/2018/10/intel-me-manufacturing-mode-macbook.html

This check was implemented based on the publicly-available info in the coreboot source repository:
https://github.com/coreboot/coreboot/blob/master/src/southbridge/intel/lynxpoint/me.h
https://github.com/coreboot/coreboot/blob/master/src/southbridge/intel/lynxpoint/me_status.c