### PR TITLE
Fix TPM's _send_command method to be compatible with Python 3.

### DIFF
--- a/chipsec/hal/tpm.py
+++ b/chipsec/hal/tpm.py
@@ -266,7 +266,10 @@ class TPM(hal_base.HALBase):
             burst_count = ( ( sts_value>>8 ) & 0xFFFFFF )
             burst_index = 0
             while ( burst_index < burst_count ) and ( count < size ):
-                self.helper.write_mmio_reg( datafifo_address, 1, struct.unpack("=B", command[count])[0] )
+                datafifo_value = command[count]
+                if sys.version_info.major == 2:
+                    datafifo_value = struct.unpack("=B", datafifo_value)[0]
+                self.helper.write_mmio_reg( datafifo_address, 1, datafifo_value )
                 count += 1
                 burst_index += 0x1
 

--- a/chipsec/utilcmd/tpm_cmd.py
+++ b/chipsec/utilcmd/tpm_cmd.py
@@ -56,15 +56,16 @@ class TPMCommand(BaseCommand):
         return True
 
     def run(self):
+        if len(self.argv) < 4:
+            print (TPMCommand.__doc__)
+            return
+
         try:
             _tpm = tpm.TPM(self.cs)
         except tpm.TpmRuntimeError as msg:
             print(msg)
             return
 
-        if len(self.argv) < 4:
-            print (TPMCommand.__doc__)
-            return
         op = self.argv[2]
         if ( 'parse_log' == op ):
             log = open(self.argv[3],'rb')


### PR DESCRIPTION
- Fix TPM's `_send_command` method to be compatible with Python 3.
- Check for proper usage before constructing a TPM object. Otherwise, simply running `chipsec_util.py tpm` will raise an error instead of printing the usage message.