### PR TITLE
CoffeeLake support

### DIFF
--- a/chipsec/cfg/cfl.xml
+++ b/chipsec/cfg/cfl.xml
@@ -26,7 +26,7 @@
     <bar name="HDABAR"   bus="0" dev="0x1F" fun="3" reg="0x10" width="8" mask="0xFFFFFFFFFFFFC000" size="0x1000" desc="HD Audio Base"/> 
     <bar name="SPIBAR"   bus="0" dev="0x1F" fun="5" reg="0x10" width="4" mask="0xFFFFF000"         size="0x1000" desc="SPI Controller Register Range" offset="0x0"/>
     <bar name="PWRMBASE" register="PWRMBASE" base_field="BA" size="0x1000" desc="Power Management Register Range"/>
-    <bar name="SBREGBAR" register="SBREG_BAR" base_field="RBA" size="0x1000000" desc="Sideband Register Access BAR"/>
+    <bar name="SBREGBAR" register="SBREG_BAR" base_field="RBA" fixed_address="0xFD000000" size="0x1000000" desc="Sideband Register Access BAR"/>
   </mmio>
 
   <!-- #################################### -->
@@ -35,9 +35,9 @@
   <!--                                      -->
   <!-- #################################### -->
   <io>
-    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x100" desc="ACPI Base Address"/>
-    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x100" desc="ACPI Base Address"/>
-    <bar name="TCOBASE"    register="TCOBASE"  base_field="TCOBA" size="0x20"  desc="TCO Base Address"/>
+    <bar name="ABASE"      register="PMC_SHDW_BAR4" base_field="BA"     size="0x100" desc="ACPI Base Address"/>
+    <bar name="PMBASE"     register="PMC_SHDW_BAR4" base_field="BA"     size="0x100" desc="ACPI Base Address"/>
+    <bar name="TCOBASE"    register="TCOBASE"       base_field="TCOBA"  size="0x20"  desc="TCO Base Address"/>
 
     <!-- old definition -->
     <bar name="SMBUS_BASE" bus="0" dev="0x1F" fun="4" reg="0x20" mask="0xFFE0"     size="0x80"  desc="SMBus Base Address"/>
@@ -66,29 +66,24 @@
     <register name="SBREG_BAR" type="pcicfg" bus="0" dev="0x1F" fun="1" offset="0x10" size="4" desc="Sideband Register Access BAR">
       <field name="RBA" bit="24" size="8" desc="Register Base Address"/>
     </register>
-
-    <register name="P2SBC" type="pcicfg" bus="0" dev="0x1F" fun="1" offset="0xE0" size="2" desc="P2SB Configuration Register">
-      <field name="HIDE" bit="8" size="1" desc="Hide SBREG_BAR"/>
-    </register>
-    <register name="P2SB_HIDE" type="pcicfg" bus="0" dev="0x1F" fun="1" offset="0xE1" size="1" desc="P2SB Configuration Register hide-unhide">
-      <field name="HIDE" bit="0" size="1" desc="Hide SBREG_BAR"/>
-    </register>
+    <!-- Since mm_msgbus needs SBREG_BAR we can't use mm_msgbus to get it...but it is at this position
+      <register name="SBREG_BAR" type="mm_msgbus" port="0xBC" offset="0x0900" size="4" desc="Sideband Register Access BAR">
+      <field name="RBA" bit="24" size="8" desc="Register Base Address"/>
+    </register>-->
 
     <!-- Power Management Controller -->
-    <register name="ABASE" type="pcicfg" bus="0" dev="0x1f" fun="2" offset="0x40" size="4" desc="ACPI Base Address">
-      <field name="STYPE" bit="0" size="1" desc="Space Type (always 1 - I/O space)"/>
-      <field name="BA"    bit="8" size="8" desc="Base Address"/>
-    </register>
     <register name="ACTL" type="pcicfg" bus="0" dev="0x1f" fun="2" offset="0x44" size="4" desc="ACPI Control">
       <field name="SCIS"    bit="0" size="2" desc="SCI IRQ Select"/>
       <field name="EN"      bit="7" size="1" desc="ACPI Enable"/>
       <field name="PWRM_EN" bit="8" size="1" desc="PWRM Enable"/>
     </register>
-    <register name="PWRMBASE" type="pcicfg" bus="0" dev="0x1f" fun="2" offset="0x48" size="4" desc="PM Base Address">
-      <field name="STYPE" bit="0"  size="1"  desc="Space Type (always 0 - memory space)"/>
-      <field name="BA"    bit="12" size="20" desc="Base Address"/>
+    <register name="PWRMBASE" type="mm_msgbus" port="0xBC" offset="0x0980" size="4" desc="PMC BAR0 PWRMBASE">
+      <field name="BA" bit="0" size="32" desc="PWRMBASE"/>
     </register>
-    <register name="GEN_PMCON_1" type="pcicfg" bus="0" dev="0x1f" fun="2" offset="0xA0" size="2" desc="General PM Configuration A">
+    <register name="PMC_SHDW_BAR4" type="mm_msgbus" port="0xBC" offset="0x0990" size="4" desc="PMC BAR4 ABASE">
+      <field name="BA" bit="0" size="32" desc="ABASE"/>
+    </register>
+    <register name="GEN_PMCON_1" type="mmio" bar="PWRMBASE" offset="0x1024" size="4" desc="General PM Configuration B">
       <field name="SMI_LOCK"    bit="4"     size="1"/>
     </register>
 
@@ -197,6 +192,7 @@
       <field name="UL"   bit="4"  size="1" desc="Upper 128 Byte Lock"/>
       <field name="BILD" bit="31" size="1" desc="BIOS Interface Lock-Down"/>
     </register>
+
     <register name="BUC" type="mm_msgbus" port="0xC3" offset="0x3414" size="4" desc="Backed Up Control">
       <field name="TS" bit="0" size="1" desc="Top Swap"/>
     </register>


### PR DESCRIPTION
Support for CoffeeLake, uses SBREGBAR = 0xFD000000, gets ABASE/PMBASE via msgbus, GEN_PMCON_1 via MMIO.