### PR TITLE
Pylint cleanup of hal modules

### DIFF
--- a/chipsec/hal/acpi.py
+++ b/chipsec/hal/acpi.py
@@ -232,7 +232,7 @@ class RSDP():
                       "  XSDT Address     : 0x{:016X}\n"
                       "  Extended Checksum: 0x{:02X}\n"
                       "  Reserved         : {}\n"
-                     ).format(self.Length, self.XsdtAddress, self.ExtChecksum, self.Reserved.hex() if ( type(self.Reserved) == type(bytes())) else self.Reserved.encode("hex"))
+                     ).format(self.Length, self.XsdtAddress, self.ExtChecksum, self.Reserved.encode("hex") if ( isinstance(self.Reserved,str) ) else self.Reserved.hex() )
         return default
 
     # some sanity checking on RSDP
@@ -487,7 +487,7 @@ class ACPI(hal_base.HALBase):
     def get_ACPI_table( self, name, isfile = False ):
         acpi_tables_data = []
         if isfile:
-            acpi_tables_data.append(chipsec.file.read_file( name ))
+            acpi_tables_data.append(read_file( name ))
         else:
             try:
                 # 1. Try to extract ACPI table(s) from physical memory

--- a/chipsec/hal/acpi_tables.py
+++ b/chipsec/hal/acpi_tables.py
@@ -1177,7 +1177,7 @@ class HEST (ACPI_TABLE):
 	""".format( sourceID, reserved1, flags , firmware_first , firmware_first_str, ghes_assist , ghes_assist_str, enabled, recordsToPreAllocate, maxSectorsPerRecord, globalCapabilityInitData, numHardwareBanks, reserved2_1, reserved2_2, reserved2_3, reserved2_4, reserved2_5, reserved2_6, reserved2_7 ) )
         curBankNum = 0
         while curBankNum < numHardwareBanks:
-            machineBankParser(table_content[40 + i*28:40 + (i+1)*28])
+            self.machineBankParser(table_content[40 + curBankNum*28:40 + (curBankNum+1)*28])
             curBankNum += 1
         return 40 + numHardwareBanks*28
 	
@@ -1236,7 +1236,7 @@ class HEST (ACPI_TABLE):
 	""".format( title, sourceID,  reserved1, flags, flags_str, firmware_first , firmware_first_str, ghes_assist , ghes_assist_str, enabled, recordsToPreAllocate, maxSectorsPerRecord, notificationStructure, numHardwareBanks, reserved2_1, reserved2_2, reserved2_3 ) )
         currBank = 0
         while currBank < numHardwareBanks:
-            machineBankParser(table_content[48 + i*28:48 + (i+1)*28])
+            self.machineBankParser(table_content[48 + currBank*28:48 + (currBank+1)*28])
             numHardwareBanks == 1	
         return 48 + numHardwareBanks*28
 	
@@ -1365,7 +1365,7 @@ class HEST (ACPI_TABLE):
             extra_str = ''
         else:
             title = 'Generic Hardware Error Source Version 2'
-            readAckReg_str = parseAddress(table_content[64:76])
+            readAckReg_str = self.parseAddress(table_content[64:76])
             readAckPresv = struct.unpack('<Q', table_content[76:84])[0]
             readAckWr = struct.unpack('<Q', table_content[84:88])[0]
             extra_str = '''

--- a/chipsec/hal/cmos.py
+++ b/chipsec/hal/cmos.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2018, Intel Corporation
+#Copyright (c) 2010-2019, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -64,35 +64,35 @@ class CMOS(hal_base.HALBase):
         super(CMOS, self).__init__(cs)
 
     def read_cmos_high( self, offset ):
-        self.cs.io.write_port_byte( CMOS_ADDR_PORT_HIGH, offset );
+        self.cs.io.write_port_byte( CMOS_ADDR_PORT_HIGH, offset )
         return self.cs.io.read_port_byte( CMOS_DATA_PORT_HIGH )
 
     def write_cmos_high( self, offset, value ):
-        self.cs.io.write_port_byte( CMOS_ADDR_PORT_HIGH, offset );
-        self.cs.io.write_port_byte( CMOS_DATA_PORT_HIGH, value );
+        self.cs.io.write_port_byte( CMOS_ADDR_PORT_HIGH, offset )
+        self.cs.io.write_port_byte( CMOS_DATA_PORT_HIGH, value )
 
     def read_cmos_low( self, offset ):
-        self.cs.io.write_port_byte( CMOS_ADDR_PORT_LOW, 0x80|offset );
+        self.cs.io.write_port_byte( CMOS_ADDR_PORT_LOW, 0x80|offset )
         return self.cs.io.read_port_byte( CMOS_DATA_PORT_LOW )
 
     def write_cmos_low( self, offset, value ):
-        self.cs.io.write_port_byte( CMOS_ADDR_PORT_LOW, offset );
-        self.cs.io.write_port_byte( CMOS_DATA_PORT_LOW, value );
+        self.cs.io.write_port_byte( CMOS_ADDR_PORT_LOW, offset )
+        self.cs.io.write_port_byte( CMOS_DATA_PORT_LOW, value )
 
     def dump_low( self ):
         cmos_buf = [0xFF]*0x80
-        orig = self.cs.io.read_port_byte( CMOS_ADDR_PORT_LOW );
+        orig = self.cs.io.read_port_byte( CMOS_ADDR_PORT_LOW )
         for off in range(0x80):
             cmos_buf[off] = self.read_cmos_low( off )
-        self.cs.io.write_port_byte( CMOS_ADDR_PORT_LOW, orig );
+        self.cs.io.write_port_byte( CMOS_ADDR_PORT_LOW, orig )
         return cmos_buf
 
     def dump_high( self ):
         cmos_buf = [0xFF]*0x80
-        orig = self.cs.io.read_port_byte( CMOS_ADDR_PORT_HIGH );
+        orig = self.cs.io.read_port_byte( CMOS_ADDR_PORT_HIGH )
         for off in range(0x80):
             cmos_buf[off] = self.read_cmos_high( off )
-        self.cs.io.write_port_byte( CMOS_ADDR_PORT_HIGH, orig );
+        self.cs.io.write_port_byte( CMOS_ADDR_PORT_HIGH, orig )
         return cmos_buf
 
     def dump( self ):

--- a/chipsec/hal/cpu.py
+++ b/chipsec/hal/cpu.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2016, Intel Corporation
+#Copyright (c) 2010-2019, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -122,7 +122,7 @@ class CPU(hal_base.HALBase):
         (table_header,APIC_object,table_header_blob,table_blob) = _acpi.get_parse_ACPI_table( acpi.ACPI_TABLE_SIG_APIC )
         for structure in APIC_object.apic_structs:
             if 0x00 == structure.Type:
-                if dACPIID.has_key( structure.APICID ) == False:
+                if not structure.ACICID in dACPIID:
                     if 1 == structure.Flags:
                         dACPIID[ structure.APICID ] = structure.ACPIProcID
         return len( dACPIID )
@@ -207,7 +207,7 @@ class CPU(hal_base.HALBase):
     def dump_page_tables( self, cr3, pt_fname=None ):
         _orig_logname = logger().LOG_FILE_NAME
         hpt = paging.c_ia32e_page_tables( self.cs )
-        if logger().HAL: logger().log( '[cpu] dumping paging hierarchy at physical base (CR3) = 0x{:08X}...'.formatcr3 )
+        if logger().HAL: logger().log( '[cpu] dumping paging hierarchy at physical base (CR3) = 0x{:08X}...'.format(cr3) )
         if pt_fname is None: pt_fname = ('pt_{:08X}'.format(cr3))
         logger().set_log_file( pt_fname )
         hpt.read_pt_and_show_status( pt_fname, 'PT', cr3 )

--- a/chipsec/hal/igd.py
+++ b/chipsec/hal/igd.py
@@ -146,11 +146,11 @@ class IGD(hal_base.HALBase):
         return ((pa & ~0xFFF) | 0x1)
 
     def get_PA_from_PTE_gen8(self, pte):
-        return (pa & ~0xFFF)
+        return (pte & ~0xFFF)
 
     def get_PA_from_PTE(self, pte):
         if self.is_legacy_gen():
-            return self.get_PA_from_PTE_legacy()
+            return self.get_PA_from_PTE_legacy( pte )
         else:
             return self.get_PA_from_PTE_gen8( pte )
 
@@ -184,7 +184,7 @@ class IGD(hal_base.HALBase):
 
         if self.logger.HAL:
             self.logger.log( '[igd] original data at address 0x{:016X}:'.format(address) )
-            print_buffer(self.cs.mem.read_physical_mem(address, size))
+            print_buffer(bytestostring(self.cs.mem.read_physical_mem(address, size)))
 
         buffer = ''
         pa = address    

--- a/chipsec/hal/iobar.py
+++ b/chipsec/hal/iobar.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2018, Intel Corporation
+#Copyright (c) 2010-2019, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -181,5 +181,5 @@ class IOBAR(hal_base.HALBase):
         logger().log("[iobar] I/O BAR {}:".format(bar_name))
         for i in range(n):
             reg = self.cs.io._read_port( range_base + i*size, size )
-            logger().log( '{:+04X}: {:{form}}'.format(i*size,r,form=fmt) )
+            logger().log( '{:+04X}: {:{form}}'.format(i*size,reg,form=fmt) )
 

--- a/chipsec/hal/mmio.py
+++ b/chipsec/hal/mmio.py
@@ -140,7 +140,7 @@ class MMIO(hal_base.HALBase):
     def get_DMIBAR_base_address(self):
         base_lo = self.cs.pci.read_dword(0, 0, 0, Cfg.PCI_DMIBAR_REG_OFF)
         base_hi = self.cs.pci.read_dword(0, 0, 0, Cfg.PCI_DMIBAR_REG_OFF + 4)
-        if (0 == base_lo & 0x1) and logger.HAL():
+        if (0 == base_lo & 0x1) and logger().HAL:
             logger().warn('DMIBAR is disabled')
         base = (base_hi << 32) | (base_lo & 0xFFFFF000)
         if logger().HAL:
@@ -222,6 +222,7 @@ class MMIO(hal_base.HALBase):
     #
     def read_MMIOBAR_reg(self, bar_id, offset ):
         bar_base  = self.MMIO_BAR_base[ bar_id ]
+        reg_addr  = bar_base + offset
         reg_value = self.cs.helper.read_mmio_reg( bar_base, 4, offset )
         if logger().HAL:
             logger().log( '[mmio] {} + 0x{:08X} (0x{:08X}) = 0x{:08X}'.format(MMIO_BAR_name[bar_id], offset, reg_addr, reg_value) )
@@ -234,7 +235,7 @@ class MMIO(hal_base.HALBase):
         bar_base  = self.MMIO_BAR_base[bar_id]
         reg_addr  = bar_base + offset
         if logger().HAL:
-            logger().log('[mmio] write {} + 0x{:08X} (0x{:08X}) = 0x{:08X}'.format(self.MMIO_BAR_name[bar_id], offset, reg_addr, dword_value) )
+            logger().log('[mmio] write {} + 0x{:08X} (0x{:08X}) = 0x{:08X}'.format(MMIO_BAR_name[bar_id], offset, reg_addr, dword_value) )
         self.cs.helper.write_mmio_reg(reg_addr, 4, dword_value)
 
 

--- a/chipsec/hal/pci.py
+++ b/chipsec/hal/pci.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2016, Intel Corporation
+#Copyright (c) 2010-2019, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -320,14 +320,14 @@ class Pci:
     # PCI Expansion ROM functions
     #
 
-    def parse_XROM( self, xrom_base, xrom_dump=False ):
-        xrom_sig = self.cs.mem.read_physical_mem_word( xrom_base )
+    def parse_XROM( self, xrom, xrom_dump=False ):
+        xrom_sig = self.cs.mem.read_physical_mem_word( xrom.base )
         if xrom_sig != XROM_SIGNATURE: return None
-        xrom_hdr_buf = self.cs.mem.read_physical_mem( xrom_base, PCI_XROM_HEADER_SIZE )
+        xrom_hdr_buf = self.cs.mem.read_physical_mem( xrom.base, PCI_XROM_HEADER_SIZE )
         xrom_hdr = PCI_XROM_HEADER( *struct.unpack_from( PCI_XROM_HEADER_FMT, xrom_hdr_buf ) )
         if xrom_dump:
-            xrom_fname = 'xrom_{:X}-{:X}-{:X}_{:X}{:X}.bin'.format(bus, dev, fun, vid, did)
-            xrom_buf = self.cs.mem.read_physical_mem( xrom_base, xrom_size ) # use xrom_hdr.InitSize ?
+            xrom_fname = 'xrom_{:X}-{:X}-{:X}_{:X}{:X}.bin'.format(xrom.bus, xrom.dev, xrom.fun, xrom.vid, xrom.did)
+            xrom_buf = self.cs.mem.read_physical_mem( xrom.base, xrom.size ) # use xrom_hdr.InitSize ?
             write_file( xrom_fname, xrom_buf )
         return xrom_hdr
 
@@ -384,7 +384,7 @@ class Pci:
             if logger().HAL: logger().log( "[pci]   XROM: BAR = 0x{:08X}, base = 0x{:08X}, size = 0x{:X}, en = {:d}".format(xrom_bar,xrom_base,xrom_size,xrom_en) )
             xrom = XROM(bus, dev, fun, xrom_en, xrom_base, xrom_size)
             if xrom_en and (xrom_base != PCI_HDR_XROM_BAR_BASE_MASK):
-                xrom.header = self.parse_XROM( xrom_base, xrom_dump )
+                xrom.header = self.parse_XROM( xrom, xrom_dump )
                 xrom_found  = (xrom.header is not None)
                 if xrom_found:
                     if logger().HAL:

--- a/chipsec/hal/smbus.py
+++ b/chipsec/hal/smbus.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2018, Intel Corporation
+#Copyright (c) 2010-2019, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -74,7 +74,7 @@ class SMBus(hal_base.HALBase):
             if logger().HAL: self.cs.print_register( 'SMBUS_HCFG', reg_value )
             return reg_value
         else:
-            raise chipsec.chipset.RegisterNotFoundError ('RegisterNotFound: SMBUS_HCFG')
+            raise self.cs.RegisterNotFoundError ('RegisterNotFound: SMBUS_HCFG')
 
     def display_SMBus_info( self ):
         if logger().HAL: logger().log( "[smbus] SMBus Base Address: 0x{:04X}".format(self.get_SMBus_Base_Address()) )

--- a/chipsec/hal/spi_uefi.py
+++ b/chipsec/hal/spi_uefi.py
@@ -512,7 +512,7 @@ def save_efi_tree(_uefi, modules, parent=None, save_modules=True, path=None, sav
                             # so for EFI_FILE type of module using parent's Image as NVRAM
                             nvram = parent.Image if (type(m) == EFI_FILE and type(parent) == EFI_FV) else m.Image
                             _uefi.parse_EFI_variables( os.path.join(mod_dir_path, 'NVRAM'), nvram, False, m.NVRAMType )
-                        else: raise
+                        else: raise("NVRAM type cannot be None")
                     except: logger().warn( "couldn't extract NVRAM in {{{}}} using type '{}'".format(m.Guid,m.NVRAMType) )
     
         # save children modules

--- a/chipsec/hal/tpm_eventlog.py
+++ b/chipsec/hal/tpm_eventlog.py
@@ -1,5 +1,6 @@
 # CHIPSEC: Platform Security Assessment Framework
 # Copyright (c) 2017, Google Inc
+# Copyright (c) 2019, Intel Corporation
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -34,7 +35,7 @@ import collections
 import struct
 
 from chipsec import defines
-from chipsec import logger
+from chipsec.logger import logger
 
 
 class TcgPcrEvent(object):
@@ -72,7 +73,7 @@ class TcgPcrEvent(object):
         pcr_index, event_type, digest, event_size = fields
         event = log.read(event_size)
         if len(event) != event_size:
-            logger.logger().warn("[tpm_eventlog] event data length "
+            logger().warn("[tpm_eventlog] event data length "
                                  "does not match the expected size")
         name = SML_EVENT_TYPE.get(event_type)
         kls = cls if isinstance(name, str) else name
@@ -99,7 +100,7 @@ class SCRTMVersion(TcgPcrEvent):
         try:
             _str += "\n\t+ version: {}".format(self.version.decode("utf-16"))
         except:
-            if logger().HAL: logger.logger().warn("[tpm_eventlog] CRTM Version is not "
+            if logger().HAL: logger().warn("[tpm_eventlog] CRTM Version is not "
                                  "a valid string")
         return _str
 
@@ -185,4 +186,4 @@ class PcrLogParser(object):
 def parse(log):
     """Simple wrapper around PcrLogParser."""
     for event in PcrLogParser(log):
-        logger.logger().log(event)
+        logger().log(event)

--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -195,7 +195,7 @@ def print_efi_variable( offset, efi_var_buf, EFI_var_header, efi_var_name, efi_v
             if EFI_var_header.__str__:
                 logger().log( EFI_var_header )
             else:
-                logger().log( 'Decoded Header ({}):'.format(uefi_platform.EFI_VAR_DICT[ self._FWType ]['name']) )
+                logger().log( 'Decoded Header ({}):'.format(uefi_platform.EFI_VAR_DICT[ uefi_platform.FWType.EFI_FW_TYPE_UEFI ]['name']) )
                 for attr in EFI_var_header._fields:
                     logger().log( '{} = {:X}'.format('{0:<16}'.format(attr), getattr(EFI_var_header, attr)) )
 
@@ -290,14 +290,20 @@ class UEFI(hal_base.HALBase):
         return self.read_EFI_variables_from_SPI( 0, 0x800000 )
 
     def read_EFI_variables_from_SPI( self, BIOS_region_base, BIOS_region_size ):
-        rom = spi.read_spi( BIOS_region_base, BIOS_region_size )
-        efi_var_store = self.find_EFI_Variable_Store( rom )
-        return self.read_EFI_NVRAM_variables( efi_var_store )
+        rom = self.cs.spi.read_spi( BIOS_region_base, BIOS_region_size )
+        efi_var_store = self.find_EFI_variable_store( rom )
+        if efi_var_store:
+            efi_vars = uefi_platform.EFI_VAR_DICT[ self._FWType ]['func_getefivariables']
+            return efi_vars
+        return efi_var_store
 
     def read_EFI_variables_from_file( self, filename ):
         rom = read_file( filename )
-        efi_var_store = self.find_EFI_Variable_Store( rom )
-        return self.read_EFI_NVRAM_variables( efi_var_store )
+        efi_var_store = self.find_EFI_variable_store( rom )
+        if efi_var_store:
+            efi_vars = uefi_platform.EFI_VAR_DICT[ self._FWType ]['func_getefivariables']
+            return efi_vars
+        return efi_var_store
 
     def find_EFI_variable_store( self, rom_buffer ):
         if ( rom_buffer is None ):

--- a/chipsec/hal/uefi_common.py
+++ b/chipsec/hal/uefi_common.py
@@ -287,7 +287,7 @@ def get_nvar_name(nvram, name_offset, isAscii):
             nend = nend + 1
             nend = nvram.find('\x00\x00', nend)
         name_size = nend - name_offset + 2 # add trailing zero symbol
-        name = unicode(nvram[name_offset:nend], "utf-16-le")
+        name = nvram[name_offset:nend].decode("utf-16-le")
         return (name, name_size)
 
 

--- a/chipsec/hal/uefi_platform.py
+++ b/chipsec/hal/uefi_platform.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2018, Intel Corporation
+#Copyright (c) 2010-2019, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -663,7 +663,7 @@ def isCorrectVSStype(nvram_buf, vss_type):
         if (efi_var_hdr.NameSize > 0):
             name = nvram_buf[name_offset: name_offset + efi_var_hdr.NameSize]
             try:
-                name = unicode(name, "utf-16-le").split('\x00')[0]
+                name = name.decode("utf-16-le").split('\x00')[0]
                 valid_name = defines.is_printable(name)
             except Exception as e:
                 pass
@@ -728,7 +728,7 @@ def _getEFIvariables_VSS( nvram_buf, _fwtype):
             #if not IS_VARIABLE_ATTRIBUTE( efi_var_hdr.Attributes, EFI_VARIABLE_HARDWARE_ERROR_RECORD ):
             #efi_var_name = "".join( efi_var_buf[ NAME_OFFSET_IN_VAR_VSS : NAME_OFFSET_IN_VAR_VSS + name_size ] )
             Name = efi_var_buf[ name_offset : name_offset + name_size ]
-            efi_var_name = unicode(Name, "utf-16-le").split('\x00')[0]
+            efi_var_name = Name.decode("utf-16-le").split('\x00')[0]
 
             efi_var_data = efi_var_buf[ name_offset + name_size : name_offset + name_size + data_size ]
             guid = guid_str(efi_var_hdr.guid0, efi_var_hdr.guid1, efi_var_hdr.guid2, efi_var_hdr.guid3)
@@ -834,7 +834,7 @@ def EFIvar_EVSA(nvram_buf):
             elif (Tag0 == 0xEE) or (Tag0 == 0xE2):  # var name
                 VAR_NAME_RECORD = "<H{:d}s".format(Size - tlv_h_size - 2)
                 VarId, Name = struct.unpack(VAR_NAME_RECORD, value)
-                Name = unicode(Name, "utf-16-le")[:-1]
+                Name = Name.decode("utf-16-le")[:-1]
                 var_list.append((Name, VarId, Tag0, Tag1))
             elif (Tag0 == 0xEF) or (Tag0 == 0xE3) or (Tag0 == 0x83):  # values
                 VAR_VALUE_RECORD = "<HHI{:d}s".format(Size - tlv_h_size - 8)
@@ -998,7 +998,7 @@ def decode_s3bs_opcode_def( data ):
         frmt = '<BBQBB'
         size = struct.calcsize( frmt )
         opcode, slave_address, command, operation, peccheck = struct.unpack( frmt, data[ : size ] )
-        op = op_smbus_execute( opcode, size, width, address, count, data[ size : ], value, mask )
+        op = op_smbus_execute( opcode, size, slave_address, command, operation, peccheck )
     elif S3BootScriptOpcode_MDE.EFI_BOOT_SCRIPT_STALL_OPCODE == opcode:
         frmt = '<BBQ'
         size = struct.calcsize( frmt )
@@ -1166,7 +1166,7 @@ def encode_s3bs_opcode_edkcompat( op ):
     elif S3BootScriptOpcode_EdkCompat.EFI_BOOT_SCRIPT_DISPATCH_OPCODE == op.opcode:
         encoded_opcode = struct.pack( '<Q', op.entrypoint )
 
-    elif S3BootScriptOpcode_EdkCompat.EFI_BOOT_SCRIPT_MEM_POLL_OPCODE == opcode:
+    elif S3BootScriptOpcode_EdkCompat.EFI_BOOT_SCRIPT_MEM_POLL_OPCODE == op.opcode:
         encoded_opcode = struct.pack( '<IQQQ', op.width, op.address, op.duration, op.looptimes )
 
     elif S3BootScriptOpcode_EdkCompat.EFI_BOOT_SCRIPT_TERMINATE_OPCODE == op.opcode:

--- a/chipsec/hal/uefi_search.py
+++ b/chipsec/hal/uefi_search.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2016, Intel Corporation
+#Copyright (c) 2010-2019, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -129,7 +129,7 @@ def check_rules( efi, rules, entry_name, _log, bLog=True ):
         if brule_match and bLog:
             _log.log_important( "match '{}'".format(fname) )
             if (match_result & MATCH_NAME       ) == MATCH_NAME       : _log.log( "    name  : '{}'".format(rule['name']) )
-            if (match_result & MATCH_GUID       ) == MATCH_GUID       : _log.log( "    GUID  : {{}}".format(rule['guid']) )
+            if (match_result & MATCH_GUID       ) == MATCH_GUID       : _log.log( "    GUID  : {{{}}}".format(rule['guid']) )
             if (match_result & MATCH_REGEXP     ) == MATCH_REGEXP     : _log.log( "    regexp: bytes '{}' at offset {:X}h".format(what,offset) )
             if (match_result & MATCH_HASH_MD5   ) == MATCH_HASH_MD5   : _log.log( "    MD5   : {}".format(rule['md5']) )
             if (match_result & MATCH_HASH_SHA1  ) == MATCH_HASH_SHA1  : _log.log( "    SHA1  : {}".format(rule['sha1']) )

--- a/chipsec/hal/virtmem.py
+++ b/chipsec/hal/virtmem.py
@@ -132,5 +132,5 @@ class VirtMemory(hal_base.HALBase):
     def free_virtual_mem(self, virt_address):
         pa = self.va2pa(virt_address)
         ret = self.helper.free_physical_mem(pa)
-        if logger().HAL: logger().log( '[mem] Deallocated : VA = 0x{:016X}'.formatvirt_address )
+        if logger().HAL: logger().log( '[mem] Deallocated : VA = 0x{:016X}'.format(virt_address) )
         return True if ret == 1 else False

--- a/chipsec/hal/vmm.py
+++ b/chipsec/hal/vmm.py
@@ -72,7 +72,7 @@ class VMM:
         (self.membuf1_va, self.membuf1_pa) = (self.membuf0_va + 0x1000, self.membuf0_pa + 0x1000)
         if self.membuf0_va == 0:
             logger().log( "[vmm] Could not allocate memory!")
-            raise
+            raise("[vmm] Could not allocate memory!")
 
     # Generic hypercall interface
 


### PR DESCRIPTION
Fixed and pylint errors within the hal modules (mostly python3 syntax errors)

Signed-off-by: user <brent.holtsclaw@intel.com>