### PR TITLE
Fixed logger flush when redirected to a file

### DIFF
--- a/chipsec/logger.py
+++ b/chipsec/logger.py
@@ -201,6 +201,7 @@ class Logger:
             try:
                 self.rootLogger.removeHandler(self.logfile)
                 self.logfile.flush()
+                self.rootLogger.addHandler(self.logfile)
             except Exception:
                 self.disable()
 


### PR DESCRIPTION
When flushing to a log file the handler is removed but was not added
back.  Added code to restore the handler.

Signed-off-by: Erik Bjorge <erik.c.bjorge@intel.com>