### PR TITLE
Correct duplicate conditional statement

### DIFF
--- a/chipsec/helper/rwe/rwehelper.py
+++ b/chipsec/helper/rwe/rwehelper.py
@@ -313,7 +313,7 @@ class RweHelper(Helper):
             self.SetFirmwareEnvironmentVariableEx.restype = c_int
             self.SetFirmwareEnvironmentVariableEx.argtypes = [c_wchar_p, c_wchar_p, c_void_p, c_int, c_int]
         except AttributeError, msg:
-            if logger().DEBUG: if logger().DEBUG: logger().warn( "G[S]etFirmwareEnvironmentVariableExW function doesn't seem to exist" )
+            if logger().DEBUG: logger().warn( "G[S]etFirmwareEnvironmentVariableExW function doesn't seem to exist" )
             pass
 
         try:


### PR DESCRIPTION
- Remove duplicated `if logger().DEBUG:` text