### PR TITLE
Fix VirtMemory base class initialization.

### DIFF
--- a/chipsec/hal/virtmem.py
+++ b/chipsec/hal/virtmem.py
@@ -44,7 +44,7 @@ class MemoryAccessError (RuntimeError):
 
 class VirtMemory(hal_base.HALBase):
     def __init__( self, cs ):
-        hal_base.HALBase.__init__(VirtMemory,cs)
+        super(VirtMemory, self).__init__(cs)
         self.helper = cs.helper
 
     ####################################################################################


### PR DESCRIPTION
The base class initialization used to fail with `TypeError: 'unbound method __init__() must be called with HALBase instance as first argument (got type instance instead)'` for not passing `self`. The net result was that many `chipsec_util vmem` commands didn't work as expected.