### PR TITLE
Util_cmd cpu fixup info command

### DIFF
--- a/chipsec/hal/cpu.py
+++ b/chipsec/hal/cpu.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2016, Intel Corporation
+#Copyright (c) 2010-2019, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -119,12 +119,13 @@ class CPU(hal_base.HALBase):
     def get_number_threads_from_APIC_table(self):
         _acpi = acpi.ACPI( self.cs )
         dACPIID = {}
-        (table_header,APIC_object,table_header_blob,table_blob) = _acpi.get_parse_ACPI_table( acpi.ACPI_TABLE_SIG_APIC )
-        for structure in APIC_object.apic_structs:
-            if 0x00 == structure.Type:
-                if dACPIID.has_key( structure.APICID ) == False:
-                    if 1 == structure.Flags:
-                        dACPIID[ structure.APICID ] = structure.ACPIProcID
+        for apic in _acpi.get_parse_ACPI_table( acpi.ACPI_TABLE_SIG_APIC ):
+            table_header,APIC_object,table_header_blob,table_blob = apic
+            for structure in APIC_object.apic_structs:
+                if 0x00 == structure.Type:
+                    if dACPIID.has_key( structure.APICID ) == False:
+                        if 1 == structure.Flags:
+                            dACPIID[ structure.APICID ] = structure.ACPIProcID
         return len( dACPIID )
     
     # determine number of physical sockets using the CPUID and APIC ACPI table

--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2018, Intel Corporation
+#Copyright (c) 2010-2019, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -582,7 +582,7 @@ NVRAM: EFI Variable Store
                 if logger().HAL: logger().log( "[uefi] UEFI appears to be in Runtime mode" )
                 ect_pa = self.cs.mem.va2pa( est.ConfigurationTable )
                 if not ect_pa:
-                    logger().error( "Can't find UEFI ConfigurationTable" )
+                    if logger().HAL: logger().warn( "Can't find UEFI ConfigurationTable" )
                     return (None,ect_pa,ect,ect_buf)
 
         if logger().HAL: logger().log( "[uefi] EFI Configuration Table ({:d} entries): VA = 0x{:016X}, PA = 0x{:016X}".format(est.NumberOfTableEntries,est.ConfigurationTable,ect_pa) )


### PR DESCRIPTION
Changed find_EFI_Configuration_Table to not log error and only log if HAL logging is enabled
Changed get_number_threads_from_APIC_table to utilize return structure from get_parse_ACPI_table
addresses #612

Signed-off-by: BrentHoltsclaw <brent.holtsclaw@intel.com>