### PR TITLE
valid_mmap_phys_addr_range conflicts with upstream

### DIFF
--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -547,7 +547,7 @@ int __weak phys_mem_access_prot_allowed(struct file *file,
         return 1;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,12) && defined(ARCH_HAS_VALID_PHYS_ADDR_RANGE)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,12) && defined(ARCH_HAS_VALID_PHYS_ADDR_RANGE) && !defined(__HAVE_ARCH_PAX_OPEN_USERLAND)
 int valid_mmap_phys_addr_range(unsigned long pfn, size_t size)
 {
 	return 1;


### PR DESCRIPTION
PaX implements valid_mmap_phys_addr_range in the kernel, and the
(return 1) hack in chipsec_km.c has a name collision with it.

Add another conditional for exposing the definition predicated on
whether __HAVE_ARCH_PAX_OPEN_USERLAND is defined in the kernel
headers. If it is, dont redefine the original function.