### PR TITLE
Print DEVICE_OBJECT and DRIVER_OBJECT addresses using %p.

### DIFF
--- a/drivers/win7/driver.c
+++ b/drivers/win7/driver.c
@@ -605,7 +605,7 @@ DriverDeviceControl(
             RtlCopyBytes( &va, (BYTE*)Irp->AssociatedIrp.SystemBuffer, sizeof(UINTN) );
             pa = MmGetPhysicalAddress( (PVOID)va );
 
-            DbgPrint( "[chipsec][IOCTL_GET_PHYSADDR] Traslated virtual address 0x%I64X to physical: 0x%I64X\n", va, pa.QuadPart, pa.LowPart);
+            DbgPrint( "[chipsec][IOCTL_GET_PHYSADDR] Translated virtual address 0x%I64X to physical: 0x%I64X\n", va, pa.QuadPart, pa.LowPart);
             RtlCopyBytes( Irp->AssociatedIrp.SystemBuffer, (void*)&pa, sizeof(UINTN) );
             IrpSp->Parameters.Read.Length = sizeof(UINTN);
             dwBytesWritten = IrpSp->Parameters.Read.Length;

--- a/drivers/win7/driver.c
+++ b/drivers/win7/driver.c
@@ -229,7 +229,7 @@ DriverOpen(
     )
 {
 
-    DbgPrint( "[chipsec] >> DriverOpen (DeviceObject = 0x%x)\n", DeviceObject );
+    DbgPrint( "[chipsec] >> DriverOpen (DeviceObject = 0x%p)\n", DeviceObject );
 
     //
     // Complete the request and return status.
@@ -248,7 +248,7 @@ DriverClose(
     )
 {
     
-    DbgPrint( "[chipsec] >> DriverClose (DeviceObject = 0x%x)\n", DeviceObject );
+    DbgPrint( "[chipsec] >> DriverClose (DeviceObject = 0x%p)\n", DeviceObject );
 
     Irp->IoStatus.Status = STATUS_SUCCESS;
     Irp->IoStatus.Information = 0;
@@ -266,7 +266,7 @@ DriverUnload(
     NTSTATUS       Status;
     UNICODE_STRING DosDeviceName;
 
-    DbgPrint( "[chipsec] >> DriverUnload (DriverObject = 0x%x)\n", DriverObject );
+    DbgPrint( "[chipsec] >> DriverUnload (DriverObject = 0x%p)\n", DriverObject );
 
     RtlInitUnicodeString(&DosDeviceName, DEVICE_NAME_DOS );
     Status = IoDeleteSymbolicLink (&DosDeviceName );
@@ -338,7 +338,7 @@ DriverDeviceControl(
     IOControlCode = IrpSp->Parameters.DeviceIoControl.IoControlCode;
 
     DbgPrint( "[chipsec] >>>>>>>>>> IOCTL >>>>>>>>>>\n" );
-    DbgPrint( "[chipsec] DeviceObject = 0x%x IOCTL = 0x%x\n", DeviceObject, IOControlCode );
+    DbgPrint( "[chipsec] DeviceObject = 0x%p IOCTL = 0x%x\n", DeviceObject, IOControlCode );
     DbgPrint( "[chipsec] InputBufferLength = 0x%x, OutputBufferLength = 0x%x\n", IrpSp->Parameters.DeviceIoControl.InputBufferLength, IrpSp->Parameters.DeviceIoControl.OutputBufferLength );
 
     //

--- a/drivers/win7/driver.c
+++ b/drivers/win7/driver.c
@@ -293,7 +293,7 @@ NTSTATUS _read_phys_mem( PHYSICAL_ADDRESS pa, unsigned int len, void * pData )
       DbgPrint( "[chipsec] ERROR: no space for mapping\n" );
       return STATUS_UNSUCCESSFUL;
     }
-  DbgPrint( "[chipsec] reading %d bytes from physical address 0x%08x_%08x (virtual = %#010x)", len, pa.HighPart, pa.LowPart, (UINTN)va );
+  DbgPrint( "[chipsec] reading %u bytes from physical address 0x%08x_%08x (virtual = %#010x)", len, pa.HighPart, pa.LowPart, (UINTN)va );
   RtlCopyMemory( pData, va, len );
   MmUnmapIoSpace( va, len );
   return STATUS_SUCCESS;
@@ -307,7 +307,7 @@ NTSTATUS _write_phys_mem( PHYSICAL_ADDRESS pa, unsigned int len, void * pData )
       DbgPrint( "[chipsec] ERROR: no space for mapping\n" );
       return STATUS_UNSUCCESSFUL;
     }
-  DbgPrint( "[chipsec] writing %d bytes to physical address 0x%08x_%08x (virtual = %#010x)", len, pa.HighPart, pa.LowPart, (UINTN)va );
+  DbgPrint( "[chipsec] writing %u bytes to physical address 0x%08x_%08x (virtual = %#010x)", len, pa.HighPart, pa.LowPart, (UINTN)va );
   RtlCopyMemory( va, pData, len );
   MmUnmapIoSpace( va, len );
   return STATUS_SUCCESS;
@@ -347,9 +347,9 @@ DriverDeviceControl(
     _num_active_cpus = KeQueryActiveProcessorCount( NULL );
     _kaffinity       = KeQueryActiveProcessors();
     _cpu_thread_id   = KeGetCurrentProcessorNumber();
-    DbgPrint( "[chipsec] Active CPU threads         : %d (KeNumberProcessors = %d)\n", _num_active_cpus, KeNumberProcessors );
+    DbgPrint( "[chipsec] Active CPU threads         : %ul (KeNumberProcessors = %d)\n", _num_active_cpus, KeNumberProcessors );
     DbgPrint( "[chipsec] Active CPU mask (KAFFINITY): 0x%08X\n", _kaffinity );
-    DbgPrint( "[chipsec] Current CPU thread         : %d\n", _cpu_thread_id );
+    DbgPrint( "[chipsec] Current CPU thread         : %u\n", _cpu_thread_id );
 
     //
     // Switch on the IOCTL code that is being requested by the user.  If the
@@ -674,7 +674,7 @@ DriverDeviceControl(
             RtlCopyBytes( &new_cpu_thread_id, (BYTE*)Irp->AssociatedIrp.SystemBuffer, sizeof(UINT32) );
             if( new_cpu_thread_id >= _num_active_cpus ) new_cpu_thread_id = 0;
             KeSetSystemAffinityThread( (KAFFINITY)(1 << new_cpu_thread_id) );
-            DbgPrint( "[chipsec][IOCTL_LOAD_UCODE_UPDATE] Changed CPU thread to %d\n", KeGetCurrentProcessorNumber() );
+            DbgPrint( "[chipsec][IOCTL_LOAD_UCODE_UPDATE] Changed CPU thread to %ul\n", KeGetCurrentProcessorNumber() );
 
             RtlCopyBytes( &ucode_size, (BYTE*)Irp->AssociatedIrp.SystemBuffer + sizeof(UINT32), sizeof(UINT16) );
             DbgPrint( "[chipsec][IOCTL_LOAD_UCODE_UPDATE] Ucode update size = 0x%X\n", ucode_size );
@@ -751,7 +751,7 @@ DriverDeviceControl(
             RtlCopyBytes( &new_cpu_thread_id, (BYTE*)Irp->AssociatedIrp.SystemBuffer, sizeof(UINT32) );
             if( new_cpu_thread_id >= _num_active_cpus ) new_cpu_thread_id = 0;
             KeSetSystemAffinityThread( (KAFFINITY)(1 << new_cpu_thread_id) );
-            DbgPrint( "[chipsec][IOCTL_WRMSR] Changed CPU thread to %d\n", KeGetCurrentProcessorNumber() );
+            DbgPrint( "[chipsec][IOCTL_WRMSR] Changed CPU thread to %ul\n", KeGetCurrentProcessorNumber() );
 
             RtlCopyBytes( msrData, (BYTE*)Irp->AssociatedIrp.SystemBuffer + sizeof(UINT32), 3 * sizeof(UINT32) );
             _msr_addr = msrData[0];
@@ -809,7 +809,7 @@ DriverDeviceControl(
             RtlCopyBytes( &new_cpu_thread_id, (BYTE*)Irp->AssociatedIrp.SystemBuffer, sizeof(UINT32) );
             if( new_cpu_thread_id >= _num_active_cpus ) new_cpu_thread_id = 0;
             KeSetSystemAffinityThread( (KAFFINITY)(1 << new_cpu_thread_id) );
-            DbgPrint( "[chipsec][IOCTL_RDMSR] Changed CPU thread to %d\n", KeGetCurrentProcessorNumber() );
+            DbgPrint( "[chipsec][IOCTL_RDMSR] Changed CPU thread to %ul\n", KeGetCurrentProcessorNumber() );
 
             RtlCopyBytes( msrData, (BYTE*)Irp->AssociatedIrp.SystemBuffer + sizeof(UINT32), sizeof(UINT32) );
             _msr_addr = msrData[0];
@@ -916,7 +916,7 @@ DriverDeviceControl(
             RtlCopyBytes( &new_cpu_thread_id, (BYTE*)Irp->AssociatedIrp.SystemBuffer, sizeof(UINT32) );
             if( new_cpu_thread_id >= _num_active_cpus ) new_cpu_thread_id = 0;
             KeSetSystemAffinityThread( (KAFFINITY)(1 << new_cpu_thread_id) );
-            DbgPrint( "[chipsec][GET_CPU_DESCRIPTOR_TABLE] Changed CPU thread to %d\n", KeGetCurrentProcessorNumber() );
+            DbgPrint( "[chipsec][GET_CPU_DESCRIPTOR_TABLE] Changed CPU thread to %ul\n", KeGetCurrentProcessorNumber() );
             RtlCopyBytes( &dt_code, (BYTE*)Irp->AssociatedIrp.SystemBuffer + sizeof(UINT32), sizeof(BYTE) );
             DbgPrint( "[chipsec][GET_CPU_DESCRIPTOR_TABLE] Descriptor table: %x\n", dt_code );
 
@@ -1015,7 +1015,7 @@ DriverDeviceControl(
               }
             if( IrpSp->Parameters.DeviceIoControl.InputBufferLength < sizeof(gprs) )
               {
-                DbgPrint( "[chipsec] ERROR: STATUS_INVALID_PARAMETER (input buffer size < %d)\n", sizeof(gprs) );
+                DbgPrint( "[chipsec] ERROR: STATUS_INVALID_PARAMETER (input buffer size < %zu)\n", sizeof(gprs) );
                 Status = STATUS_INVALID_PARAMETER;
                 break;
               }
@@ -1235,7 +1235,7 @@ DriverDeviceControl(
     // -- restore current KAFFINITY
     KeSetSystemAffinityThread( _kaffinity );
     DbgPrint( "[chipsec] Restored active CPU mask (KAFFINITY): 0x%08X\n", KeQueryActiveProcessors() );
-    DbgPrint( "[chipsec] Current CPU thread                  : %d\n", KeGetCurrentProcessorNumber() );
+    DbgPrint( "[chipsec] Current CPU thread                  : %ul\n", KeGetCurrentProcessorNumber() );
 
     // --
     // -- Complete the I/O request, Record the status of the I/O action.

--- a/drivers/win7/driver.c
+++ b/drivers/win7/driver.c
@@ -605,7 +605,7 @@ DriverDeviceControl(
             RtlCopyBytes( &va, (BYTE*)Irp->AssociatedIrp.SystemBuffer, sizeof(UINTN) );
             pa = MmGetPhysicalAddress( (PVOID)va );
 
-            DbgPrint( "[chipsec][IOCTL_GET_PHYSADDR] Translated virtual address 0x%I64X to physical: 0x%I64X\n", va, pa.QuadPart, pa.LowPart);
+            DbgPrint( "[chipsec][IOCTL_GET_PHYSADDR] Translated virtual address 0x%I64X to physical: 0x%I64X\n", va, pa.QuadPart);
             RtlCopyBytes( Irp->AssociatedIrp.SystemBuffer, (void*)&pa, sizeof(UINTN) );
             IrpSp->Parameters.Read.Length = sizeof(UINTN);
             dwBytesWritten = IrpSp->Parameters.Read.Length;


### PR DESCRIPTION
Printing addresses using the %x format specifier leads to truncated output on x64 platforms, for example:
![image](https://user-images.githubusercontent.com/8438963/70671866-5e0bde00-1c32-11ea-8b40-a611efb0d10a.png)
