### PR TITLE
Extend register to use memory type within configuration files

### DIFF
--- a/chipsec/cfg/common.xml
+++ b/chipsec/cfg/common.xml
@@ -88,8 +88,8 @@ Common (default) XML platform configuration file
   <!--                                      -->
   <!-- #################################### -->
   <memory>
-    <range name="Legacy DOS" type="dram" address="0x0"        size="0x100000"/>
-    <range name="TPM"        type="mmio" address="0xFED40000" size="0x10000"/>
+    <range name="Legacy DOS" access="dram" address="0x0"        size="0x100000"/>
+    <range name="TPM"        access="mmio" address="0xFED40000" size="0x10000"/>
   </memory>
 
 

--- a/chipsec/cfg/template.xml
+++ b/chipsec/cfg/template.xml
@@ -42,7 +42,7 @@ Template for XML configuration file
   <!--                                      -->
   <!-- #################################### -->
   <memory>
-    <range name="[RANGE NAME]" type="dram|mmio" address="[PHYS ADDRESS]" size="[RANGE SIZE]"/>
+    <range name="[RANGE NAME]" access="dram|mmio" address="[PHYS ADDRESS]" size="[RANGE SIZE]"/>
   </memory>
 
   <!-- #################################### -->
@@ -51,7 +51,7 @@ Template for XML configuration file
   <!--                                      -->
   <!-- #################################### -->
   <registers>
-    <register name="[UNIQUE REGISTER NAME]" type="msr|mmio|io|iobar|pcicfg|mmcfg|msgbus" desc="[REGISTER DESCRIPTION]" />
+    <register name="[UNIQUE REGISTER NAME]" type="msr|mmio|io|iobar|pcicfg|mmcfg|msgbus|memory" desc="[REGISTER DESCRIPTION]" />
   </registers>
 
   <!-- #################################### -->

--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -847,7 +847,7 @@ class Chipset:
             if reg['access'] == 'dram':
                 reg_value= self.mem.read_physical_mem(int(reg['address'],16), int(reg['size'],16))
             elif reg['access'] == 'mmio':
-                reg_value = self.mmio.read_MMIO_reg(int(reg['address'],16), int(reg['offset']),int(reg['size'],16))
+                reg_value = self.mmio.read_MMIO_reg(int(reg['address'],16), int(reg['offset'],16),int(reg['size'],16))
         else:
             raise RegisterTypeNotFoundError("Register type not found: {}".format(rtype))
 
@@ -890,7 +890,7 @@ class Chipset:
             if reg['access'] == 'dram':
                 self.mem.write_physical_mem(int(reg['address'],16), int(reg['size'],16), reg_value)
             elif reg['access'] == 'mmio':
-                self.mmio.write_MMIO_reg(int(reg['address'],16), int(reg['offset']), reg_value, int(reg['size'],16))
+                self.mmio.write_MMIO_reg(int(reg['address'],16), int(reg['offset'],16), reg_value, int(reg['size'],16))
         else:
             raise RegisterTypeNotFoundError("Register type not found: {}".format(rtype))
 


### PR DESCRIPTION
Add ability for register to reference memory as a type
Modified memory xml attribute renamed type to function

Signed-off-by: BrentHoltsclaw <brent.holtsclaw@intel.com>