### PR TITLE
Fix decoding of S3 bootscript EDKCompat opcodes

### DIFF
--- a/chipsec/hal/uefi_platform.py
+++ b/chipsec/hal/uefi_platform.py
@@ -1155,6 +1155,10 @@ def decode_s3bs_opcode_edkcompat( data ):
     else:
         op = op_unknown( opcode, size )
         if logger().HAL: logger().warn( 'Unrecognized opcode {:X}'.format(opcode) )
+
+    return op
+
+#
 # @TODO: encode functions are not fully implemented
 #
 def encode_s3bs_opcode_edkcompat( op ):


### PR DESCRIPTION
Decoded opcodes were not returned from the function.
Was broken since 2efeda434594041371cd0337f95737924f4e1db2. Bad merge, apparently.

Signed-off-by: Evgeny Zinoviev <me@ch1p.io>