### PR TITLE
More varstore parsing fixes

### DIFF
--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -229,7 +229,7 @@ def decode_EFI_variables( efi_vars, nvram_pth ):
         for (off, buf, hdr, data, guid, attrs) in efi_vars[name]:
             # efi_vars[name] = (off, buf, hdr, data, guid, attrs)
             attr_str = get_attr_string( attrs )
-            var_fname = os.path.join( nvram_pth, '{}_{}_{}_{:d}.bin'.format(name.encode('utf-8'), guid, attr_str.strip(), n) )
+            var_fname = os.path.join( nvram_pth, '{}_{}_{}_{:d}.bin'.format(name, guid, attr_str.strip(), n) )
             write_file( var_fname, data )
             if name in SECURE_BOOT_KEY_VARIABLES:
                 parse_efivar_file(var_fname, data, SECURE_BOOT_SIG_VAR)

--- a/chipsec/hal/uefi_common.py
+++ b/chipsec/hal/uefi_common.py
@@ -670,9 +670,9 @@ def NextFwFile(FvImage, FvLength, fof, polarity):
             header_size = struct.calcsize(EFI_FFS_FILE_HEADER)
         #Check for a blank header
         if polarity:
-            blank = "\xff" * file_header_size
+            blank = b"\xff" * file_header_size
         else:
-            blank = "\x00" * file_header_size
+            blank = b"\x00" * file_header_size
 
         if (blank == FvImage[fof:fof+file_header_size]):
             next_offset = fof + 8

--- a/chipsec/hal/uefi_common.py
+++ b/chipsec/hal/uefi_common.py
@@ -269,17 +269,14 @@ MAX_NVRAM_SIZE    = 1024*1024
 
 def get_nvar_name(nvram, name_offset, isAscii):
     if isAscii:
-        nend = nvram.find('\x00', name_offset)
-        name_size = nend - name_offset + 1 # add trailing zero symbol
-        name = nvram[name_offset:nend]
+        nend = nvram.find(b'\x00', name_offset)
+        name = nvram[name_offset:nend].decode('latin1')
+        name_size = len(name) + 1
         return (name, name_size)
     else:
-        nend = nvram.find('\x00\x00', name_offset)
-        while (nend & 1) == 1:
-            nend = nend + 1
-            nend = nvram.find('\x00\x00', nend)
-        name_size = nend - name_offset + 2 # add trailing zero symbol
-        name = nvram[name_offset:nend].decode("utf-16-le")
+        nend = nvram.find(b'\x00\x00', name_offset)
+        name = nvram[name_offset:nend].decode('utf-16le')
+        name_size = len(name) + 2
         return (name, name_size)
 
 

--- a/chipsec/hal/uefi_platform.py
+++ b/chipsec/hal/uefi_platform.py
@@ -355,7 +355,7 @@ Attributes : 0x{:02X}
 State      : 0x{:02X}
 """.format( self.StartId, self.TotalSize, self.Reserved1, self.Reserved2, self.Reserved3, self.Attributes, self.State )
 
-NVAR_EFIvar_signature   = 'NVAR'
+NVAR_EFIvar_signature   = b'NVAR'
 
 def getNVstore_NVAR( nvram_buf ):
     l = (-1, -1, None)
@@ -378,8 +378,11 @@ def getNVstore_NVAR( nvram_buf ):
         FvOffset, FsGuid, FvLength, Attributes, HeaderLength, Checksum, ExtHeaderOffset, FvImage, CalcSum = NextFwVolume(nvram_buf, FvOffset+FvLength)
     return l
 
+def _ord(c):
+    return ord(c) if isinstance(c, str) else c
+
 def getEFIvariables_NVAR( nvram_buf ):
-    start = defines.bytestostring(nvram_buf).find( NVAR_EFIvar_signature )
+    start = nvram_buf.find( NVAR_EFIvar_signature )
     nvram_size = len(nvram_buf)
     EFI_HDR_NVAR = "<4sH3sB"
     nvar_size = struct.calcsize(EFI_HDR_NVAR)
@@ -398,13 +401,14 @@ def getEFIvariables_NVAR( nvram_buf ):
         if (not isvar) or (size == (EMPTY & 0xffff)): break
         var_name_off = 1
         if bit_set(attributes, NVRAM_ATTR_GUID):
-            guid0, guid1, guid2, guid3 = struct.unpack(GUID, nvram_buf[nof+nvar_size:nof+nvar_size+guid_size])
-            guid = guid_str(guid0, guid1, guid2, guid3)
+            guid = UUID(bytes_le=nvram_buf[nof + nvar_size: nof + nvar_size + guid_size])
+            guid = str(guid).upper()
             var_name_off = guid_size
         else:
-            guid_idx = ord(nvram_buf[nof+nvar_size])
-            guid0, guid1, guid2, guid3 = struct.unpack(GUID, nvram_buf[nvram_size - guid_size - guid_idx:nvram_size - guid_idx])
-            guid = guid_str(guid0, guid1, guid2, guid3)
+            guid_idx = _ord(nvram_buf[nof+nvar_size])
+            guid_off = (nvram_size - guid_size) - guid_idx * guid_size
+            guid = UUID(bytes_le=nvram_buf[guid_off: guid_off + guid_size])
+            guid = str(guid).upper()
         name_size = 0
         name_offset = nof+nvar_size+var_name_off
         if not bit_set(attributes, NVRAM_ATTR_DATA):
@@ -413,7 +417,7 @@ def getEFIvariables_NVAR( nvram_buf ):
         eattrs = 0
         if bit_set(attributes, NVRAM_ATTR_EXTHDR):
             esize, = struct.unpack("<H", nvram_buf[nof+size-2:nof+size])
-            eattrs = ord(nvram_buf[nof+size-esize])
+            eattrs = _ord(nvram_buf[nof+size-esize])
         attribs = EFI_VARIABLE_BOOTSERVICE_ACCESS
         attribs = attribs | EFI_VARIABLE_NON_VOLATILE
         if bit_set(attributes, NVRAM_ATTR_RT):  attribs = attribs | EFI_VARIABLE_RUNTIME_ACCESS

--- a/chipsec/hal/uefi_platform.py
+++ b/chipsec/hal/uefi_platform.py
@@ -823,7 +823,7 @@ def EFIvar_EVSA(nvram_buf):
     fof = 0
     variables = dict()
     while fof < image_size:
-        fof = nvram_buf.find("EVSA", fof)
+        fof = nvram_buf.find(VARIABLE_STORE_SIGNATURE_EVSA, fof)
         if fof == -1: break
         if fof < tlv_h_size:
             fof = fof + 4


### PR DESCRIPTION
A bunch of fixes for NVRAM parsing functions. Most of bugs were related to python 3 compatibility.

Tested using `chipsec_util.py uefi nvram ...` and `chipsec_util.py uefi decode ...`.