### PR TITLE
Add ability to require pch configuriation file to be loaded

### DIFF
--- a/chipsec/cfg/template.xml
+++ b/chipsec/cfg/template.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<configuration platform="[PLATFORM_CODE]">
+<configuration platform="[PLATFORM_CODE]" req_pch="BOOLEAN">
 <!--
 Template for XML configuration file
 -->

--- a/chipsec/cfg/whl.xml
+++ b/chipsec/cfg/whl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<configuration platform="WHL">
+<configuration platform="WHL" req_pch="True">
 <!--
 XML configuration file for Whiskey Lake
 


### PR DESCRIPTION
Add reqs_pch to configuration attributes within template.xml
Add reqs_pch as field for WHL as example
Update logic within chipset.py to check if reqs_pch attribute exists
Update logic within chipset.py to raise error if pch is required and driver needs to be loaded
Note can still work around with the -i flag

Signed-off-by: BrentHoltsclaw <brent.holtsclaw@intel.com>