### PR TITLE
Fixed errors caused by list_EFI_variables in Windows.

### DIFF
--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2019, Intel Corporation
+#Copyright (c) 2010-2020, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License

--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -75,7 +75,7 @@ def parse_script( script, log_script=False ):
     if logger().HAL: logger().log( '[uefi] S3 Resume Boot-Script size: 0x{:X}'.format(off) )
     if logger().HAL: 
         logger().log( '\n[uefi] [++++++++++ S3 Resume Boot-Script Buffer ++++++++++]' )
-        print_buffer( script[ : off ] )
+        print_buffer( bytestostring(script[ : off ]) )
 
     return s3_boot_script_entries
 
@@ -420,7 +420,7 @@ NVRAM: EFI Variable Store
                 if logger().HAL: logger().log( "[uefi] found: {} {{{}}} {} variable".format(efivar_name,guid,get_attr_string(attrs)) )
                 if logger().HAL:
                     logger().log('[uefi] {} variable data:'.format(efivar_name))
-                    print_buffer( data )
+                    print_buffer( bytestostring(data) )
 
                 varsz = len(data)
                 if   4 == varsz: AcpiGlobalAddr_fmt = '<L'
@@ -437,7 +437,7 @@ NVRAM: EFI Variable Store
                 AcpiVariableSet = self.helper.read_physical_mem( AcpiGlobalAddr, ACPI_VARIABLE_SET_STRUCT_SIZE )
                 if logger().HAL:
                     logger().log('[uefi] AcpiVariableSet structure:')
-                    print_buffer( AcpiVariableSet )
+                    print_buffer( bytestostring(AcpiVariableSet) )
                 AcpiVariableSet_fmt = '<6Q'
                 #if len(AcpiVariableSet) < struct.calcsize(AcpiVariableSet_fmt):
                 #    logger().error( 'Unrecognized format of AcpiVariableSet structure' )

--- a/chipsec/helper/win/win32helper.py
+++ b/chipsec/helper/win/win32helper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2019, Intel Corporation
+#Copyright (c) 2010-2020, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License

--- a/chipsec/modules/common/secureboot/variables.py
+++ b/chipsec/modules/common/secureboot/variables.py
@@ -99,7 +99,7 @@ class variables(BaseModule):
 
         sbvars = self._uefi.list_EFI_variables()
         if sbvars is None:
-            self.logger.log_warn_check( 'Could not enumerate UEFI variables (Windows Enterprise?)' )
+            self.logger.log_warn_check( 'Could not enumerate UEFI variables.' )
             return ModuleResult.SKIPPED
 
         for name in SECURE_BOOT_VARIABLES:

--- a/chipsec/modules/common/secureboot/variables.py
+++ b/chipsec/modules/common/secureboot/variables.py
@@ -99,8 +99,8 @@ class variables(BaseModule):
 
         sbvars = self._uefi.list_EFI_variables()
         if sbvars is None:
-            self.logger.log_error_check( 'Could not enumerate UEFI variables (non-UEFI OS?)' )
-            return ModuleResult.ERROR
+            self.logger.log_warn_check( 'Could not enumerate UEFI variables (Windows Enterprise?)' )
+            return ModuleResult.SKIPPED
 
         for name in SECURE_BOOT_VARIABLES:
 

--- a/chipsec/modules/common/uefi/access_uefispec.py
+++ b/chipsec/modules/common/uefi/access_uefispec.py
@@ -131,7 +131,7 @@ class access_uefispec(BaseModule):
         error = False
         vars = self._uefi.list_EFI_variables()
         if vars is None:
-            self.logger.log_warn_check( 'Could not enumerate UEFI Variables from runtime (Windows Enterprise?)' )
+            self.logger.log_warn_check( 'Could not enumerate UEFI Variables from runtime.' )
             self.logger.log_important( "Note that UEFI variables may still exist, OS just did not expose runtime UEFI Variable API to read them.\nYou can extract variables directly from ROM file via 'chipsec_util.py uefi nvram bios.bin' command and verify their attributes manually." )
             return ModuleResult.SKIPPED
 

--- a/chipsec/modules/common/uefi/access_uefispec.py
+++ b/chipsec/modules/common/uefi/access_uefispec.py
@@ -131,9 +131,9 @@ class access_uefispec(BaseModule):
         error = False
         vars = self._uefi.list_EFI_variables()
         if vars is None:
-            self.logger.log_error_check( 'Could not enumerate UEFI Variables from runtime (Legacy OS?)' )
+            self.logger.log_warn_check( 'Could not enumerate UEFI Variables from runtime (Windows Enterprise?)' )
             self.logger.log_important( "Note that UEFI variables may still exist, OS just did not expose runtime UEFI Variable API to read them.\nYou can extract variables directly from ROM file via 'chipsec_util.py uefi nvram bios.bin' command and verify their attributes manually." )
-            return ModuleResult.ERROR
+            return ModuleResult.SKIPPED
 
         bsnv_vars = []
         bsnv_concern = []

--- a/chipsec/modules/common/uefi/s3bootscript.py
+++ b/chipsec/modules/common/uefi/s3bootscript.py
@@ -139,7 +139,7 @@ class s3bootscript(BaseModule):
             found,bootscript_PAs = self._uefi.find_s3_bootscript()
             if not found:
                 self.logger.log_good( "Didn't find any S3 boot-scripts in EFI variables" )
-                self.logger.log_warn_check( "S3 Boot-Script was not found. Firmware may be using other ways to store/locate it" )
+                self.logger.log_warn_check( "S3 Boot-Script was not found. Firmware may be using other ways to store/locate it, or OS might be blocking access." )
                 return ModuleResult.WARNING
 
             self.logger.log_important( 'Found {:d} S3 boot-script(s) in EFI variables'.format(len(bootscript_PAs)) )


### PR DESCRIPTION
Fixing issues in helper/modules that are caused by some versions of windows blocking runtime access to UEFI varialbes. Also fixed issue print_buffer issue when using --hal.

Signed-off-by: Nathaniel Mitchell <nathaniel.p.mitchell@intel.com>