### PR TITLE
Removing python brew command for MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       language: generic
       install:
         - brew update
-        - brew install python@2 nasm
+        - brew install nasm
 
 script:
   - python setup.py test


### PR DESCRIPTION
It seems that python 2 is already installed on MacOS builds.

Signed-off-by: Erik Bjorge <erik.c.bjorge@intel.com>