### PR TITLE
Add some Windows related entries to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,19 @@
 *.o
 *.d
 *.pyc
+*.obj
+*.pdb
+*.lib
 chipsec.egg-info
 dist
+
+# Windows driver
+.vs/
+chipsec/helper/win/win7_amd64/
+chipsec/helper/win/win7_x86/
+drivers/win7/Debug/
+drivers/win7/Release/
+drivers/win7/x64/
+
+# Compression tools
+chipsec_tools/compression/Bin/


### PR DESCRIPTION
Previously, building the Windows driver or the compression tools resulted in a large number of artifacts being recognized as untracked files by Git. This PR attempts to remediate this situation by adding some common binary file extensions as well as some output directories to `.gitignore`.