### PR TITLE
The path to library.zip should be relative to the root executable.

### DIFF
--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -106,7 +106,7 @@ class ChipsecUtil:
     def import_cmds(self):
         if self.CHIPSEC_LOADED_AS_EXE:
             import zipfile
-            myzip = zipfile.ZipFile("library.zip")
+            myzip = zipfile.ZipFile(os.path.join(get_main_dir(),"library.zip"))
             cmds = [i.replace('/','.').replace('chipsec.utilcmd.','')[:-4] for i in myzip.namelist() if 'chipsec/utilcmd/' in i and i[-4:] == ".pyc" and not os.path.basename(i)[:2] == '__' ]
         else:
             cmds_dir = os.path.join(get_main_dir(),"chipsec","utilcmd")


### PR DESCRIPTION
The path to `library.zip` should be relative to the root executable, not to the current working directory. Using a path relative to the CWD means we won't be able to execute `chipsec_util.exe` unless we first `cd` into its directory.

![image](https://user-images.githubusercontent.com/8438963/73841390-33e62f00-4823-11ea-8e9c-c78d51f6d5b7.png)
