### PR TITLE
python2 compatability fix for uefi variable fuzzer

### DIFF
--- a/chipsec/fuzzing/primitives.py
+++ b/chipsec/fuzzing/primitives.py
@@ -623,7 +623,10 @@ class string (base_primitive):
         try:
             self.rendered = str(self.value).encode(self.encoding)
         except:
-            self.rendered = str(self.value).encode('latin-1')
+            if version[0] is '3':
+                self.rendered = str(self.value).encode('latin-1')
+            else:
+                self.rendered = self.value
 
         return self.rendered
 


### PR DESCRIPTION
Revert to old primitives.py fallback if ascii encode fails on python2