### PR TITLE
Issue warning when Python architecture is different from OS architecture.

### DIFF
--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -81,6 +81,7 @@ class ChipsecMain:
     def __init__(self, argv):
         self.CHIPSEC_FOLDER        = os.path.abspath(chipsec.file.get_main_dir())
         self.CHIPSEC_LOADED_AS_EXE = chipsec.file.main_is_frozen()
+        self.PYTHON_64_BITS        = True if (sys.maxsize > 2**32) else False
         self.ZIP_MODULES_RE        = None
         self.Import_Path           = "chipsec.modules."
         self.Modules_Path          = os.path.join(self.CHIPSEC_FOLDER,"chipsec","modules")
@@ -432,10 +433,13 @@ class ChipsecMain:
 
     def log_properties( self ):
         logger().log("[CHIPSEC] OS      : {} {} {} {}".format(self._cs.helper.os_system, self._cs.helper.os_release, self._cs.helper.os_version, self._cs.helper.os_machine) )
-        logger().log("[CHIPSEC] Python  : {} ({})".format(platform.python_version(),"64-bit" if sys.maxsize > 2**32 else "32-bit"))
+        logger().log("[CHIPSEC] Python  : {} ({})".format(platform.python_version(),"64-bit" if self.PYTHON_64_BITS else "32-bit"))
         logger().log("[CHIPSEC] Helper  : {} ({})".format(*self._cs.helper.helper.get_info()))
         logger().log("[CHIPSEC] Platform: {}\n[CHIPSEC]      VID: {:04X}\n[CHIPSEC]      DID: {:04X}\n[CHIPSEC]      RID: {:02X}".format(self._cs.longname, self._cs.vid, self._cs.did, self._cs.rid))
         logger().log("[CHIPSEC] PCH     : {}\n[CHIPSEC]      VID: {:04X}\n[CHIPSEC]      DID: {:04X}\n[CHIPSEC]      RID: {:02X}".format(self._cs.pch_longname, self._cs.pch_vid, self._cs.pch_did, self._cs.pch_rid))
+        
+        if not self.PYTHON_64_BITS and platform.machine().endswith("64"):
+            logger().warn("Python architecture (32-bit) is different from OS architecture (64-bit)")
 
     ##################################################################################
     # Entry point for command-line execution

--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -64,7 +64,9 @@ class ChipsecUtil:
         self.commands = {}
         # determine if CHIPSEC is loaded as chipsec_*.exe or in python
         self.CHIPSEC_LOADED_AS_EXE = True if (hasattr(sys, "frozen") or hasattr(sys, "importers")) else False
-
+        # determine if the hosting Python interpreter is a 64-bit executable
+        self.PYTHON_64_BITS = True if (sys.maxsize > 2**32) else False
+        
         self.argv = argv
         self.print_banner()
         self.import_cmds()
@@ -185,8 +187,11 @@ class ChipsecUtil:
                      "################################################################")
         logger().log("[CHIPSEC] Version : {}".format(get_version()))
         logger().log("[CHIPSEC] OS      : {} {} {} {}".format(platform.system(), platform.release(), platform.version(), platform.machine()))
-        logger().log("[CHIPSEC] Python  : {} ({})".format(platform.python_version(),"64-bit" if sys.maxsize > 2**32 else "32-bit"))
+        logger().log("[CHIPSEC] Python  : {} ({})".format(platform.python_version(),"64-bit" if self.PYTHON_64_BITS else "32-bit"))
         logger().log(get_message())
+        
+        if not self.PYTHON_64_BITS and platform.machine().endswith("64"):
+            logger().warn("Python architecture (32-bit) is different from OS architecture (64-bit)")
 
 def main(argv=None):
     chipsecUtil = ChipsecUtil(argv if argv else sys.argv[1:])


### PR DESCRIPTION
Running CHIPSEC from a 32-bit Python environment on a 64-bit OS will usually lead to some unexpected failures and should generally be avoided. For example, on Windows CHIPSEC won't be even able to locate the helper driver due to WoW64 filesystem redirection issues.