### PR TITLE
Fix error messages and helper loading

### DIFF
--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -164,10 +164,16 @@ class LinuxHelper(Helper):
         driver_path = os.path.join(chipsec.file.get_main_dir(), "chipsec", "helper" ,"linux", "chipsec.ko" )
         if not os.path.exists(driver_path):
             #check DKMS modules location
-            driver_path = self.get_dkms_module_location()
+            try:
+                driver_path = self.get_dkms_module_location()
+            except Exception:
+                pass
             if not os.path.exists(driver_path):
                 raise Exception("Cannot find chipsec.ko module")
-        subprocess.check_output( [ "insmod", driver_path, a1, a2 ] )
+        try:
+            subprocess.check_output( [ "insmod", driver_path, a1, a2 ] )
+        except Exception as err:
+            raise Exception("Could not start Linux Helper, are you running as Admin/root?\n\t{}.format(err)")
         uid = gid = 0
         os.chown(self.DEVICE_NAME, uid, gid)
         os.chmod(self.DEVICE_NAME, 600)

--- a/chipsec/helper/oshelper.py
+++ b/chipsec/helper/oshelper.py
@@ -91,7 +91,7 @@ class OsHelper:
         if(not self.helper):
             import platform
             os_system  = platform.system()
-            raise OsHelperError( "Could not load helper for '{}' environment (unsupported environment?)".format(os_system), errno.ENODEV )
+            raise OsHelperError( "Could not load any helpers for '{}' environment (unsupported environment?)".format(os_system), errno.ENODEV )
         else:
             self.os_system  = self.helper.os_system
             self.os_release = self.helper.os_release
@@ -106,7 +106,8 @@ class OsHelper:
             except OsHelperError:
                 raise
             except:
-                pass
+                if logger().DEBUG:
+                    logger().log("Unable to load helper: {}".format(helper))
 
     def start(self, start_driver, driver_exists=None, to_file=None, from_file=False):
         if not to_file is None:
@@ -126,7 +127,7 @@ class OsHelper:
             error_no = errno.ENXIO
             if hasattr(msg,'errorcode'):
                 error_no = msg.errorcode
-            raise OsHelperError("Could not start the OS Helper, are you running as Admin/root?\n           Message: \"{}\"".format(msg),error_no)
+            raise OsHelperError("Message: \"{}\"".format(msg),error_no)
 
     def stop( self, start_driver ):
         if not self.filecmds is None:


### PR DESCRIPTION
Remove dependency for win32helper to find .sys file within init
Fixup logic to better display when driver file cannot be found

Signed-off-by: BrentHoltsclaw <brent.holtsclaw@intel.com>