### PR TITLE
Changes in modules for manual

### DIFF
--- a/chipsec/cfg/8086/sfdp.xml
+++ b/chipsec/cfg/8086/sfdp.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 <configuration>
+<!--
+XML configuration for Serial Flash Discoverable Parameter feature
+document: https://www.jedec.org/system/files/docs/JESD216D-01.pdf
+-->
   <registers>
 	<register name="DWORD1"             offset="0x00" type="R Byte"    desc="JEDEC Basic Flash Parameter Table: 1st DWORD " >
 	<field name="BLK_ERASE_SUPPORT"              bit="0" size="2" desc="Block Sector Erase Sizes" />

--- a/chipsec/hal/msgbus.py
+++ b/chipsec/hal/msgbus.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2020, Intel Corporation
+#Copyright (c) 2010-2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -24,9 +24,6 @@
 Access to message bus (IOSF sideband) interface registers on Intel SoCs
 
 References:
-
-- Intel(R) Atom(TM) Processor E3800 Product Family Datasheet, May 2016, Revision 4.0
-  http://www.intel.com/content/www/us/en/embedded/products/bay-trail/atom-e3800-family-datasheet.html (sections 3.6 and 13.4.6 - 13.4.8)
 
 - Intel(R) Atom(TM) Processor D2000 and N2000 Series Datasheet, Volume 2, July 2012, Revision 003
   http://www.intel.com/content/dam/doc/datasheet/atom-d2000-n2000-vol-2-datasheet.pdf (section 1.10.2)

--- a/chipsec/hal/spd.py
+++ b/chipsec/hal/spd.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2020, Intel Corporation
+#Copyright (c) 2010-2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -28,9 +28,9 @@ http://www.jedec.org/sites/default/files/docs/4_01_02R19.pdf
 http://www.jedec.org/sites/default/files/docs/4_01_02_10R17.pdf
 http://www.jedec.org/sites/default/files/docs/4_01_02_11R24.pdf
 http://www.jedec.org/sites/default/files/docs/4_01_02_12R23A.pdf
-http://www.simmtester.com/page/news/showpubnews.asp?num=184
-http://www.simmtester.com/page/news/showpubnews.asp?num=153
-http://www.simmtester.com/page/news/showpubnews.asp?num=101
+https://www.simmtester.com/News/PublicationArticle/184
+https://www.simmtester.com/News/PublicationArticle/153
+https://www.simmtester.com/News/PublicationArticle/101
 http://en.wikipedia.org/wiki/Serial_presence_detect
 """
 

--- a/chipsec/modules/common/cpu/cpu_info.py
+++ b/chipsec/modules/common/cpu/cpu_info.py
@@ -1,5 +1,5 @@
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2018 - 2019, Intel Corporation
+#Copyright (c) 2018 - 2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -17,6 +17,10 @@
 #Contact information:
 #chipsec@intel.com
 #
+
+"""
+Displays CPU information 
+"""
 
 import struct
 from chipsec.module_common import BaseModule, ModuleResult

--- a/chipsec/modules/common/cpu/ia_untrusted.py
+++ b/chipsec/modules/common/cpu/ia_untrusted.py
@@ -1,5 +1,5 @@
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2018-2020, Intel Corporation
+#Copyright (c) 2018-2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -18,6 +18,9 @@
 #chipsec@intel.com
 #
 
+"""
+IA Untrusted checks
+"""
 
 from chipsec.module_common import BaseModule, ModuleResult, MTAG_HWCONFIG
 

--- a/chipsec/modules/common/me_mfg_mode.py
+++ b/chipsec/modules/common/me_mfg_mode.py
@@ -1,6 +1,6 @@
 # CHIPSEC: Platform Security Assessment Framework
 # Copyright (c) 2018, Eclypsium, Inc.
-# Copyright (c) 2019-2020, Intel Corporation
+# Copyright (c) 2019-2021, Intel Corporation
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -22,9 +22,9 @@ References:
 
 https://blog.ptsecurity.com/2018/10/intel-me-manufacturing-mode-macbook.html
 
-https://github.com/coreboot/coreboot/blob/master/src/soc/intel/*/include/soc/pci_devs.h
+`PCI_DEVS.H <https://github.com/coreboot/coreboot/blob/master/src/soc/intel/*/include/soc/pci_devs.h>`_
 
-Code::
+.. code-block::
 
     #define PCH_DEV_SLOT_CSE        0x16
     #define  PCH_DEVFN_CSE          _PCH_DEVFN(CSE, 0)
@@ -32,24 +32,23 @@ Code::
 
 https://github.com/coreboot/coreboot/blob/master/src/soc/intel/apollolake/cse.c
 
-Code::
+.. code-block::
 
     fwsts1 = dump_status(1, PCI_ME_HFSTS1);
+    # Minimal decoding is done here in order to call out most important
+    # pieces. Manufacturing mode needs to be locked down prior to shipping
+    # the product so it's called out explicitly.
+    printk(BIOS_DEBUG, "ME: Manufacturing Mode      : %s", (fwsts1 & (1 << 0x4)) ? "YES" : "NO");
 
-    /* Minimal decoding is done here in order to call out most important
-       pieces. Manufacturing mode needs to be locked down prior to shipping
-       the product so it's called out explicitly. */
-       printk(BIOS_DEBUG, "ME: Manufacturing Mode      : %s", (fwsts1 & (1 << 0x4)) ? "YES" : "NO");
+`PCH.H <https://github.com/coreboot/coreboot/blob/master/src/southbridge/intel/*/pch.h>`_
 
-https://github.com/coreboot/coreboot/blob/master/src/southbridge/intel/*/pch.h
-
-Code::
+.. code-block::
 
     #define PCH_ME_DEV                PCI_DEV(0, 0x16, 0)
 
-https://github.com/coreboot/coreboot/blob/master/src/southbridge/intel/*/me.h
+`ME.H <https://github.com/coreboot/coreboot/blob/master/src/southbridge/intel/*/me.h>`_
 
-Code::
+.. code-block::
 
     struct me_hfs {
             u32 working_state: 4;
@@ -67,9 +66,9 @@ Code::
             u32 bios_msg_ack: 4;
     } __packed;
 
-https://github.com/coreboot/coreboot/blob/master/src/southbridge/intel/*/me_status.c
+`ME_STATUS.C <https://github.com/coreboot/coreboot/blob/master/src/southbridge/intel/*/me_status.c>`_
 
-Code::
+.. code-block::
 
      printk(BIOS_DEBUG, "ME: Manufacturing Mode      : %s", hfs->mfg_mode ? "YES" : "NO");
 

--- a/chipsec/modules/tools/vmm/hv/hypercall.py
+++ b/chipsec/modules/tools/vmm/hv/hypercall.py
@@ -1,5 +1,5 @@
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2018, Intel Corporation
+#Copyright (c) 2010-2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -28,14 +28,14 @@ import sys
 import time
 import binascii
 import chipsec_util
-from random                           import *
-from struct                           import *
-from define                           import *
-from chipsec.modules.tools.vmm.common import *
-from chipsec.logger                   import *
-from chipsec.file                     import *
-from chipsec.module_common            import *
-from chipsec.hal.vmm                  import *
+from random                                import *
+from struct                                import *
+from chipsec.modules.tools.vmm.hv.define   import *
+from chipsec.modules.tools.vmm.common      import *
+from chipsec.logger                        import *
+from chipsec.file                          import *
+from chipsec.module_common                 import *
+from chipsec.hal.vmm                       import *
 
 class HyperVHypercall(BaseModuleHwAccess):
     def __init__(self):

--- a/chipsec/modules/tools/vmm/hv/hypercallfuzz.py
+++ b/chipsec/modules/tools/vmm/hv/hypercallfuzz.py
@@ -1,5 +1,5 @@
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2018, Intel Corporation
+#Copyright (c) 2010-2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -36,9 +36,9 @@ Usage:
 
 Note: the fuzzer is incompatible with native VMBus driver (``vmbus.sys``). To use it, remove ``vmbus.sys``
 """
-from define                 import *
-from hypercall              import *
-from chipsec.module_common  import *
+from chipsec.modules.tools.vmm.hv.define       import *
+from chipsec.modules.tools.vmm.hv.hypercall    import *
+from chipsec.module_common                     import *
 
 # Hypercall vectors excluded from scan/fuzzing
 excluded_hypercalls_from_scan = []

--- a/chipsec/modules/tools/vmm/hv/synth_dev.py
+++ b/chipsec/modules/tools/vmm/hv/synth_dev.py
@@ -1,5 +1,5 @@
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2018, Intel Corporation
+#Copyright (c) 2010-2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -38,9 +38,9 @@ import time
 from struct    import *
 from random    import *
 from binascii  import *
-from define    import *
-from chipsec.modules.tools.vmm.common import *
-from vmbus     import *
+from chipsec.modules.tools.vmm.hv.define    import *
+from chipsec.modules.tools.vmm.common       import *
+from chipsec.modules.tools.vmm.hv.vmbus     import *
 import chipsec_util
 
 sys.stdout = session_logger(True, 'synth_dev')

--- a/chipsec/modules/tools/vmm/hv/synth_kbd.py
+++ b/chipsec/modules/tools/vmm/hv/synth_kbd.py
@@ -1,5 +1,5 @@
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2018, Intel Corporation
+#Copyright (c) 2010-2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -29,10 +29,10 @@ Note: the fuzzer is incompatible with native VMBus driver (``vmbus.sys``). To us
 """
 from struct  import *
 from random  import *
-from define  import *
-from chipsec.modules.tools.vmm.common import *
-from vmbus   import *
-from chipsec.defines import *
+from chipsec.modules.tools.vmm.hv.define  import *
+from chipsec.modules.tools.vmm.common     import *
+from chipsec.modules.tools.vmm.hv.vmbus   import *
+from chipsec.defines                      import *
 import chipsec_util
 
 SYNTH_KBD_VERSION              = 0x00010000
@@ -61,7 +61,7 @@ class RingBufferFuzzer(RingBuffer):
             result = ''
             self.count += 1
             if self.count > 1000000:
-                raise
+                raise Exception 
         else:
             result = RingBuffer.ringbuffer_read(self)
         return result

--- a/chipsec/modules/tools/vmm/hv/vmbus.py
+++ b/chipsec/modules/tools/vmm/hv/vmbus.py
@@ -1,5 +1,5 @@
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2018, Intel Corporation
+#Copyright (c) 2010-2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -27,15 +27,15 @@ import sys
 import time
 import binascii
 import chipsec_util
-from struct                           import *
-from random                           import *
-from chipsec.modules.tools.vmm.common import *
-from define                           import *
-from chipsec.logger                   import *
-from chipsec.file       	      import *
-from chipsec.module_common            import *
-from chipsec.hal.vmm                  import VMM
-from chipsec.defines                  import *
+from struct                              import *
+from random                              import *
+from chipsec.modules.tools.vmm.common    import *
+from chipsec.modules.tools.vmm.hv.define import *
+from chipsec.logger                      import *
+from chipsec.file       	             import *
+from chipsec.module_common               import *
+from chipsec.hal.vmm                     import VMM
+from chipsec.defines                     import *
 
 class RingBuffer(BaseModuleDebug):
     def __init__(self):

--- a/chipsec/modules/tools/vmm/hv/vmbusfuzz.py
+++ b/chipsec/modules/tools/vmm/hv/vmbusfuzz.py
@@ -1,5 +1,5 @@
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2016, Intel Corporation
+#Copyright (c) 2010-2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -36,9 +36,9 @@ Note: the fuzzer is incompatible with native VMBus driver (``vmbus.sys``). To us
 """
 from struct import *
 from random import *
-from define import *
-from chipsec.modules.tools.vmm.common import *
-from vmbus  import *
+from chipsec.modules.tools.vmm.hv.define import *
+from chipsec.modules.tools.vmm.common    import *
+from chipsec.modules.tools.vmm.hv.vmbus  import *
 import chipsec_util
 
 sys.stdout = session_logger(True, 'vmbusfuzz')

--- a/chipsec/modules/tools/vmm/xen/hypercall.py
+++ b/chipsec/modules/tools/vmm/xen/hypercall.py
@@ -1,5 +1,5 @@
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2018, Intel Corporation
+#Copyright (c) 2010-2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -25,10 +25,10 @@ Xen specific hypercall functionality
 
 import binascii
 import collections
-from define                           import *
-from chipsec.hal.vmm                  import *
-from chipsec.module_common            import *
-from chipsec.modules.tools.vmm.common import *
+from chipsec.modules.tools.vmm.xen.define  import *
+from chipsec.hal.vmm                       import *
+from chipsec.module_common                 import *
+from chipsec.modules.tools.vmm.common      import *
 
 SM_RANGE = { 'masks': [ 0x00000000000000FF ] }
 MD_RANGE = { 'masks': [ 0x000000000000FFFF ] }

--- a/chipsec/modules/tools/vmm/xen/hypercallfuzz.py
+++ b/chipsec/modules/tools/vmm/xen/hypercallfuzz.py
@@ -1,5 +1,5 @@
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2016, Intel Corporation
+#Copyright (c) 2010-2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -44,11 +44,11 @@ Examples:
   ``chipsec_main.py -i -m tools.vmm.xen.hypercallfuzz -a set_timer_op,10,0x10000000 -l log.txt``
 """
 
-from define                           import *
-from hypercall                        import *
-from chipsec.hal.vmm                  import *
-from chipsec.module_common            import *
-from chipsec.modules.tools.vmm.common import *
+from chipsec.modules.tools.vmm.xen.define      import *
+from chipsec.modules.tools.vmm.xen.hypercall   import *
+from chipsec.hal.vmm                           import *
+from chipsec.module_common                     import *
+from chipsec.modules.tools.vmm.common          import *
 
 class HypercallFuzz (BaseModule):
 

--- a/chipsec/utilcmd/mem_cmd.py
+++ b/chipsec/utilcmd/mem_cmd.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2020, Intel Corporation
+#Copyright (c) 2010-2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -56,7 +56,7 @@ class MemCommand(BaseCommand):
     >>> chipsec_util mem allocate                    0x1000
     >>> chipsec_util mem pagedump 0xFED00000         0x100000
     >>> chipsec_util mem search   0xF0000            0x10000  _SM_
-:
+
     """
 
     def requires_driver(self):


### PR DESCRIPTION
Hal msg bus - removed non working link
Hal spd - changed simmtester links to functioning ones
Cfg sfdp - added docstring
utilcmd mem_cmd - removed random lonely colon
Modules-Common-cpu-cpuinfo and iauntrusted - added temp docstrings
Tools-vmm-hv and xen folders -> imports needed more detail
Modules Me mfg mode - fixed error caused by asterisk in links