### PR TITLE
Changes to 3xx.xml to match datasheets

### DIFF
--- a/chipsec/cfg/pch_3xx.xml
+++ b/chipsec/cfg/pch_3xx.xml
@@ -33,7 +33,7 @@ XML configuration file for the 300 series PCH
   <!-- #################################### -->
   <io>
     <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
-    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="PMBASE"     register="PMBASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
     <bar name="TCOBASE"    register="TCOBASE"  base_field="TCOBA" size="0x20"  desc="TCO Base Address"/>
 
     <!-- old definition -->
@@ -60,8 +60,8 @@ XML configuration file for the 300 series PCH
     <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 
     <!-- Sideband Register Access Registers -->
-    <register name="SBREG_BAR" type="pcicfg" bus="0" dev="0x1F" fun="1" offset="0x10" size="4" desc="Sideband Register Access BAR">
-      <field name="RBA" bit="24" size="8" desc="Register Base Address"/>
+    <register name="SBREG_BAR" type="pcicfg" bus="0" dev="0x1F" fun="1" offset="0x10" size="8" desc="Sideband Register Access BAR">
+      <field name="RBA" bit="24" size="40" desc="Register Base Address"/>
     </register>
     <register name="P2SBC" type="pcicfg" bus="0" dev="0x1F" fun="1" offset="0xE0" size="2" desc="P2SB Configuration Register">
       <field name="HIDE" bit="8" size="1" desc="Hide SBREG_BAR"/>
@@ -71,13 +71,20 @@ XML configuration file for the 300 series PCH
     </register>
 
     <!-- Power Management Controller -->
-    <register name="ABASE" type="pcicfg" bus="0" dev="0x1f" fun="2" offset="0x40" size="4" desc="ACPI Base Address">
-      <field name="STYPE" bit="0" size="1" desc="Space Type (always 1 - I/O space)"/>
-      <field name="BA"    bit="8" size="8" desc="Base Address"/>
+     <register name="ABASE" type="mm_msgbus" port="0x88" offset="0x27B4" size="4" desc="ACPI Base Address">
+      <field name="MASK" bit="18" size="6" desc="MASK for lower 6 bits"/>
+      <field name="BA"    bit="2" size="14" desc="Base Address"/>
+    </register>
+    <register name="PMBASE" type="mm_msgbus" port="0x88" offset="0x27AC" size="4" desc="PM Base Address">
+      <field name="BA" bit="0" size="16" desc="Base Address" />
+      <field name="BAMRL" bit="16" size="16" desc="Memory Range Limit"/>
     </register>
     <register name="PWRMBASE" type="pcicfg" bus="0" dev="0x1f" fun="2" offset="0x10" size="8" desc="PM Base Address">
       <field name="STYPE" bit="0"  size="1"  desc="Space Type (always 0 - memory space)"/>
-      <field name="BA"    bit="13" size="51" desc="Base Address"/>
+      <field name="BA"    bit="12" size="52" desc="Base Address"/>
+      <!-- bit 31 on 3xx-OP is reserved and should be set to 0
+           BA starts at 12 on 3xx-OP and 13 on because 12 will be 0 on 3xx moving the
+           starting address to 12 -->
     </register>
     <register name="GEN_PMCON_1" type="mmio" bar="PWRMBASE" offset="0x1020" size="4" desc="General PM Configuration A">
     </register>


### PR DESCRIPTION
ABASE and PMBASE changed
PWRMBASE moved to help match 3xx-OP datasheets
Reference 337868-002 and 337348-001
#729 #730 

Signed-off-by: BrentHoltsclaw <brent.holtsclaw@intel.com>