### PR TITLE
Pack blacklist.json in the py2exe distribution.

### DIFF
--- a/chipsec/modules/tools/uefi/blacklist.py
+++ b/chipsec/modules/tools/uefi/blacklist.py
@@ -157,7 +157,7 @@ class blacklist(BaseModule):
 
         # Load JSON config with black-listed EFI modules
         if len(module_argv) > 1: self.cfg_name = module_argv[1]
-        cfg_pth = os.path.join( os.path.dirname(os.path.realpath(__file__)), self.cfg_name )
+        cfg_pth = os.path.join( chipsec.file.get_main_dir(), "chipsec/modules/tools/uefi", self.cfg_name )
         with open(cfg_pth, 'r') as blacklist_json:
              self.efi_blacklist = json.load( blacklist_json )
 

--- a/scripts/build_exe_win7-amd64.py
+++ b/scripts/build_exe_win7-amd64.py
@@ -69,7 +69,11 @@ sys.path.append(tool_dir)
 print os.getcwd()
 
 
-data_files = [(WIN_DRIVER_INSTALL_PATH + "/win7_amd64", ['chipsec/helper/win/win7_amd64/chipsec_hlpr.sys'])]
+data_files = [
+    (WIN_DRIVER_INSTALL_PATH + "/win7_amd64", ['chipsec/helper/win/win7_amd64/chipsec_hlpr.sys']),
+    ('chipsec/modules/tools/uefi', ['chipsec/modules/tools/uefi/blacklist.json']),
+]
+
 for current, dirs, files in os.walk(cfg_dir ):
     for file in files:
         if file.endswith('.xml') :

--- a/scripts/build_exe_win7-x86.py
+++ b/scripts/build_exe_win7-x86.py
@@ -69,7 +69,11 @@ sys.path.append(tool_dir)
 print os.getcwd()
 
 
-data_files = [(WIN_DRIVER_INSTALL_PATH + "/win7_x86", ['chipsec/helper/win/win7_x86/chipsec_hlpr.sys'])]
+data_files = [
+    (WIN_DRIVER_INSTALL_PATH + "/win7_x86", ['chipsec/helper/win/win7_x86/chipsec_hlpr.sys']),
+    ('chipsec/modules/tools/uefi', ['chipsec/modules/tools/uefi/blacklist.json']),
+]
+
 for current, dirs, files in os.walk(cfg_dir ):
     for file in files:
         if file.endswith('.xml') :


### PR DESCRIPTION
Pack `blacklist.json` in the `py2exe` distribution of CHIPSEC, so that modules such as `tools.uefi.blacklist` could run correctly (see #814).