### PR TITLE
Check that 'uefispec_concern' is not empty before logging an error.

### DIFF
--- a/chipsec/modules/common/uefi/access_uefispec.py
+++ b/chipsec/modules/common/uefi/access_uefispec.py
@@ -1,5 +1,5 @@
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2015, Intel Corporation
+#Copyright (c) 2010-2020, Intel Corporation
 # 
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License

--- a/chipsec/modules/common/uefi/access_uefispec.py
+++ b/chipsec/modules/common/uefi/access_uefispec.py
@@ -178,7 +178,7 @@ class access_uefispec(BaseModule):
                             self.logger.log_bad("Variable {} should be read only.".format(name))
                             res = ModuleResult.FAILED
 
-        if len(uefispec_concern) > 0:
+        if uefispec_concern:
             self.logger.log('')
             self.logger.log_bad('Variables with attributes that differ from UEFI spec:')
             for name in uefispec_concern:

--- a/chipsec/modules/common/uefi/access_uefispec.py
+++ b/chipsec/modules/common/uefi/access_uefispec.py
@@ -178,10 +178,11 @@ class access_uefispec(BaseModule):
                             self.logger.log_bad("Variable {} should be read only.".format(name))
                             res = ModuleResult.FAILED
 
-        self.logger.log('')
-        self.logger.log_bad('Variables with attributes that differ from UEFI spec:')
-        for name in uefispec_concern:
-            self.logger.log('    {}'.format(name))
+        if len(uefispec_concern) > 0:
+            self.logger.log('')
+            self.logger.log_bad('Variables with attributes that differ from UEFI spec:')
+            for name in uefispec_concern:
+                self.logger.log('    {}'.format(name))
 
         if do_modify:
             self.logger.log('')


### PR DESCRIPTION
CHIPSEC currently logs an error message even if no variables with attributes different from the UEFI spec were encountered:
![image](https://user-images.githubusercontent.com/8438963/72526503-3b8f6500-386f-11ea-90d1-5a30e8dd9799.png)
