### PR TITLE
Fix ACPI util command in Python3

### DIFF
--- a/chipsec/hal/acpi.py
+++ b/chipsec/hal/acpi.py
@@ -290,7 +290,7 @@ class ACPI(hal_base.HALBase):
         rsdp    = None
         membuf = self.cs.mem.read_physical_mem( 0xE0000, 0x20000 )
         membuf = bytestostring(membuf)
-        pos = membuf.find( ACPI_RSDP_SIG )
+        pos = bytestostring(membuf).find( ACPI_RSDP_SIG )
         if -1 != pos:
             rsdp_pa  = 0xE0000 + pos
             rsdp     = self.read_RSDP(rsdp_pa)
@@ -335,7 +335,7 @@ class ACPI(hal_base.HALBase):
         pa = smram_base - CHUNK_SZ
         while pa > CHUNK_SZ:
             membuf = self.cs.mem.read_physical_mem( pa, CHUNK_SZ )
-            pos = membuf.find( ACPI_RSDP_SIG )
+            pos = bytestostring(membuf).find( ACPI_RSDP_SIG )
             if -1 != pos:
                 rsdp_pa  = pa + pos
                 if logger().HAL: logger().log( "[acpi] found '{}' signature at 0x{:16X}. Checking if valid RSDP..".format(ACPI_RSDP_SIG,rsdp_pa) )

--- a/chipsec/utilcmd/acpi_cmd.py
+++ b/chipsec/utilcmd/acpi_cmd.py
@@ -59,7 +59,7 @@ class ACPICommand(BaseCommand):
         parser_table.add_argument('-f','--file',dest='_file', help='Read from file', action='store_true')
         parser_table.add_argument('_name',metavar='table|filename',nargs=1,help="table to list")
         parser_table.set_defaults(func=self.acpi_table)
-        parser.parse_args(self.argv[2:],namespace=ACPICommand)
+        parser.parse_args(self.argv[2:], namespace=self)
         if self.func == self.acpi_table and self._file:
             return False
         return True

--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -191,9 +191,6 @@ class ChipsecUtil:
             except Exception as msg:
                 logger().error(str(msg))
                 sys.exit(ExitCode.EXCEPTION)
-            except None as msg:
-                logger().error(str(msg))
-                sys.exit(ExitCode.EXCEPTION)
 
             logger().log( "[CHIPSEC] Executing command '{}' with args {}\n".format(cmd,self.argv[2:]) )
             comm.run()


### PR DESCRIPTION
Please see the commits for more details.

Probably all other commands should do `parser.parse_args(self.argv[2:], namespace=self)` as well.

Why did you do `except None as msg`?