### PR TITLE
Explanation of Kbuild warning.

### DIFF
--- a/drivers/linux/README
+++ b/drivers/linux/README
@@ -21,6 +21,26 @@ NOTE:
 You may need run apt-get install python-dev for the Python.h header (needed for switching cpu affinity). 
 If you already have this in a non-standard location (i.e. any other than /usr/include/python-2.7), you can manually edit the path in drivers/linux/Makefile
 
+NOTE:
+Building against recent Linux kernels generates the warning 
+
+	WARNING: could not find [...]/chipsec/drivers/linux/amd64/.cpu.o.cmd for [...]/chipsec/drivers/linux/amd64/cpu.o
+
+The cmd files are generated with the cmd_and_fixdep rule found in scripts/Kbuild.include, which are used (among other
+places) in rule_cc_o_c and rule_as_o_S defined in scripts/Makefile.build (both files are in the kernel source tree).  
+Removing the warning could be done by converting cpu.asm to cpu.S (i.e. nasm to as), or by adding a rule_nasm_o_asm 
+to the Kbuild project.  The latter might require a new rule in our Makefile:
+
+	NASM ?= `which nasm`
+	NASMFLAGS = -f $(elf-size)
+
+	%.o : %.asm
+        	$(NASM) $(NASMFLAGS) $< -o $@
+
+but for now it's probably best to just ignore the warning (it's harmless).  See 
+	https://www.kernel.org/doc/ols/2003/ols2003-pages-185-200.pdf for an introduction to Kbuild 
+	https://www.kernel.org/doc/Documentation/kbuild/modules.txt
+for more detail.
 
 -------------
 


### PR DESCRIPTION
Chipsec uses .asm files for assembly in the linux driver, and the Kbuild system doesn't know how to manage those even when a nasm rule is added to the makefile.  Chasing down the problem has convinced me it's not worth trying to fix.  I've added a few notes to the README documenting why.  Not sure if the README is the right place for this, but it might save someone else a bit of bother if they try to chase it down.