### PR TITLE
Get extended BIOS R/W access information

### DIFF
--- a/chipsec/hal/spi.py
+++ b/chipsec/hal/spi.py
@@ -364,6 +364,11 @@ class SPI(hal_base.HALBase):
         brwa  = self.cs.get_register_field('FRAP', fracc, 'BRWA' )
         bmrag = self.cs.get_register_field('FRAP', fracc, 'BMRAG' )
         bmwag = self.cs.get_register_field('FRAP', fracc, 'BMWAG' )
+        if self.cs.is_register_defined('FDOC') and self.cs.is_register_defined('FDOD'):
+            self.cs.write_register('FDOC', 0x3000)
+            tmp_reg = self.cs.read_register('FDOD')
+            brra |= ((tmp_reg >> 8) & 0xFFF)
+            brwa |= ((tmp_reg >> 20) & 0xFFF)
         logger().log( '' )
         logger().log( "BIOS Region Write Access Grant ({:02X}):".format(bmwag) )
         regions = self.get_SPI_regions()

--- a/chipsec/modules/common/spi_access.py
+++ b/chipsec/modules/common/spi_access.py
@@ -51,6 +51,11 @@ class spi_access(BaseModule):
         frap = self.cs.read_register( 'FRAP' )
         brra = self.cs.get_register_field( 'FRAP', frap, 'BRRA' )
         brwa = self.cs.get_register_field( 'FRAP', frap, 'BRWA' )
+        if self.cs.is_register_defined('FDOC') and self.cs.is_register_defined('FDOD'):
+            self.cs.write_register('FDOC', 0x3000)
+            tmp_reg = self.cs.read_register('FDOD')
+            brra |= ((tmp_reg >> 8) & 0xFFF)
+            brwa |= ((tmp_reg >> 20) & 0xFFF)
 
         # Informational
         # CPU/Software access to Platform Data region (platform specific)


### PR DESCRIPTION
Use the Flash Descriptor Observability registers to OR in the settings
from the flash descriptor to the existing FRAP register fields.

Signed-off-by: Erik Bjorge <erik.c.bjorge@intel.com>