### PR TITLE
detect legacy BIOS on win7+    fix for issue #306

### DIFF
--- a/chipsec/helper/win/win32helper.py
+++ b/chipsec/helper/win/win32helper.py
@@ -723,8 +723,8 @@ class Win32Helper(Helper):
     # EFI Variable API
     #
     def EFI_supported( self):
-        # @TODO: use GetFirmwareType ?
-        return ((self.GetFirmwareEnvironmentVariable is not None) or (self.GetFirmwareEnvironmentVariableEx is not None))
+        # GetFirmwareEnvironmentVariable with garbage parameters will return 0 reliably on a legacy system
+        return self.GetFirmwareEnvironmentVariable("","{00000000-0000-0000-0000-000000000000}",0,0) !=0
 
     def get_EFI_variable_full( self, name, guid, attrs=None ):
         status = 0 # EFI_SUCCESS


### PR DESCRIPTION
https://gallery.technet.microsoft.com/scriptcenter/Determine-UEFI-or-Legacy-7dc79488

For Windows 7/Server 2008R2 and above, the GetFirmwareEnvironmentVariable Win32 API (designed to extract firmware environment variables) can be used.  This API is not supported on non-UEFI firmware and will fail in a predictable way when called - this will identify a legacy BIOS.  On UEFI firmware, the API can be called with dummy parameters, and while it will still fail (probably!) the resulting error code will be different from the legacy BIOS case.