### PR TITLE
Register definition updates

### DIFF
--- a/chipsec/cfg/bdx.xml
+++ b/chipsec/cfg/bdx.xml
@@ -173,15 +173,6 @@ Intel (c) C610 Series Chipset and Intel (c) X99 Chipset Platform Controller Hub 
       <field name="DTI"          bit="28" size="4"  desc="Device Type Identifier" />
     </register>
 
-
-    <!-- LPC Interface Bridge -->
-    <register name="GEN_PMCON_LOCK" type="pcicfg" device="LPC" offset="0xA6" size="1" desc="General Power Management Configuration Lock">
-      <field name="ACPI_BASE_LOCK"   bit="1" size="1" desc="Lock down ACPI Base Address (ABASE)"/>
-      <field name="SLP_STR_POL_LOCK" bit="2" size="1" desc="SLP Stretching Policy Lock-Down"/>
-    </register>
-
-    <!-- PCH Root Complex Register Base MMIO registers -->
-
     <!-- PCH ABASE (PMBASE) I/O registers -->
     <register name="SMI_EN" type="iobar" bar="ABASE" offset="0x30" size="4" desc="SMI Control and Enable">
       <field name="GBL_SMI_EN"         bit="0"  size="1"/>

--- a/chipsec/cfg/hsx.xml
+++ b/chipsec/cfg/hsx.xml
@@ -173,15 +173,6 @@ Intel (c) C610 Series Chipset and Intel (c) X99 Chipset Platform Controller Hub 
       <field name="DTI"          bit="28" size="4"  desc="Device Type Identifier" />
     </register>
 
-
-    <!-- LPC Interface Bridge -->
-    <register name="GEN_PMCON_LOCK" type="pcicfg" device="LPC" offset="0xA6" size="1" desc="General Power Management Configuration Lock">
-      <field name="ACPI_BASE_LOCK"   bit="1" size="1" desc="Lock down ACPI Base Address (ABASE)"/>
-      <field name="SLP_STR_POL_LOCK" bit="2" size="1" desc="SLP Stretching Policy Lock-Down"/>
-    </register>
-
-    <!-- PCH Root Complex Register Base MMIO registers -->
-
     <!-- PCH ABASE (PMBASE) I/O registers -->
     <register name="SMI_EN" type="iobar" bar="ABASE" offset="0x30" size="4" desc="SMI Control and Enable">
       <field name="GBL_SMI_EN"         bit="0"  size="1"/>

--- a/chipsec/cfg/pch_c60x.xml
+++ b/chipsec/cfg/pch_c60x.xml
@@ -39,4 +39,8 @@ XML configuration file for C600 series PCH
 
   </registers>
 
+  <controls>
+    <control name="ACPIBaseLock" register="GEN_PMCON_LOCK" field="ACPI_BASE_LOCK" desc="Lock Down ACPI Base Address" />
+  </controls>
+
 </configuration>

--- a/chipsec/cfg/pch_c61x.xml
+++ b/chipsec/cfg/pch_c61x.xml
@@ -42,4 +42,8 @@ XML configuration file for C610 series PCH
 
   </registers>
 
+  <controls>
+    <control name="ACPIBaseLock" register="GEN_PMCON_LOCK" field="ACPI_BASE_LOCK" desc="Lock Down ACPI Base Address" />
+  </controls>
+
 </configuration>

--- a/chipsec/cfg/pch_c620.xml
+++ b/chipsec/cfg/pch_c620.xml
@@ -371,6 +371,7 @@ XML configuration file for
   <controls>
     <control name="BiosInterfaceLockDown"  register="BC"    field="BILD"    desc="BIOS Interface Lock-Down"/>
     <control name="SpiWriteStatusDis"      register="HSFS"  field="WRSDIS"  desc="Write Status Disable"/>
+    <control name="ACPIBaseLock" register="GEN_PMCON_B" field="ACPI_BASE_LOCK" desc="Lock Down ACPI Base Address" />
   </controls>
 
 </configuration>


### PR DESCRIPTION
Added ACPIBaseLock control and removed duplicated register
definition from bdx and hsx platforms

Signed-off-by: Ignacio Hernandez <ignacio.hernandez@intel.com>