### PR TITLE
Update the py2exe build scripts to be Python 3 compatible.

### DIFF
--- a/scripts/build_exe_win7-amd64.py
+++ b/scripts/build_exe_win7-amd64.py
@@ -60,6 +60,7 @@ bin_dir = os.path.join(root_dir,"bin")
 source_dir = os.path.join(root_dir,"source")
 tool_dir   = root_dir
 cfg_dir    = os.path.join(tool_dir,"chipsec","cfg")
+version_file = os.path.join(root_dir, "chipsec", VERSION_FILE)
 
 win_7_amd64 = os.path.join(bin_dir,'win7-amd64');
 
@@ -82,9 +83,9 @@ for current, dirs, files in os.walk(cfg_dir ):
             data_files.append( xf ) 
 
 version=""
-if os.path.exists(VERSION_FILE):
-    data_files.append(('.',['VERSION']))
-    with open(VERSION_FILE, "r") as verFile:
+if os.path.exists(version_file):
+    data_files.append(('.',[version_file]))
+    with open(version_file, "r") as verFile:
         version = verFile.read()
 print("VERSION: {}".format(version))
 

--- a/scripts/build_exe_win7-amd64.py
+++ b/scripts/build_exe_win7-amd64.py
@@ -47,7 +47,7 @@
 import os
 import sys
 
-print 'Python', (sys.version)
+print('Python', sys.version)
 
 import py2exe
 WIN_DRIVER_INSTALL_PATH = "chipsec/helper/win"
@@ -63,10 +63,10 @@ cfg_dir    = os.path.join(tool_dir,"chipsec","cfg")
 win_7_amd64 = os.path.join(bin_dir,'win7-amd64');
 
 
-print os.getcwd()
+print(os.getcwd())
 os.chdir( tool_dir )
 sys.path.append(tool_dir)
-print os.getcwd()
+print(os.getcwd())
 
 
 data_files = [
@@ -86,7 +86,7 @@ if os.path.exists(VERSION_FILE):
     data_files.append(('.',['VERSION']))
     with open(VERSION_FILE, "r") as verFile:
         version = verFile.read()
-print "VERSION: {}".format(version) 
+print("VERSION: {}".format(version))
 
 mypackages = []
 for current, dirs, files in os.walk(tool_dir ):
@@ -98,7 +98,7 @@ for current, dirs, files in os.walk(tool_dir ):
             pkg = current.replace(tool_dir+os.path.sep,"")
             pkg = pkg.replace(os.path.sep,'.')
             mypackages.append(pkg)
-            print pkg
+            print(pkg)
 
 from distutils.core import setup
 

--- a/scripts/build_exe_win7-amd64.py
+++ b/scripts/build_exe_win7-amd64.py
@@ -100,6 +100,10 @@ for current, dirs, files in os.walk(tool_dir ):
             mypackages.append(pkg)
             print(pkg)
 
+# Don't rely on py2exe to create the dist dir
+if not os.path.exists(win_7_amd64):
+    os.makedirs(win_7_amd64)
+
 from distutils.core import setup
 
 

--- a/scripts/build_exe_win7-amd64.py
+++ b/scripts/build_exe_win7-amd64.py
@@ -77,7 +77,6 @@ data_files = [
 for current, dirs, files in os.walk(cfg_dir ):
     for file in files:
         if file.endswith('.xml') :
-            #xf = os.path.join('chipsec','cfg') ,os.path.join(cfg_dir,file)
             xf = 'chipsec/cfg' ,['chipsec/cfg/{}'.format(file)]
             data_files.append( xf ) 
 
@@ -91,7 +90,6 @@ print("VERSION: {}".format(version))
 mypackages = []
 for current, dirs, files in os.walk(tool_dir ):
     if current.startswith(os.path.join(tool_dir,'build')): 
-        #print "*********** skipped: {}".format(current)
         continue
     for file in files:
         if file == "__init__.py":
@@ -110,13 +108,10 @@ setup(
         description     = 'CHIPSEC: Platform Security Assessment Framework',
         version         = version,
         console         = [ 'chipsec_main.py', 'chipsec_util.py' ],
-        #zipfile         = None,
         data_files      =  data_files,
         options         = {
                             'build' : { 'build_base': build_dir },
                             'py2exe': {
-                                        #"bundle_files": 1,
-                                        #'includes'    : includes,
                                         'dist_dir'    : win_7_amd64,
                                         'packages'    : mypackages,
                                         'compressed'  : True

--- a/scripts/build_exe_win7-amd64.py
+++ b/scripts/build_exe_win7-amd64.py
@@ -39,6 +39,7 @@
 # To build Windows executable chipsec.exe using py2exe:
 #
 # 1. Install py2exe package from http://www.py2exe.org
+#    * for Python 3 please use https://github.com/albertosottile/py2exe instead
 # 2. run "python build_exe_<platform>.py py2exe"
 # 3. chipsec.exe and all needed libraries will be created in "./bin/<platform>"
 #

--- a/scripts/build_exe_win7-x86.py
+++ b/scripts/build_exe_win7-x86.py
@@ -77,7 +77,6 @@ data_files = [
 for current, dirs, files in os.walk(cfg_dir ):
     for file in files:
         if file.endswith('.xml') :
-            #xf = os.path.join('chipsec','cfg') ,os.path.join(cfg_dir,file)
             xf = 'chipsec/cfg' ,['chipsec/cfg/{}'.format(file)]
             data_files.append( xf ) 
 
@@ -91,7 +90,6 @@ print("VERSION: {}".format(version))
 mypackages = []
 for current, dirs, files in os.walk(tool_dir ):
     if current.startswith(os.path.join(tool_dir,'build')): 
-        #print "*********** skipped: {}".format(current)
         continue
     for file in files:
         if file == "__init__.py":
@@ -110,13 +108,10 @@ setup(
         description     = 'CHIPSEC: Platform Security Assessment Framework',
         version         = version,
         console         = [ 'chipsec_main.py', 'chipsec_util.py' ],
-        #zipfile         = None,
         data_files      =  data_files,
         options         = {
                             'build' : { 'build_base': build_dir },
                             'py2exe': {
-                                        #"bundle_files": 1,
-                                        #'includes'    : includes,
                                         'dist_dir'    : win_7_x86,
                                         'packages'    : mypackages,
                                         'compressed'  : True

--- a/scripts/build_exe_win7-x86.py
+++ b/scripts/build_exe_win7-x86.py
@@ -100,6 +100,10 @@ for current, dirs, files in os.walk(tool_dir ):
             mypackages.append(pkg)
             print(pkg)
 
+# Don't rely on py2exe to create the dist dir
+if not os.path.exists(win_7_x86):
+    os.makedirs(win_7_x86)
+
 from distutils.core import setup
 
 

--- a/scripts/build_exe_win7-x86.py
+++ b/scripts/build_exe_win7-x86.py
@@ -47,7 +47,7 @@
 import os
 import sys
 
-print 'Python', (sys.version)
+print('Python', sys.version)
 
 import py2exe
 WIN_DRIVER_INSTALL_PATH = "chipsec/helper/win"
@@ -63,10 +63,10 @@ cfg_dir    = os.path.join(tool_dir,"chipsec","cfg")
 win_7_x86 = os.path.join(bin_dir,'win7-x86');
 
 
-print os.getcwd()
+print(os.getcwd())
 os.chdir( tool_dir )
 sys.path.append(tool_dir)
-print os.getcwd()
+print(os.getcwd())
 
 
 data_files = [
@@ -86,7 +86,7 @@ if os.path.exists(VERSION_FILE):
     data_files.append(('.',['VERSION']))
     with open(VERSION_FILE, "r") as verFile:
         version = verFile.read()
-print "VERSION: {}".format(version) 
+print("VERSION: {}".format(version))
 
 mypackages = []
 for current, dirs, files in os.walk(tool_dir ):
@@ -98,7 +98,7 @@ for current, dirs, files in os.walk(tool_dir ):
             pkg = current.replace(tool_dir+os.path.sep,"")
             pkg = pkg.replace(os.path.sep,'.')
             mypackages.append(pkg)
-            print pkg
+            print(pkg)
 
 from distutils.core import setup
 

--- a/scripts/build_exe_win7-x86.py
+++ b/scripts/build_exe_win7-x86.py
@@ -39,6 +39,7 @@
 # To build Windows executable chipsec.exe using py2exe:
 #
 # 1. Install py2exe package from http://www.py2exe.org
+#    * for Python 3 please use https://github.com/albertosottile/py2exe instead
 # 2. run "python build_exe_<platform>.py py2exe"
 # 3. chipsec.exe and all needed libraries will be created in "./bin/<platform>"
 #

--- a/scripts/build_exe_win7-x86.py
+++ b/scripts/build_exe_win7-x86.py
@@ -60,6 +60,7 @@ bin_dir = os.path.join(root_dir,"bin")
 source_dir = os.path.join(root_dir,"source")
 tool_dir   = root_dir
 cfg_dir    = os.path.join(tool_dir,"chipsec","cfg")
+version_file = os.path.join(root_dir, "chipsec", VERSION_FILE)
 
 win_7_x86 = os.path.join(bin_dir,'win7-x86');
 
@@ -82,9 +83,9 @@ for current, dirs, files in os.walk(cfg_dir ):
             data_files.append( xf ) 
 
 version=""
-if os.path.exists(VERSION_FILE):
-    data_files.append(('.',['VERSION']))
-    with open(VERSION_FILE, "r") as verFile:
+if os.path.exists(version_file):
+    data_files.append(('.',[version_file]))
+    with open(version_file, "r") as verFile:
         version = verFile.read()
 print("VERSION: {}".format(version))
 


### PR DESCRIPTION
Afterwards, one can use an up-to-date fork of `py2exe` such as https://github.com/albertosottile/py2exe to build the entire CHIPSEC distribution using Python 3.

![image](https://user-images.githubusercontent.com/8438963/72353909-7bc6da00-36ed-11ea-96d1-1bc8afa80abf.png)

Building with Python 2 still works, of course.