### PR TITLE
detect legacy BIOS on win7+ fix for issue #306

### DIFF
--- a/chipsec/helper/win/win32helper.py
+++ b/chipsec/helper/win/win32helper.py
@@ -723,9 +723,15 @@ class Win32Helper(Helper):
     # EFI Variable API
     #
     def EFI_supported( self):
-        # kern32.GetFirmwareEnvironmentVariable with garbage parameters will return error = 1 reliably on a legacy system
-        self.GetFirmwareEnvironmentVariable("","{00000000-0000-0000-0000-000000000000}",0,0)
-        return win32api.GetLastError() !=1
+        # kern32.GetFirmwareEnvironmentVariable with garbage parameters will cause GetLastError() == 1 reliably on a legacy system
+        if self.GetFirmwareEnvironmentVariable is not None:
+            self.GetFirmwareEnvironmentVariable("","{00000000-0000-0000-0000-000000000000}",0,0)
+            return win32api.GetLastError() !=1
+        elif self.GetFirmwareEnvironmentVariableEx is not None:
+            self.GetFirmwareEnvironmentVariableEx("","{00000000-0000-0000-0000-000000000000}",0,0)
+            return win32api.GetLastError() !=1
+        else:
+            return False
 
     def get_EFI_variable_full( self, name, guid, attrs=None ):
         status = 0 # EFI_SUCCESS

--- a/chipsec/helper/win/win32helper.py
+++ b/chipsec/helper/win/win32helper.py
@@ -723,8 +723,9 @@ class Win32Helper(Helper):
     # EFI Variable API
     #
     def EFI_supported( self):
-        # GetFirmwareEnvironmentVariable with garbage parameters will return 0 reliably on a legacy system
-        return self.GetFirmwareEnvironmentVariable("","{00000000-0000-0000-0000-000000000000}",0,0) !=0
+        # kern32.GetFirmwareEnvironmentVariable with garbage parameters will return error = 1 reliably on a legacy system
+        self.GetFirmwareEnvironmentVariable("","{00000000-0000-0000-0000-000000000000}",0,0)
+        return win32api.GetLastError() !=1
 
     def get_EFI_variable_full( self, name, guid, attrs=None ):
         status = 0 # EFI_SUCCESS

--- a/chipsec/helper/win/win32helper.py
+++ b/chipsec/helper/win/win32helper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2016, Intel Corporation
+#Copyright (c) 2010-2019, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -25,7 +25,7 @@
 # -------------------------------------------------------------------------------
 #
 # CHIPSEC: Platform Hardware Security Assessment Framework
-# (c) 2010-2012 Intel Corporation
+# (c) 2010-2019 Intel Corporation
 #
 # -------------------------------------------------------------------------------
 

--- a/chipsec/helper/win/win32helper.py
+++ b/chipsec/helper/win/win32helper.py
@@ -723,8 +723,8 @@ class Win32Helper(Helper):
     # EFI Variable API
     #
     def EFI_supported( self):
-        # @TODO: use GetFirmwareType ?
-        return ((self.GetFirmwareEnvironmentVariable is not None) or (self.GetFirmwareEnvironmentVariableEx is not None))
+        # GetFirmwareEnvironmentVariable with garbage parameters will return 0 reliably on a legacy system
+        return self.GetFirmwareEnvironmentVariable("","{00000000-0000-0000-0000-000000000000}",0,0) !=0
 
     def get_EFI_variable_full( self, name, guid, attrs=None ):
         status = 0 # EFI_SUCCESS


### PR DESCRIPTION
https://gallery.technet.microsoft.com/scriptcenter/Determine-UEFI-or-Legacy-7dc79488

For Windows 7/Server 2008R2 and above, the GetFirmwareEnvironmentVariable Win32 API (designed to extract firmware environment variables) can be used. This API is not supported on non-UEFI firmware and will fail in a predictable way when called - this will identify a legacy BIOS. On UEFI firmware, the API can be called with dummy parameters, and while it will still fail (probably!) the resulting error code will be different from the legacy BIOS case.