### PR TITLE
Strip terminating NULL bytes from the CPU brand.

### DIFF
--- a/chipsec/modules/common/cpu/cpu_info.py
+++ b/chipsec/modules/common/cpu/cpu_info.py
@@ -54,6 +54,7 @@ class cpu_info(BaseModule):
                 regs = self.cs.cpu.cpuid(eax_val, 0)
                 for i in range(4):
                     brand += bytestostring(struct.pack('<I', regs[i]))
+            brand = brand.rstrip('\x00')
             self.logger.log('[*] Processor: {}'.format(brand))
 
             # Get processor version information


### PR DESCRIPTION
When executing the `cpu_info` module, the CPU brand as obtained via the `cpuid` instruction used to have trailing NULL bytes in it, for example: 
![image](https://user-images.githubusercontent.com/8438963/71779466-4ddfe800-2fbf-11ea-8acf-09356ef80c2d.png)

In case the `-x` flag was passed, those NULL bytes were propagated into the XML output file which lead to the following parsing error:
![image](https://user-images.githubusercontent.com/8438963/71779617-0c9c0800-2fc0-11ea-9f47-1bf0f1c20036.png)

This PR attempts to remediate this scenario by simply striping trailing NULL bytes from the CPU brand prior to doing any other processing on it.

