### PR TITLE
Fix broken s3script_modify

### DIFF
--- a/chipsec/hal/uefi_common.py
+++ b/chipsec/hal/uefi_common.py
@@ -1266,7 +1266,7 @@ class op_io_pci_mem():
         if self.unknown is not None: str_r += "  Unknown: 0x{:04X}\n".format(self.unknown)
         if self.count   is not None: str_r += "  Count  : 0x{:X}\n".format(self.count)
         if self.values  is not None:
-            fmt = '0x{}'.format( '{{{:d}X}}'.format(script_width_sizes[self.width]*2) )
+            fmt = '0x{}'.format( '{{:0{:d}X}}'.format(script_width_sizes[self.width]*2) )
             str_r += "  Values : {}\n".format("  ".join( [fmt.format(v) for v in self.values] ))
         elif self.buffer is not None:
             str_r += ("  Buffer (size = 0x{:X}):\n".format(len(self.buffer)) + dump_buffer( self.buffer, 16 ))


### PR DESCRIPTION
S3 bootscript patching was broken because of incorrect format string
used in `__str__` method of `class op_io_pci_mem`, which was raising `KeyError`.

Signed-off-by: Evgeny Zinoviev <me@ch1p.io>