### PR TITLE
Add cpuid option when identifing cpu

### DIFF
--- a/chipsec/cfg/8086/cfl.xml
+++ b/chipsec/cfg/8086/cfl.xml
@@ -12,7 +12,7 @@ XML configuration file for Coffee Lake
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core">
+  <info family="core" detection_value="906EA, 906EB, 906EC">
     <sku did="0x3E0F" name="CoffeeLake" code="CFL" longname="Desktop 8th Generation Core Processor (CoffeeLake S 2 Cores)" />
     <sku did="0x3E1F" name="CoffeeLake" code="CFL" longname="Desktop 8th Generation Core Processor (Coffeelake S 4 Cores)" />
     <sku did="0x3EC2" name="CoffeeLake" code="CFL" longname="Desktop 8th Generation Core Processor (Coffeelake S 6 Cores)" />
@@ -24,7 +24,7 @@ XML configuration file for Coffee Lake
     <sku did="0x3E18" name="CoffeeLake" code="CFL" longname="Desktop 8th Generation Core Processor (CoffeeLake Workstation 4 Cores)" />
     <sku did="0x3EC6" name="CoffeeLake" code="CFL" longname="Desktop 8th Generation Core Processor (CoffeeLake Workstation 6 Cores)" />
     <sku did="0x3E31" name="CoffeeLake" code="CFL" longname="Desktop 8th Generation Core Processor (CoffeeLake Workstation 8 Cores)" />
-    <sku did="0x3E33" name="CoffeeLake" code="CFL" longname="Desktop 8th Generation Core Processor (CoffeeLake Server 4 Cores)" detection_value="906EA" />
+    <sku did="0x3E33" name="CoffeeLake" code="CFL" longname="Desktop 8th Generation Core Processor (CoffeeLake Server 4 Cores)" />
     <sku did="0x3ECA" name="CoffeeLake" code="CFL" longname="Desktop 8th Generation Core Processor (CoffeeLake Server 6 Cores)" />
     <sku did="0x3E32" name="CoffeeLake" code="CFL" longname="Desktop 8th Generation Core Processor (CoffeeLake Server 8 Cores)" />
   </info>

--- a/chipsec/cfg/8086/cml.xml
+++ b/chipsec/cfg/8086/cml.xml
@@ -7,10 +7,10 @@
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core">
+  <info family="core" detection_value="806EC, A0652, A0653, A0655, A0660">
     <sku did="0x3E35" name="CometLake" code="CML" longname="CometLake v1 U2 Core" />
-    <sku did="0x3E34" name="CometLake" code="CML" longname="CometLake v1 U4 Core" detection_value="806EC" />
-    <sku did="0x3E33" name="CometLake" code="CML" longname="CometLake v1 U6 Core" detection_value="806EC" />
+    <sku did="0x3E34" name="CometLake" code="CML" longname="CometLake v1 U4 Core" />
+    <sku did="0x3E33" name="CometLake" code="CML" longname="CometLake v1 U6 Core" />
     <sku did="0x9B51" name="CometLake" code="CML" longname="CometLake v1/v2 U6 Core" />
     <sku did="0x9B61" name="CometLake" code="CML" longname="CometLake U" />
   </info>

--- a/chipsec/cfg/8086/whl.xml
+++ b/chipsec/cfg/8086/whl.xml
@@ -13,9 +13,9 @@ XML configuration file for Whiskey Lake
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core">
-    <sku did="0x3E34" name="Whiskey Lake" code="WHL" longname="Mobile 8th Generation Core Processor (Whiskey Lake U 4 Cores)" detection_value="806EA" />
-    <sku did="0x3E34" name="Whiskey Lake" code="WHL" longname="Mobile 8th Generation Core Processor (Whiskey Lake U 4 Cores)" detection_value="806EB" />
+  <info family="core" detection_value="806EA, 806EB">
+    <sku did="0x3E34" name="Whiskey Lake" code="WHL" longname="Mobile 8th Generation Core Processor (Whiskey Lake U 4 Cores)" />
+    <sku did="0x3E34" name="Whiskey Lake" code="WHL" longname="Mobile 8th Generation Core Processor (Whiskey Lake U 4 Cores)" />
   </info>
 
   <!-- #################################### -->

--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -393,7 +393,7 @@ class Chipset:
                             if _info.attrib['family'].lower() == "quark":
                                 CHIPSET_FAMILY_QUARK.append(_cfg.attrib['platform'].upper())
                         if 'detection_value' in _info.attrib:
-                            for dv in list(_info.attrib['detection_value'].split(', ')):
+                            for dv.strip() in list(_info.attrib['detection_value'].split(',')):
                                 self.detection_dictionary[dv] = _cfg.attrib['platform'].upper()
                         if _info.iter('sku'):
                             for _sku in _info.iter('sku'):

--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -244,6 +244,7 @@ class Chipset:
                 self.did = did
                 self.rid = rid
             elif cpuid in self.detection_dictionary.keys():
+                _unknown_platform = False
                 self.code       = self.detection_dictionary[cpuid]
                 self.longname   = self.detection_dictionary[cpuid]
                 self.vid = vid
@@ -391,7 +392,7 @@ class Chipset:
                                 CHIPSET_FAMILY_XEON.append(_cfg.attrib['platform'].upper())
                             if _info.attrib['family'].lower() == "quark":
                                 CHIPSET_FAMILY_QUARK.append(_cfg.attrib['platform'].upper())
-                        if 'detection_value' in info.attrib:
+                        if 'detection_value' in _info.attrib:
                             for dv in list(_info.attrib['detection_value'].split(', ')):
                                 self.detection_dictionary[dv] = _cfg.attrib['platform'].upper()
                         if _info.iter('sku'):


### PR DESCRIPTION
If cpuid is within configuration file, can assign cpu configuration
without did

Signed-off-by: brentholtsclaw <brent.holtsclaw@intel.com>