### PR TITLE
Changed the method used for counting the number of threads

### DIFF
--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -1177,8 +1177,8 @@ class LinuxHelper(Helper):
     # Logical CPU count
     #
     def get_threads_count ( self ):
-        import subprocess
-        return int(subprocess.check_output("grep -c process /proc/cpuinfo", shell=True))
+        import multiprocessing
+        return multiprocessing.cpu_count()
 
 def get_helper():
     return LinuxHelper()


### PR DESCRIPTION
The current method breaks when 'process' is found in the CPU
brand string. Instead use the multiprocessing module to collect
this information.

We could get the information from the MSR but that method does
not work when one or more CPUs are offline.

Signed-off-by: Ignacio Hernandez <ignacio.hernandez@intel.com>