### PR TITLE
chipsec_util return proper error codes

### DIFF
--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -195,15 +195,17 @@ class ChipsecUtil:
             comm.run()
             if comm.requires_driver():
                 self._cs.destroy(True)
+            return comm.ExitCode
 
         elif cmd == 'help':
             if len(self.argv) <= 2:
                 self.chipsec_util_help()
             else:
                 self.chipsec_util_help(self.argv[2])
+            return ExitCode.OK
         else:
             logger().error( "Unknown command '%.32s'" % cmd )
-        return comm.ExitCode
+        return ExitCode.WARNING
 
     def set_logfile(self, logfile):
         """


### PR DESCRIPTION
comm.run will return the exitcode from the command
If a command is not defined returns 2.
For no command present or help command - display the list of commands or help then return 0.
fix issue #606 