### PR TITLE
Add attr conversion within set_EFI_variable win32helper

### DIFF
--- a/chipsec/helper/win/win32helper.py
+++ b/chipsec/helper/win/win32helper.py
@@ -774,6 +774,8 @@ class Win32Helper(Helper):
     def set_EFI_variable( self, name, guid, data, datasize, attrs ):
         var     = bytes(0) if data     is None else data
         var_len = len(var) if datasize is None else datasize
+        if isinstance(attrs, (str,bytes)):
+            attrs = struct.unpack("Q","{messge:\x00<{fill}}".format(message=attrs,fill=8)[:8])[0]
 
         if attrs is None:
             if self.SetFirmwareEnvironmentVariable is not None:


### PR DESCRIPTION
tools.uefi.uefivar_fuzz generates attributes as string/bytes type.  Need to convert to integer within the helper to avoid exception.

Signed-off-by: BrentHoltsclaw <brent.holtsclaw@intel.com>