### PR TITLE
Fix chipsec.ko driver filepath for linux

### DIFF
--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -152,7 +152,7 @@ class LinuxHelper(Helper):
             else:
                 a2 = "a2=0x{}".format(phys_mem_access_prot)
 
-        driver_path = os.path.join(chipsec.file.get_main_dir(), "chipsec", "helper", "linux", "chipsec.ko" )
+        driver_path = os.path.join(chipsec.file.get_main_dir(), "drivers", "linux", "chipsec.ko" )
         if not os.path.exists(driver_path):
             driver_path += ".xz"
             if not os.path.exists(driver_path):


### PR DESCRIPTION
In building Chipsec [rel 1.5.6](https://github.com/chipsec/chipsec/releases/tag/1.5.6) for Ubuntu 18.04 with `Linux 5.4.0-53-generic`, I had the following message when i ran `# python chipsec_main.py`

`ERROR: Message: "Cannot find chipsec.ko module"`

It seems that the file path was erroneous and i changed it in this PR.