### PR TITLE
linux helper HAS_EFI bugfix

### DIFF
--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -24,7 +24,7 @@ check_kernel_dir:
 
 chipsec: check_kernel_dir clean
 	nasm -f $(elf-size) -o $(asm-path)/cpu.o $(asm-path)/cpu.asm
-	@if [ `grep -c 'D efi' /proc/kallsyms` != "0" ]; then \
+	@if [ `grep -c 'efi_call' /proc/kallsyms` != "0" ]; then \
 	    make CFLAGS_MODULE=-DHAS_EFI=1 -C $(KERNEL_SRC_DIR) M=${CURDIR} modules; \
 	else \
 	    make -C $(KERNEL_SRC_DIR) M=${CURDIR} modules; \


### PR DESCRIPTION
Linux helper Makefile uses `grep -c 'D efi' /proc/kallsyms` search string in order to check if kernel image was built with EFI support which is quite unreliable, it is better to grep by `efi_call`.
Here's some example from my Gentoo system:
```
# uname -a
Linux HWSEC 4.19.97-gentoo-x86_64 #1 SMP Thu Mar 26 09:52:53 -00 2020 x86_64 Intel(R) Atom(TM) Processor E3950 @ 1.60GHz GenuineIntel GNU/Linux
# grep -c 'D efi' /proc/kallsyms
0
# grep -c 'efi_call' /proc/kallsyms
7
```
