### PR TITLE
Add BlackArch Linux reference

### DIFF
--- a/README
+++ b/README
@@ -15,6 +15,7 @@ Projects That Include CHIPSEC
 -----------------------------
 
  * Linux UEFI Validation (LUV): https://01.org/linux-uefi-validation
+ * BlackArch Linux: https://www.blackarch.org/index.html
 
 Contact Us
 ----------

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Projects That Include CHIPSEC
 -----------------------------
 
  * [Linux UEFI Validation (LUV)](https://01.org/linux-uefi-validation)
+ * [BlackArch Linux](https://www.blackarch.org/index.html)
 
 Contact Us
 ----------


### PR DESCRIPTION
Adding BlackArch Linux as a distro that includes CHIPSEC by default

Signed-off-by: Erik Bjorge <erik.c.bjorge@intel.com>