### PR TITLE
Address issue #386

### DIFF
--- a/chipsec/hal/mmio.py
+++ b/chipsec/hal/mmio.py
@@ -222,7 +222,6 @@ class MMIO(hal_base.HALBase):
     #
     def read_MMIOBAR_reg(self, bar_id, offset ):
         bar_base  = self.MMIO_BAR_base[ bar_id ]
-        #reg_addr  = bar_base + offset
         reg_value = self.cs.helper.read_mmio_reg( bar_base, 4, offset )
         if logger().VERBOSE:
             logger().log( '[mmio] %s + 0x%08X (0x%08X) = 0x%08X' % (MMIO_BAR_name[bar_id], offset, reg_addr, reg_value) )

--- a/chipsec/helper/linux/helper.py
+++ b/chipsec/helper/linux/helper.py
@@ -554,7 +554,8 @@ class LinuxHelper(Helper):
             if not region:
                 self.native_map_io_space(bar_base, bar_size)
                 region = self.memory_mapping(bar_base, bar_size)
-            region.seek(phys_address - region.start)
+                if not region: logger().error("Unable to map region {:08x}".format(bar_base))
+            region.seek(bar_base + offset - region.start)
             reg = region.read(size)
             return defines.unpack1(reg, size)
 
@@ -570,7 +571,8 @@ class LinuxHelper(Helper):
             if not region:
                 self.native_map_io_space(bar_base, bar_size)
                 region = self.memory_mapping(bar_base, bar_size)
-            region.seek(phys_address - region.start)
+                if not region: logger().error("Unable to map region {:08x}".format(bar_base))
+            region.seek(bar_base + offset - region.start)
             region.write(reg)                
             if written != size:
                 logger().error("Unable to write all data to MMIO (wrote %d of %d)" % (written, size))

--- a/chipsec/helper/linux/helper.py
+++ b/chipsec/helper/linux/helper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2018, Intel Corporation
+#Copyright (c) 2010-2019, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -314,7 +314,7 @@ class LinuxHelper(Helper):
                 return region
         return None
 
-    def native_map_io_space(self, base, size, unused_cache_type):
+    def native_map_io_space(self, base, size):
         """Map to memory a specific region."""
         if self.devmem_available() and not self.memory_mapping(base, size):
             if logger().VERBOSE:
@@ -547,33 +547,34 @@ class LinuxHelper(Helper):
         reg = out_buf[:size]
         return defines.unpack1(reg, size)
 
-    def native_read_mmio_reg(self, phys_address, size):
+    def native_read_mmio_reg(self, bar_base, bar_size, offset, size):
+        if bar_size is None: bar_size = offset + size
         if self.devmem_available():
-            region = self.memory_mapping(phys_address, size)
+            region = self.memory_mapping(bar_base, bar_size)
             if not region:
-                os.lseek(self.dev_mem, phys_address, os.SEEK_SET)
-                reg = os.read(self.dev_mem, size)
-            else:
-                region.seek(phys_address - region.start)
-                reg = region.read(size)
+                self.native_map_io_space(bar_base, bar_size)
+                region = self.memory_mapping(bar_base, bar_size)
+            region.seek(phys_address - region.start)
+            reg = region.read(size)
             return defines.unpack1(reg, size)
 
     def write_mmio_reg(self, phys_address, size, value):
         in_buf = struct.pack( "3"+self._pack, phys_address, size, value )
         out_buf = self.ioctl(IOCTL_WRMMIO, in_buf)
 
-    def native_write_mmio_reg(self, phys_address, size, value):
+    def native_write_mmio_reg(self, bar_base, bar_size, offset, size, value):
+        if bar_size is None: bar_size = offset + size
         if self.devmem_available():
             reg = defines.pack1(value, size)
-            region = self.memory_mapping(phys_address, size)
+            region = self.memory_mapping(bar_base, bar_size)
             if not region:
-                os.lseek(self.dev_mem, phys_address, os.SEEK_SET)
-                written = os.write(self.dev_mem, reg)
-                if written != size:
-                    logger().error("Unable to write all data to MMIO (wrote %d of %d)" % (written, size))
-            else:
-                region.seek(phys_address - region.start)
-                region.write(reg)
+                self.native_map_io_space(bar_base, bar_size)
+                region = self.memory_mapping(bar_base, bar_size)
+            region.seek(phys_address - region.start)
+            region.write(reg)                
+            if written != size:
+                logger().error("Unable to write all data to MMIO (wrote %d of %d)" % (written, size))
+
 
     def get_ACPI_SDT( self ):
         raise UnimplementedAPIError( "get_ACPI_SDT" )

--- a/chipsec/helper/oshelper.py
+++ b/chipsec/helper/oshelper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2018, Intel Corporation
+#Copyright (c) 2010-2019, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -202,17 +202,17 @@ class OsHelper:
     #
     # read/write mmio
     #
-    def read_mmio_reg( self, phys_address, size ):
+    def read_mmio_reg( self, bar_base, size, offset=0, bar_size=None ):
         if self.use_native_api() and hasattr(self.helper, 'native_read_mmio_reg'):
-            return self.helper.native_read_mmio_reg( phys_address, size )
+            return self.helper.native_read_mmio_reg( bar_base, bar_size, offset, size )
         else:
-            return self.helper.read_mmio_reg( phys_address, size )
+            return self.helper.read_mmio_reg( bar_base+offset, size )
         
-    def write_mmio_reg( self, phys_address, size, value ):
+    def write_mmio_reg( self, bar_base, size, value, offset=0, bar_size=None ):
         if self.use_native_api() and hasattr(self.helper, 'native_write_mmio_reg'):
-            return self.helper.native_write_mmio_reg( phys_address, size, value )
+            return self.helper.native_write_mmio_reg( bar_base, bar_size, offset, size, value )
         else:
-            return self.helper.write_mmio_reg( phys_address, size, value )
+            return self.helper.write_mmio_reg(bar_base+offset, size, value )
         
     #
     # physical_address is 64 bit integer

--- a/chipsec/utilcmd/mmcfg_cmd.py
+++ b/chipsec/utilcmd/mmcfg_cmd.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2015, Intel Corporation
+#Copyright (c) 2010-2019, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -53,7 +53,7 @@ class MMCfgCommand(BaseCommand):
 
         if 2 == len(self.argv):
             #pciexbar = _mmio.get_PCIEXBAR_base_address()
-            pciexbar = _mmio.get_MMCFG_base_address()
+            pciexbar, pciexbar_sz = _mmio.get_MMCFG_base_address()
             self.logger.log( "[CHIPSEC] Memory Mapped Config Base: 0x%016X" % pciexbar )
             return
         elif 6 > len(self.argv):

--- a/chipsec/utilcmd/mmcfg_cmd.py
+++ b/chipsec/utilcmd/mmcfg_cmd.py
@@ -55,6 +55,7 @@ class MMCfgCommand(BaseCommand):
             #pciexbar = _mmio.get_PCIEXBAR_base_address()
             pciexbar, pciexbar_sz = _mmio.get_MMCFG_base_address()
             self.logger.log( "[CHIPSEC] Memory Mapped Config Base: 0x%016X" % pciexbar )
+            if self.logger.VERBOSE: self.logger.log("[CHIPSEC] Memory Mapped Config Size: {:016X}".format(pciebar_sz))
             return
         elif 6 > len(self.argv):
             print MMCfgCommand.__doc__


### PR DESCRIPTION
Found that native linux helper needs to first map io memory before reading it
    -  changed hal and helper functionality to allow base address and offset to be passed
  to the function allowing the call to native_map_io_space to be used without guessing the base address
Discovered a bug within hal list_MMIO_BARs that failed if a MMIOBAR was unreadable 
    -  added a try except to fix