### PR TITLE
Correctly set py2exe root dir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ drivers/win7/x64/
 
 # Compression tools
 chipsec_tools/compression/Bin/
+
+# py2exe
+bin/
+scripts/bdist.win-amd64/

--- a/scripts/build_exe_win7-amd64.py
+++ b/scripts/build_exe_win7-amd64.py
@@ -55,7 +55,7 @@ WIN_DRIVER_INSTALL_PATH = "chipsec/helper/win"
 VERSION_FILE="VERSION"
 
 build_dir = os.getcwd()
-root_dir = os.path.abspath(os.pardir)
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
 bin_dir = os.path.join(root_dir,"bin")
 source_dir = os.path.join(root_dir,"source")
 tool_dir   = root_dir

--- a/scripts/build_exe_win7-amd64.py
+++ b/scripts/build_exe_win7-amd64.py
@@ -57,7 +57,6 @@ VERSION_FILE="VERSION"
 build_dir = os.getcwd()
 root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
 bin_dir = os.path.join(root_dir,"bin")
-source_dir = os.path.join(root_dir,"source")
 tool_dir   = root_dir
 cfg_dir    = os.path.join(tool_dir,"chipsec","cfg")
 version_file = os.path.join(root_dir, "chipsec", VERSION_FILE)

--- a/scripts/build_exe_win7-x86.py
+++ b/scripts/build_exe_win7-x86.py
@@ -55,7 +55,7 @@ WIN_DRIVER_INSTALL_PATH = "chipsec/helper/win"
 VERSION_FILE="VERSION"
 
 build_dir = os.getcwd()
-root_dir = os.path.abspath(os.pardir)
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
 bin_dir = os.path.join(root_dir,"bin")
 source_dir = os.path.join(root_dir,"source")
 tool_dir   = root_dir

--- a/scripts/build_exe_win7-x86.py
+++ b/scripts/build_exe_win7-x86.py
@@ -57,7 +57,6 @@ VERSION_FILE="VERSION"
 build_dir = os.getcwd()
 root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
 bin_dir = os.path.join(root_dir,"bin")
-source_dir = os.path.join(root_dir,"source")
 tool_dir   = root_dir
 cfg_dir    = os.path.join(tool_dir,"chipsec","cfg")
 version_file = os.path.join(root_dir, "chipsec", VERSION_FILE)


### PR DESCRIPTION
The `py2exe` build scripts used to have a limitation where the user had to `cd` into the `scripts` directory before running them (otherwise things would break).