### PR TITLE
Fix handler for IOCTL_LOAD_UCODE_PATCH.

### DIFF
--- a/drivers/win7/driver.c
+++ b/drivers/win7/driver.c
@@ -690,6 +690,7 @@ DriverDeviceControl(
             if( !ucode_buf )
               {
                 DbgPrint( "[chipsec] ERROR: couldn't allocate pool for ucode binary\n" );
+                Status = STATUS_INSUFFICIENT_RESOURCES;
                 break;
               }
             RtlCopyBytes( ucode_buf, (BYTE*)Irp->AssociatedIrp.SystemBuffer + sizeof(UINT32) + sizeof(UINT16), ucode_size );

--- a/drivers/win7/driver.c
+++ b/drivers/win7/driver.c
@@ -664,9 +664,9 @@ DriverDeviceControl(
             DbgPrint("[chipsec] > IOCTL_LOAD_UCODE_UPDATE\n" );
 
             if( !Irp->AssociatedIrp.SystemBuffer ||
-                IrpSp->Parameters.DeviceIoControl.InputBufferLength < sizeof(BYTE) + sizeof(UINT16) )
+                IrpSp->Parameters.DeviceIoControl.InputBufferLength < sizeof(UINT32) + sizeof(UINT16) )
             {
-               DbgPrint( "[chipsec] ERROR: STATUS_INVALID_PARAMETER (input buffer size < 3)\n" );
+               DbgPrint( "[chipsec] ERROR: STATUS_INVALID_PARAMETER (input buffer size < 6)\n" );
                Status = STATUS_INVALID_PARAMETER;
                break;
             }
@@ -681,7 +681,7 @@ DriverDeviceControl(
 
             if( IrpSp->Parameters.DeviceIoControl.InputBufferLength < ucode_size + sizeof(UINT32) + sizeof(UINT16) )
               {
-                DbgPrint( "[chipsec] ERROR: STATUS_INVALID_PARAMETER (input buffer size < ucode_size + 3)\n" );
+                DbgPrint( "[chipsec] ERROR: STATUS_INVALID_PARAMETER (input buffer size < ucode_size + 6)\n" );
                 Status = STATUS_INVALID_PARAMETER;
                 break;
               }
@@ -691,8 +691,8 @@ DriverDeviceControl(
               {
                 DbgPrint( "[chipsec] ERROR: couldn't allocate pool for ucode binary\n" );
                 break;
-              }           
-            RtlCopyBytes( ucode_buf, (BYTE*)Irp->AssociatedIrp.SystemBuffer + sizeof(BYTE) + sizeof(UINT16), ucode_size );
+              }
+            RtlCopyBytes( ucode_buf, (BYTE*)Irp->AssociatedIrp.SystemBuffer + sizeof(UINT32) + sizeof(UINT16), ucode_size );
             ucode_start = (UINT64)ucode_buf;
             DbgPrint( "[chipsec][IOCTL_LOAD_UCODE_UPDATE] ucode update address = 0x%p (eax = 0x%08X, edx = 0x%08X)\n", ucode_start, (UINT32)(ucode_start & 0xFFFFFFFF), (UINT32)((ucode_start >> 32) & 0xFFFFFFFF) );
             DbgPrint( "[chipsec][IOCTL_LOAD_UCODE_UPDATE] ucode update contents:\n" );

--- a/drivers/win7/driver.c
+++ b/drivers/win7/driver.c
@@ -658,7 +658,7 @@ DriverDeviceControl(
             PVOID ucode_buf = NULL;
             UINT64 ucode_start = 0;
             UINT16 ucode_size = 0;
-            UINT32 _eax = 0, _edx = 0;
+            UINT32 _eax[2] = {0}, _edx[2] = {0};
             int CPUInfo[4] = {-1};
 
             DbgPrint("[chipsec] > IOCTL_LOAD_UCODE_UPDATE\n" );
@@ -700,6 +700,12 @@ DriverDeviceControl(
             _dump_buffer( (unsigned char *)ucode_buf, min(ucode_size,0x100) );
 
             // --
+            // -- read IA32_BIOS_SIGN_ID MSR to save current patch ID
+            // -- we'll need this value later to verify the microcode update was successful
+            // --
+            _rdmsr(MSR_IA32_BIOS_SIGN_ID, &_eax[0], &_edx[0]);
+
+            // --
             // -- trigger CPU ucode patch update
             // -- pInBuf points to the beginning of ucode update binary
             // --
@@ -712,17 +718,23 @@ DriverDeviceControl(
             // --
             // -- need to clear IA32_BIOS_SIGN_ID MSR first
             // -- CPUID will deposit an update ID value in 64-bit MSR at address MSR_IA32_BIOS_SIGN_ID
-            // -- read IA32_BIOS_SIGN_ID MSR to check patch ID != 0
+            // -- read IA32_BIOS_SIGN_ID MSR to check patch ID != previous patch ID
             // --
             DbgPrint( "[chipsec][IOCTL_LOAD_UCODE_UPDATE] checking ucode update was loaded..\n" );
             DbgPrint( "[chipsec][IOCTL_LOAD_UCODE_UPDATE] clear IA32_BIOS_SIGN_ID, CPUID EAX=1, read back IA32_BIOS_SIGN_ID\n" );
             _wrmsr( MSR_IA32_BIOS_SIGN_ID, 0, 0 );
             __cpuid(CPUInfo, 1);
-            _rdmsr( MSR_IA32_BIOS_SIGN_ID, &_eax, &_edx );
-            DbgPrint( "[chipsec][IOCTL_LOAD_UCODE_UPDATE] RDMSR( IA32_BIOS_SIGN_ID=0x8b ) = 0x%08x%08x\n", _edx, _eax );
-            if( 0 != _edx ) DbgPrint( "[chipsec][IOCTL_LOAD_UCODE_UPDATE] Microcode update loaded (ID != 0)\n" );
-            else            DbgPrint( "[chipsec] ERROR: Microcode update failed\n" );
+            _rdmsr( MSR_IA32_BIOS_SIGN_ID, &_eax[1], &_edx[1] );
+            DbgPrint( "[chipsec][IOCTL_LOAD_UCODE_UPDATE] RDMSR( IA32_BIOS_SIGN_ID=0x8b ) = 0x%08x%08x\n", _edx[1], _eax[1] );
+            if ( _edx[1] == _edx[0] )
+              {
+                // same patch ID, microcode update failed
+                DbgPrint("[chipsec] ERROR: Microcode update failed\n");
+                Status = STATUS_BAD_DATA;
+                break;
+              }
 
+            DbgPrint("[chipsec][IOCTL_LOAD_UCODE_UPDATE] Microcode update loaded (ID != %u)\n", _edx[0]);
             Status = STATUS_SUCCESS;
             break;
           }


### PR DESCRIPTION
- Fix input buffer length check.
- Fix copy of microcode contents.
- Set appropriate failure status when pool allocation fails.
- Correctly handle the case where the CPU already has microcode updates.