### PR TITLE
docs: fix simple typo, incompatibe -> incompatible

### DIFF
--- a/chipsec/modules/tools/vmm/hv/hypercallfuzz.py
+++ b/chipsec/modules/tools/vmm/hv/hypercallfuzz.py
@@ -34,7 +34,7 @@ Usage:
     - ``vector``		hypercall vector
     - ``iterations``		number of hypercall iterations
 
-Note: the fuzzer is incompatibe with native VMBus driver (``vmbus.sys``). To use it, remove ``vmbus.sys``
+Note: the fuzzer is incompatible with native VMBus driver (``vmbus.sys``). To use it, remove ``vmbus.sys``
 """
 from define                 import *
 from hypercall              import *
@@ -56,7 +56,7 @@ class HypercallFuzz(BaseModule):
         print ('        = custom-fuzzing  fuzzing of known hypercalls')
         print ('      vector              hypercall vector')
         print ('      iterations          number of hypercall iterations')
-        print ('  Note: the fuzzer is incompatibe with native VMBus driver (vmbus.sys). To use it, remove vmbus.sys')
+        print ('  Note: the fuzzer is incompatible with native VMBus driver (vmbus.sys). To use it, remove vmbus.sys')
         return
 
     def run(self, module_argv):

--- a/chipsec/modules/tools/vmm/hv/synth_dev.py
+++ b/chipsec/modules/tools/vmm/hv/synth_dev.py
@@ -32,7 +32,7 @@ Usage:
 
   ``chipsec_main.py -i -m tools.vmm.hv.synth_dev -a fuzz,<relid> -l log.txt``
 
-Note: the fuzzer is incompatibe with native VMBus driver (``vmbus.sys``). To use it, remove ``vmbus.sys``
+Note: the fuzzer is incompatible with native VMBus driver (``vmbus.sys``). To use it, remove ``vmbus.sys``
 """
 import time
 from struct    import *
@@ -98,7 +98,7 @@ class synth_dev(BaseModule):
         print ('      print channel offers')
         print ('    chipsec_main.py -i -m tools.vmm.hv.synth_dev -a fuzz,<relid>')
         print ('      fuzzing device with specified relid')
-        print ('  Note: the fuzzer is incompatibe with native VMBus driver (vmbus.sys). To use it, remove vmbus.sys')
+        print ('  Note: the fuzzer is incompatible with native VMBus driver (vmbus.sys). To use it, remove vmbus.sys')
         return
 
     def run(self, module_argv):

--- a/chipsec/modules/tools/vmm/hv/synth_kbd.py
+++ b/chipsec/modules/tools/vmm/hv/synth_kbd.py
@@ -25,7 +25,7 @@ Hyper-V VMBus synthetic keyboard fuzzer. Fuzzes inbound ring buffer in VMBus vir
 Usage:
   ``chipsec_main.py -i -m tools.vmm.hv.synth_kbd -a fuzz -l log.txt``
 
-Note: the fuzzer is incompatibe with native VMBus driver (``vmbus.sys``). To use it, remove ``vmbus.sys``
+Note: the fuzzer is incompatible with native VMBus driver (``vmbus.sys``). To use it, remove ``vmbus.sys``
 """
 from struct  import *
 from random  import *
@@ -70,7 +70,7 @@ class synth_kbd(BaseModule):
     def usage(self):
         print ('  Usage:')
         print ('    chipsec_main.py -i -m tools.vmm.hv.synth_kbd -a fuzz')
-        print ('  Note: the fuzzer is incompatibe with native VMBus driver (vmbus.sys). To use it, remove vmbus.sys')
+        print ('  Note: the fuzzer is incompatible with native VMBus driver (vmbus.sys). To use it, remove vmbus.sys')
         return
 
     def run(self, module_argv):

--- a/chipsec/modules/tools/vmm/hv/vmbusfuzz.py
+++ b/chipsec/modules/tools/vmm/hv/vmbusfuzz.py
@@ -32,7 +32,7 @@ Usage:
     - ``vmbus``        fuzzing HyperV message body / VMBUS message
     - ``<pos>,<size>`` fuzzing number of bytes at specific position
 
-Note: the fuzzer is incompatibe with native VMBus driver (``vmbus.sys``). To use it, remove ``vmbus.sys``
+Note: the fuzzer is incompatible with native VMBus driver (``vmbus.sys``). To use it, remove ``vmbus.sys``
 """
 from struct import *
 from random import *
@@ -108,7 +108,7 @@ class VMBusFuzz(VMBusDiscovery):
         self.logger.log('        hv           fuzzing HyperV message header')
         self.logger.log('        vmbus        fuzzing HyperV message body / VMBUS message')
         self.logger.log('        <pos>,<size> fuzzing number of bytes at specific position')
-        self.logger.log('  Note: the fuzzer is incompatibe with native VMBus driver (vmbus.sys). To use it, remove vmbus.sys')
+        self.logger.log('  Note: the fuzzer is incompatible with native VMBus driver (vmbus.sys). To use it, remove vmbus.sys')
 
     def run(self, module_argv):
         self.logger.start_test( "Hyper-V VMBus fuzzer" )


### PR DESCRIPTION
There is a small typo in chipsec/modules/tools/vmm/hv/hypercallfuzz.py, chipsec/modules/tools/vmm/hv/synth_dev.py, chipsec/modules/tools/vmm/hv/synth_kbd.py, chipsec/modules/tools/vmm/hv/vmbusfuzz.py.

Should read `incompatible` rather than `incompatibe`.

