### PR TITLE
Make the platform cfg loader to only accept hex based names

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -35,6 +35,7 @@ from chipsec.hal import cpu, io, iobar, mmio, msgbus, msr, pci, physmem, ucode, 
 from chipsec.hal.pci import PCI_HDR_RID_OFF
 
 from chipsec.logger import logger
+from chipsec.defines import is_hex
 
 import chipsec.file
 
@@ -341,7 +342,7 @@ class Chipset:
 
         # find VID
         _cfg_path = os.path.join( chipsec.file.get_main_dir(), 'chipsec', 'cfg' )
-        VID = [f for f in os.listdir(_cfg_path) if os.path.isdir(os.path.join(_cfg_path, f)) and not f[:2] == '__' ]
+        VID = [f for f in os.listdir(_cfg_path) if os.path.isdir(os.path.join(_cfg_path, f)) and is_hex(f) ]
         # create dictionaries
         for vid in VID:
             self.chipset_dictionary[int(vid,16)] = collections.defaultdict(list)

--- a/chipsec/defines.py
+++ b/chipsec/defines.py
@@ -180,6 +180,9 @@ def get_version():
 def is_printable(seq):
     return set(seq).issubset(set(string.printable))
 
+def is_hex(maybe_hex):
+    return all(char in string.hexdigits for char in maybe_hex)
+
 def get_message():
     msg_str = ""
     chipsec_folder = os.path.abspath(chipsec.file.get_main_dir())


### PR DESCRIPTION
In the cfg folder, filter out the non-hex folder names, currently
we only filter out folders whose name starts with '__'

Signed-off-by: Ignacio Hernandez <ignacio.hernandez@intel.com>