### PR TITLE
Remove PCH data from SKX and require PCH to be loaded

### DIFF
--- a/chipsec/cfg/pch_c620.xml
+++ b/chipsec/cfg/pch_c620.xml
@@ -370,6 +370,10 @@ XML configuration file for
       <field name="TCO_LOCK" bit="12" size="1" desc="TCO Lock"/>
     </register>
 
+    <register name="ECTRL" type="mm_msgbus" port="0xB8" offset="0x0004" size="4" desc="DCI Control Register">
+      <field name="ENABLE" bit="4" size="1"/>
+    </register>
+
   </registers>
 
   <!-- #################################### -->
@@ -381,6 +385,7 @@ XML configuration file for
     <control name="BiosInterfaceLockDown"  register="BC"    field="BILD"    desc="BIOS Interface Lock-Down"/>
     <control name="SpiWriteStatusDis"      register="HSFS"  field="WRSDIS"  desc="Write Status Disable"/>
     <control name="ACPIBaseLock" register="GEN_PMCON_B" field="ACPI_BASE_LOCK" desc="Lock Down ACPI Base Address" />
+    <control name="TcoCtlLock"      register="TCOCTL"  field="TCO_BASE_LOCK"  desc="TCO Base Lock"/>
   </controls>
 
 </configuration>

--- a/chipsec/cfg/skx.xml
+++ b/chipsec/cfg/skx.xml
@@ -1,25 +1,17 @@
 <?xml version="1.0"?>
-<configuration platform="SKX" >
+<configuration platform="SKX" req_pch="True">
 <!--
 XML configuration file for Skylake/Purely Server
 Intel (c) Xeon Processor Scalable Family datasheet Vol. 2
-Intel (c) C620 Series Chipset Platform Controller Hub datasheet
+
 -->
 
   <pci>
-    <device name="P2SBC" bus="0" dev="0x1F" fun="1" vid="0x8086" did="0xA220,0xA1A0" />
-    <device name="PMC"   bus="0" dev="0x1F" fun="2" vid="0x8086" did="0xA221,0xA1A1" />
-    <device name="SMBUS" bus="0" dev="0x1F" fun="4" vid="0x8086" did="0xA223,0xA1A3" />
-    <device name="SPI"   bus="0" dev="0x1F" fun="5" vid="0x8086" did="0xA224,0xA1A4" />
   </pci>
 
   <mmio>
     <bar name="MMCFG"    bus="0" dev="5"    fun="0" reg="0x90" width="8" mask="0x7FFFFFC000000" size="0x1000" desc="PCI Express Register Range"/>
     <bar name="DMIBAR"   bus="0" dev="0"    fun="0" reg="0x50" width="4" mask="0xFFFFF000"      size="0x1000" enable_bit="0" desc="Root Complex Register Range"/>
-    <bar name="PWRMBASE" bus="0" dev="0x1F" fun="2" reg="0x48" width="4" mask="0xFFFFF000"      size="0x1000" desc="PM Base Address"/>
-    <bar name="TCO_BAR"  bus="0" dev="0x1F" fun="4" reg="0x50" width="4" mask="0xFFE0"          size="0x1000" desc="TCO Base Register Register Range"/>
-    <bar name="SPIBAR"   bus="0" dev="0x1F" fun="5" reg="0x10" width="4" mask="0xFFFFF000"      size="0x1000" desc="SPI Controller Register Range"/>
-    <bar name="SBREGBAR" register="SBREG_BAR" base_field="RBA" size="0x1000000" desc="Sideband Register Access BAR"/>
   </mmio>
 
   <io>
@@ -31,26 +23,8 @@ Intel (c) C620 Series Chipset Platform Controller Hub datasheet
   <registers>
 
       <!-- PCH -->
-    <register name="ABAR"   type="pcicfg" bus="0" dev="0x17" fun="0" offset="0x24" size="4" desc="AHCI Base Address">
-      <field name="BA" bit="19" size="13" desc="Base Address"/>
-    </register>
-    <register name="SATAGC" type="pcicfg" bus="0" dev="0x17" fun="0" offset="0x9C" size="4" desc="SATA General Configuration">
-      <field name="ASSEL" bit="0" size="3" desc="ABAR Size Select"/>
-    </register>
 
     <!-- Sideband Register Access Registers -->
-    <register name="SBREG_BAR"  type="pcicfg" device="P2SBC" offset="0x10" size="4" desc="Sideband Register Access BAR">
-      <field name="RBA" bit="24" size="8" desc="Register Base Address"/>
-    </register>
-    <register name="SBREG_BARH" type="pcicfg" device="P2SBC" offset="0x14" size="4" desc="Sideband Register Access BAR High DWORD">
-      <field name="RBAH" bit="0" size="32" desc="Register Base Address"/>
-    </register>
-    <register name="P2SBC"      type="pcicfg" device="P2SBC" offset="0xE0" size="4" desc="P2SB Configuration Register">
-      <field name="HIDE" bit="8" size="1" desc="Hide SBREG_BAR"/>
-    </register>
-    <register name="P2SB_HIDE"  type="pcicfg" device="P2SBC" offset="0xE1" size="1" desc="P2SB Configuration Register hide-unhide">
-      <field name="HIDE" bit="0" size="1" desc="Hide SBREG_BAR"/>
-    </register>
 
     <!-- MMCFG -->
     <register name="MMCFG_BASE"  type="pcicfg" bus="0" dev="5" fun="0" offset="0x90" size="8" desc="MMCFG Address Base">
@@ -84,89 +58,25 @@ Intel (c) C620 Series Chipset Platform Controller Hub datasheet
     </register>
 
     <!-- PCH ABASE (PMBASE) I/O registers -->
-    <register name="ABASE" type="pcicfg" device="PMC" offset="0x40" size="4" desc="ACPI Base Address">
-      <field  name="Base" bit="8" size="24" desc="Base Address"/>
-    </register>
 
-    <register name="GEN_PMCON_1" type="pcicfg" device="PMC" offset="0xA0" size="2" desc="General PM Configuration 1">
-      <field name="SMI_LOCK" bit="4" size="1" desc="SMI Lock"/>
-    </register>
-
-    <register name="GEN_PMCON_B" type="pcicfg" device="PMC" offset="0xA4" size="4" desc="General Power Management Configuration Lock">
-      <field name="ACPI_BASE_LOCK" bit="17" size="1" desc="Lock down ACPI Base Address (ABASE)"/>
-    </register>
 
     <!-- SPI Flash Controller MMIO registers -->
-    <register name="HSFS" type="mmio" bar="SPIBAR" offset="0x04" size="4" desc="Hardware Sequencing Flash Status Register">
-      <field name="FDONE"     bit="0"  size="1" desc="Flash Cycle Done"/>
-      <field name="FCERR"     bit="1"  size="1" desc="Flash Cycle Error"/>
-      <field name="AEL"       bit="2"  size="1" desc="Access Error Log"/>
-      <field name="SAF_ERROR" bit="3"  size="1" desc="SAF Error"/>
-      <field name="SAF_DLE"   bit="4"  size="1" desc="SAF Data Length Error"/>
-      <field name="SCIP"      bit="5"  size="1" desc="SPI cycle in progress"/>
-      <field name="WRSDIS"    bit="11" size="1" desc="Write status disable"/>
-      <field name="PR34LKD"   bit="12" size="1" desc="PRR3 PRR4 Lock-Down"/>
-      <field name="FDOPSS"    bit="13" size="1" desc="Flash Descriptor Override Pin-Strap Status"/>
-      <field name="FDV"       bit="14" size="1" desc="Flash Descriptor Valid"/>
-      <field name="FLOCKDN"   bit="15" size="1" desc="Flash Configuration Lock-Down"/>
-      <field name="FGO"       bit="16" size="1" desc="Flash cycle go"/>
-      <field name="FCYCLE"    bit="17" size="4" desc="Flash Cycle Type"/>
-      <field name="WET"       bit="21" size="1" desc="Write Enable Type"/>
-      <field name="FDBC"      bit="24" size="6" desc="Flash Data Byte Count"/>
-      <field name="FSMIE"     bit="31" size="1" desc="Flash SPI SMI Enable"/>
-    </register>
 
     <!-- SMBus Host Controller -->
-    <register name="SMBUS_VID"  type="pcicfg" device="SMBUS" offset="0x00" size="2" desc="VID" />
-    <register name="SMBUS_DID"  type="pcicfg" device="SMBUS" offset="0x02" size="2" desc="DID" />
-    <register name="SMBUS_CMD"  type="pcicfg" device="SMBUS" offset="0x04" size="2" desc="CMD" />
-    <register name="SMBUS_HCFG" type="pcicfg" device="SMBUS" offset="0x40" size="1" desc="Host Configuration">
-      <field name="HST_EN"     bit="0" size="1"/>
-      <field name="SMB_SMI_EN" bit="1" size="1"/>
-      <field name="I2C_EN"     bit="2" size="2"/>
-      <field name="SSRESET"    bit="3" size="1"/>
-      <field name="SPD_WD"     bit="4" size="1"/>
-    </register>
-    <register name="TCOBASE"    type="pcicfg" device="SMBUS" offset="0x50" size="4" desc="TCO Base Address">
-      <field name="IOS"   bit="0" size="1"  desc="I/O space"/>
-      <field name="TCOBA" bit="5" size="11" desc="TCO Base Address"/>
-    </register>
-    <register name="TCOCTL"     type="pcicfg" device="SMBUS" offset="0x54" size="4" desc="TCO Control">
-      <field name="TCO_BASE_LOCK" bit="0" size="1" desc="TCO Base Lock"/>
-      <field name="TCO_BASE_EN"   bit="8" size="1" desc="TCO Base Enable"/>
-    </register>
 
-    <register name="SMI_EN" type="iobar" bar="ABASE" offset="0x30" size="4" desc="SMI Control and Enable">
-      <field name="GBL_SMI_EN"         bit="0"  size="1" desc="Global SMI Enable"/>
-      <field name="TCO_EN"             bit="13" size="1" desc="TCO Enable"/>
-      <field name="GPIO_UNLOCK_SMI_EN" bit="27" size="1" desc="GPIO Unlock SMI Enable"/>
-    </register>
 
-    <register name="TCO1_CNT" type="iobar" bar="TCOBAR" offset="0x8" size="2" desc="TCO1 Control">
-      <field name="TCO_LOCK"           bit="12" size="1" desc="TCO Lock"/>
-    </register>
+
+
 
 
     <!-- SPI Interface Controller -->
-    <register name="BC" type="pcicfg" device="SPI" offset="0xDC" size="4" desc="BIOS Control">
-      <field name="BIOSWE"   bit="0" size="1" desc="BIOS Write Enable" /> <!-- WPD -->
-      <field name="BLE"      bit="1" size="1" desc="BIOS Lock Enable" /> <!-- LE -->
-      <field name="TSS"      bit="4" size="1" desc="Top Swap Status" /> <!-- TSS -->
-      <field name="SMM_BWP"  bit="5" size="1" desc="SMM BIOS Write Protection" /> <!-- EISS -->
-      <field name="BILD"     bit="7" size="1" desc="BIOS Interface Lock Down"/> <!-- BILD -->
-    </register>
 
     <!-- DCI registers -->
-    <register name="ECTRL" type="mm_msgbus" port="0xB8" offset="0x0004" size="4" desc="DCI Control Register">
-      <field name="ENABLE" bit="4" size="1"/>
-    </register>
+
 
   </registers>
 
   <controls>
-    <control name="BiosInterfaceLockDown" register="BC"   field="BILD"   desc="BIOS Interface Lock-Down"/>
-    <control name="SpiWriteStatusDis"     register="HSFS" field="WRSDIS" desc="Write Status Disable"/>
-    <control name="TcoCtlLock"      register="TCOCTL"  field="TCO_BASE_LOCK"  desc="TCO Base Lock"/>
   </controls>
 
 </configuration>


### PR DESCRIPTION
Add req_pch="True" in configuration tag
Diff c620.xml and skx.xml to remove pch registers

Signed-off-by: BrentHoltsclaw <brent.holtsclaw@intel.com>