### PR TITLE
Removed workaround for RwEverything over Hyper-V

### DIFF
--- a/chipsec/hal/cpu.py
+++ b/chipsec/hal/cpu.py
@@ -193,9 +193,6 @@ class CPU(hal_base.HALBase):
     # Check that SMRR is supported by CPU in IA32_MTRRCAP_MSR[SMRR]
     #
     def check_SMRR_supported( self ):
-        # MS HyperV workaround. HyperV reports SMRR support but throws and exception on access to SMRR msrs.
-        # Not a problem for chipsec driver but crashes RwDrv.
-        if self.check_vmm() == VMM_HYPER_V: return False
         mtrrcap_msr_reg = self.cs.read_register( 'MTRRCAP' )
         if logger().HAL: self.cs.print_register( 'MTRRCAP', mtrrcap_msr_reg )
         smrr = self.cs.get_register_field( 'MTRRCAP', mtrrcap_msr_reg, 'SMRR' )


### PR DESCRIPTION
A workaround for RWE driver causing CHIPSEC over Hyper-V to report SMRR is not supported regardless of used driver.
Since CHIPSEC manual states that it no longer supprts RwEverything driver on Windows, that workaround should be removed.
If this workaround is still needed for some reason, better tell RWE driver from CHIPSEC driver, and act accordingly.