### PR TITLE
XML fix to correctly identify a system

### DIFF
--- a/chipsec/cfg/8086/cml.xml
+++ b/chipsec/cfg/8086/cml.xml
@@ -7,7 +7,7 @@
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core" detection_value="806EC, A0652, A0653, A0655, A0660">
+  <info family="core" detection_value="A0652, A0653, A0655, A0660">
     <sku did="0x3E35" name="CometLake" code="CML" longname="CometLake v1 U2 Core" />
     <sku did="0x3E34" name="CometLake" code="CML" longname="CometLake v1 U4 Core" />
     <sku did="0x3E33" name="CometLake" code="CML" longname="CometLake v1 U6 Core" />

--- a/chipsec/cfg/8086/whl.xml
+++ b/chipsec/cfg/8086/whl.xml
@@ -13,8 +13,7 @@ XML configuration file for Whiskey Lake
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core" detection_value="806EA, 806EB">
-    <sku did="0x3E34" name="Whiskey Lake" code="WHL" longname="Mobile 8th Generation Core Processor (Whiskey Lake U 4 Cores)" />
+  <info family="core" detection_value="806EA, 806EB, 806EC">
     <sku did="0x3E34" name="Whiskey Lake" code="WHL" longname="Mobile 8th Generation Core Processor (Whiskey Lake U 4 Cores)" />
   </info>
 


### PR DESCRIPTION
The WHL xml file listed twice an sku, which was also defined in
CML. That caused the cpu to be identified using cpuid, which was
also mistaken, CML had an WHL cpuid listed.

Signed-off-by: Ignacio Hernandez <ignacio.hernandez@intel.com>