### PR TITLE
Trivial README patch for module loading/unloading.

### DIFF
--- a/drivers/linux/README
+++ b/drivers/linux/README
@@ -12,10 +12,10 @@ To build:
 	make
 
 To load kernel module:
-	make install
+	sudo insmod ./chipsec.ko
 
 To remove kernel module:
-	make uninstall
+	sudo rmmod chipsec
 
 NOTE:
 You may need run apt-get install python-dev for the Python.h header (needed for switching cpu affinity). 


### PR DESCRIPTION
Trivial README update for loading/unloading the linux kernel module.  The current makefile no longer has "install" and "uninstall" targets.