### PR TITLE
Added check to see if S3 Boot script was found

### DIFF
--- a/chipsec/modules/tools/uefi/s3script_modify.py
+++ b/chipsec/modules/tools/uefi/s3script_modify.py
@@ -148,6 +148,9 @@ class s3script_modify(BaseModule):
 
     def modify_s3_reg( self, opcode, address, new_value ):
         (bootscript_PAs, parsed_scripts) = self.get_bootscript()
+        if parsed_scripts is None: 
+            self.logger.log_bad("Did not find boot script.")
+            return False
         for bootscript_pa in bootscript_PAs:
             if (bootscript_pa == 0): continue
             self.logger.log( "[*] Looking for 0x%X opcode in the script at 0x%016X.." % (opcode,bootscript_pa) )
@@ -193,6 +196,9 @@ class s3script_modify(BaseModule):
         print_buffer( new_ep )
 
         (bootscript_PAs, parsed_scripts) = self.get_bootscript()
+        if parsed_scripts is None: 
+            self.logger.log_bad("Did not find boot script.")
+            return False 
         for bootscript_pa in bootscript_PAs:
             if (bootscript_pa == 0): continue
             self.logger.log( "[*] Searching the script at 0x%016X for DISPATCH opcodes.." % bootscript_pa )
@@ -225,6 +231,9 @@ class s3script_modify(BaseModule):
     def modify_s3_dispatch_ep( self ):
         ep_pa = None
         (bootscript_PAs, parsed_scripts) = self.get_bootscript()
+        if parsed_scripts is None: 
+            self.logger.log_bad("Did not find boot script.")
+            return False 
         for script_pa in bootscript_PAs:
             if (script_pa == 0): continue
             self.logger.log( "[*] Looking for DISPATCH opcode in the script at 0x%016X.." % script_pa )
@@ -259,6 +268,9 @@ class s3script_modify(BaseModule):
         self.logger.log( "[*] Original value at 0x%016X: 0x%08X" % (address,val) )
 
         (bootscript_PAs, parsed_scripts) = self.get_bootscript()
+        if parsed_scripts is None: 
+            self.logger.log_bad("Did not find boot script.")
+            return False 
         for bootscript_pa in bootscript_PAs:
             if (bootscript_pa == 0): continue
             self.logger.log( "[*] Looking for MEM_WRITE opcode in the script at 0x%016X.." % bootscript_pa )
@@ -292,7 +304,9 @@ class s3script_modify(BaseModule):
     def modify_s3_add(self, new_opcode):
         e_index = None
         (bootscript_PAs, parsed_scripts) = self.get_bootscript()
-
+        if parsed_scripts is None: 
+            self.logger.log_bad("Did not find boot script.")
+            return False 
         for bootscript_pa in bootscript_PAs:
             if (bootscript_pa == 0): continue
             script_buffer = self.cs.mem.read_physical_mem( bootscript_pa, 4 )


### PR DESCRIPTION
If the S3 boot script was not found, it will tell the user that instead of giving a false error.

Signed-off-by: Nathaniel Mitchell <nathaniel.p.mitchell@intel.com>