### PR TITLE
Fix ability to explicitly specify OS helper.

### DIFF
--- a/chipsec/helper/oshelper.py
+++ b/chipsec/helper/oshelper.py
@@ -116,7 +116,7 @@ class OsHelper:
         if not driver_exists is None:
             for name in avail_helpers:
                 if name == driver_exists:
-                    self.helper = getattr(chiphelpers,helper).get_helper()
+                    self.helper = getattr(chiphelpers,name).get_helper()
         try:
             if not self.helper.create( start_driver ):
                 raise OsHelperError("failed to create OS helper",1)


### PR DESCRIPTION
The ability to explicitly specify an OS helper using the `--helper` switch was broken, as can be seen by the following screenshot:

![image](https://user-images.githubusercontent.com/8438963/70481350-261c6380-1a97-11ea-8dcb-b51f69614a53.png) 

The proposed bugfix is quite simple and self-explanatory 😅 