### PR TITLE
Force string type when collecting testcase output

### DIFF
--- a/chipsec/testcase.py
+++ b/chipsec/testcase.py
@@ -204,7 +204,7 @@ class TestCase():
         self.time = None
         
     def add_output(self, text):
-		self.output += text
+		self.output += str(text)
 		
     def add_result(self, result):
         self.result = result


### PR DESCRIPTION
Make sure that objects are converted to string representations.

Signed-off-by: Erik Bjorge <erik.c.bjorge@intel.com>