### PR TITLE
Fix python3 utilcmd help issue

### DIFF
--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -98,6 +98,8 @@ class ChipsecUtil:
             logger().DEBUG   = True
         if self.log:
             logger().set_log_file( self.log )
+        if not self._cmd_args:
+            self._cmd_args = ["--help"]
 
     def import_cmds(self):
         if self.CHIPSEC_LOADED_AS_EXE:
@@ -142,7 +144,7 @@ class ChipsecUtil:
 
         # @TODO: change later
         # all util cmds assume 'chipsec_util.py' as the first arg so adding dummy first arg
-        self.argv = ['dummy'] + [self._cmd] +self._cmd_args
+        self.argv = ['dummy'] + [self._cmd] + self._cmd_args
         comm = self.commands[self._cmd](self.argv, cs = self._cs)
 
         try:


### PR DESCRIPTION
Help was not being displayed in python3 when no arguments were provided

Signed-off-by: BrentHoltsclaw <brent.holtsclaw@intel.com>