### PR TITLE
Update interrupts_cmd.py CLI

### DIFF
--- a/chipsec/utilcmd/interrupts_cmd.py
+++ b/chipsec/utilcmd/interrupts_cmd.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2015, Intel Corporation
+#Copyright (c) 2010-2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License
@@ -21,10 +21,11 @@
 
 
 import time
+import os
 
 from chipsec.command        import BaseCommand
 from chipsec.hal.interrupts import Interrupts
-import os
+from argparse               import ArgumentParser
 
 
 # ###################################################################
@@ -34,107 +35,107 @@ import os
 # ###################################################################
 
 
-
 class SMICommand(BaseCommand):
     """
     >>> chipsec_util smi count
-    >>> chipsec_util smi <thread_id> <SMI_code> <SMI_data> [RAX] [RBX] [RCX] [RDX] [RSI] [RDI]
+    >>> chipsec_util smi send <thread_id> <SMI_code> <SMI_data> [RAX] [RBX] [RCX] [RDX] [RSI] [RDI]
     >>> chipsec_util smi smmc <RT_code_start> <RT_code_end> <GUID> <payload_loc> <payload_file|payload_string>
 
     Examples:
 
     >>> chipsec_util smi count
-    >>> chipsec_util smi 0x0 0xDE 0x0
-    >>> chipsec_util smi 0x0 0xDE 0x0 0xAAAAAAAAAAAAAAAA ..
-    >>> chipsec_util.py smi smmc 0x79dfe000 0x79efdfff ed32d533-99e6-4209-9cc02d72cdd998a7 0x79dfaaaa payload.bin
+    >>> chipsec_util smi send 0x0 0xDE 0x0
+    >>> chipsec_util smi send 0x0 0xDE 0x0 0xAAAAAAAAAAAAAAAA ..
+    >>> chipsec_util smi smmc 0x79dfe000 0x79efdfff ed32d533-99e6-4209-9cc02d72cdd998a7 0x79dfaaaa payload.bin
     """
     def requires_driver(self):
-        # No driver required when printing the util documentation
-        if len(self.argv) < 3:
-            return False
+        parser = ArgumentParser(prog='chipsec_util smi', usage=SMICommand.__doc__)
+        subparsers = parser.add_subparsers()
+
+        parser_count = subparsers.add_parser('count')
+        parser_count.set_defaults(func=self.smi_count)
+
+        parser_send = subparsers.add_parser('send')
+        parser_send.add_argument('thread_id', type=lambda x: int(x, 16), help='Thread ID (hex)')
+        parser_send.add_argument('SMI_code_port_value', type=lambda x: int(x, 16), help='SMI Code (hex)')
+        parser_send.add_argument('SMI_data_port_value', type=lambda x: int(x, 16), help='SMI Data (hex)')
+        parser_send.add_argument('_rax', type=lambda x: int(x, 16), nargs='?', default=None, help='RAX (hex)')
+        parser_send.add_argument('_rbx', type=lambda x: int(x, 16), nargs='?', default=0, help='RBX (hex) [default=0]')
+        parser_send.add_argument('_rcx', type=lambda x: int(x, 16), nargs='?', default=0, help='RCX (hex) [default=0]')
+        parser_send.add_argument('_rdx', type=lambda x: int(x, 16), nargs='?', default=0, help='RDX (hex) [default=0]')
+        parser_send.add_argument('_rsi', type=lambda x: int(x, 16), nargs='?', default=0, help='RSI (hex) [default=0]')
+        parser_send.add_argument('_rdi', type=lambda x: int(x, 16), nargs='?', default=0, help='RDI (hex) [default=0]')
+        parser_send.set_defaults(func=self.smi_send)
+
+        parser_smmc = subparsers.add_parser('smmc')
+        parser_smmc.add_argument('RTC_start', type=lambda x: int(x, 16), help='RTC Code Start (hex)')
+        parser_smmc.add_argument('RTC_end', type=lambda x: int(x, 16), help='RT Code End (hex)')
+        parser_smmc.add_argument('guid', type=str, help='GUID')
+        parser_smmc.add_argument('payload_loc', type=lambda x: int(x, 16), help='Payload Location (hex)')
+        parser_smmc.add_argument('payload', type=str, help='Payload')
+        parser_smmc.set_defaults(func=self.smi_smmc)
+
+        parser.parse_args(self.argv[2:], namespace=self)
         return True
 
+    def smi_count(self):
+        self.logger.log( "[CHIPSEC] SMI count:" )
+        for tid in range(self.cs.msr.get_cpu_thread_count()):
+            smi_cnt = self.cs.read_register_field('MSR_SMI_COUNT', 'Count', cpu_thread=tid)
+            self.logger.log( "  CPU{:d}: {:d}".format(tid, smi_cnt) )
+
+
+    def smi_smmc(self):
+        if os.path.isfile(self.payload):
+            f = open(self.payload, 'rb')
+            self.payload = f.read()
+            f.close()
+
+        self.logger.log("Searching for \'smmc\' in range 0x{:x}-0x{:x}".format(self.RTC_start, self.RTC_end))
+        # scan for SMM_CORE_PRIVATE_DATA smmc signature
+        smmc_loc = self.interrupts.find_smmc(self.RTC_start, self.RTC_end)
+        if (smmc_loc == 0):
+            self.logger.log(" Couldn't find smmc signature")
+            return
+        self.logger.log("Found \'smmc\' structure at 0x{:x}".format(smmc_loc))
+
+        ReturnStatus = self.interrupts.send_smmc_SMI(smmc_loc, self.guid, self.payload, self.payload_loc)
+        #TODO Translate ReturnStatus to EFI_STATUS enum
+        self.logger.log("ReturnStatus: {:x}".format(ReturnStatus))
+
+
+    def smi_send(self):
+        self.logger.log( "[CHIPSEC] Sending SW SMI (code: 0x{:02X}, data: 0x{:02X})..".format(self.SMI_code_port_value, self.SMI_data_port_value) )
+        if self._rax is None:
+            self.interrupts.send_SMI_APMC( self.SMI_code_port_value, self.SMI_data_port_value )
+        else:
+            self.logger.log( "          RAX: 0x{:016X} (AX will be overridden with values of SW SMI ports B2/B3)".format(self._rax) )
+            self.logger.log( "          RBX: 0x{:016X}".format(self._rbx) )
+            self.logger.log( "          RCX: 0x{:016X}".format(self._rcx) )
+            self.logger.log( "          RDX: 0x{:016X} (DX will be overridden with 0x00B2)".format(self._rdx) )
+            self.logger.log( "          RSI: 0x{:016X}".format(self._rsi) )
+            self.logger.log( "          RDI: 0x{:016X}".format(self._rdi) )
+            ret = self.interrupts.send_SW_SMI( self.thread_id, self.SMI_code_port_value, self.SMI_data_port_value, self._rax, self._rbx, self._rcx, self._rdx, self._rsi, self._rdi )
+            if not ret is None:
+                self.logger.log( "Return values")
+                self.logger.log( "          RAX: {:16X}".format(ret[1]) )
+                self.logger.log( "          RBX: {:16X}".format(ret[2]) )
+                self.logger.log( "          RCX: {:16X}".format(ret[3]) )
+                self.logger.log( "          RDX: {:16X}".format(ret[4]) )
+                self.logger.log( "          RSI: {:16X}".format(ret[5]) )
+                self.logger.log( "          RDI: {:16X}".format(ret[6]) )
+
+
     def run(self):
-        if len(self.argv) < 3:
-            print (SMICommand.__doc__)
-            return
-
         try:
-            interrupts = Interrupts( self.cs )
+            self.interrupts = Interrupts( self.cs )
         except RuntimeError as msg:
-            print (msg)
+            self.logger.log(msg)
             return
 
-        op = self.argv[2]
         t = time.time()
 
-        if 'count' == op:
-            self.logger.log( "[CHIPSEC] SMI count:" )
-            for tid in range(self.cs.msr.get_cpu_thread_count()):
-                smi_cnt = self.cs.read_register_field('MSR_SMI_COUNT', 'Count', cpu_thread=tid)
-                self.logger.log( "  CPU{:d}: {:d}".format(tid, smi_cnt) )
-        elif 'smmc' == op:
-            if len(self.argv) < 8:
-                print (SMICommand.__doc__)
-                return
-
-            RTC_start = int(self.argv[3], 16)
-            RTC_end = int(self.argv[4], 16)
-            guid = self.argv[5]
-            payload_loc = int(self.argv[6], 16)
-            payload = self.argv[7]
-            if os.path.isfile(payload):
-                f = open(payload, 'rb')
-                payload = f.read()
-                f.close()
-
-            self.logger.log("Searching for \'smmc\' in range 0x{:x}-0x{:x}".format(RTC_start, RTC_end))
-            # scan for SMM_CORE_PRIVATE_DATA smmc signature
-            smmc_loc = interrupts.find_smmc(RTC_start, RTC_end)
-            if smmc_loc == 0:
-                self.logger.log(" Couldn't find smmc signature")
-                return
-            self.logger.log("Found \'smmc\' structure at 0x{:x}".format(smmc_loc))
-
-            ReturnStatus = interrupts.send_smmc_SMI(smmc_loc, guid, payload, payload_loc)
-            #TODO Translate ReturnStatus to EFI_STATUS enum
-            self.logger.log("ReturnStatus: {:x}".format(ReturnStatus))
-        else:
-            SMI_data_port_value = 0x0
-            if len(self.argv) > 4:
-                thread_id           = int(self.argv[2], 16)
-                SMI_code_port_value = int(self.argv[3], 16)
-                SMI_data_port_value = int(self.argv[4], 16)
-                self.logger.log( "[CHIPSEC] Sending SW SMI (code: 0x{:02X}, data: 0x{:02X})..".format(SMI_code_port_value, SMI_data_port_value) )
-                if 5 == len(self.argv):
-                    interrupts.send_SMI_APMC( SMI_code_port_value, SMI_data_port_value )
-                elif 11 == len(self.argv):
-                    _rax = int(self.argv[5], 16)
-                    _rbx = int(self.argv[6], 16)
-                    _rcx = int(self.argv[7], 16)
-                    _rdx = int(self.argv[8], 16)
-                    _rsi = int(self.argv[9], 16)
-                    _rdi = int(self.argv[10], 16)
-                    self.logger.log( "          RAX: 0x{:016X} (AX will be overwridden with values of SW SMI ports B2/B3)".format(_rax) )
-                    self.logger.log( "          RBX: 0x{:016X}".format(_rbx) )
-                    self.logger.log( "          RCX: 0x{:016X}".format(_rcx) )
-                    self.logger.log( "          RDX: 0x{:016X} (DX will be overwridden with 0x00B2)".format(_rdx) )
-                    self.logger.log( "          RSI: 0x{:016X}".format(_rsi) )
-                    self.logger.log( "          RDI: 0x{:016X}".format(_rdi) )
-                    ret = interrupts.send_SW_SMI( thread_id, SMI_code_port_value, SMI_data_port_value, _rax, _rbx, _rcx, _rdx, _rsi, _rdi )
-                    if not ret is None:
-                        self.logger.log( "Return values")
-                        self.logger.log( "          RAX: {:16X}".format(ret[1]) )
-                        self.logger.log( "          RBX: {:16X}".format(ret[2]) )
-                        self.logger.log( "          RCX: {:16X}".format(ret[3]) )
-                        self.logger.log( "          RDX: {:16X}".format(ret[4]) )
-                        self.logger.log( "          RSI: {:16X}".format(ret[5]) )
-                        self.logger.log( "          RDI: {:16X}".format(ret[6]) )
-                else: print (SMICommand.__doc__)
-            else:
-                self.logger.error( "unknown command-line option '{:32}'".format(op) )
-                print (SMICommand.__doc__)
-                return
+        self.func()
 
         self.logger.log( "[CHIPSEC] (smi) time elapsed {:.3f}".format(time.time() -t) )
 
@@ -154,11 +155,11 @@ class NMICommand(BaseCommand):
         try:
             interrupts = Interrupts( self.cs )
         except RuntimeError as msg:
-            print (msg)
+            self.logger.log(msg)
             return
 
         t = time.time()
-        self.logger.log( "[CHIPSEC] Sending NMI#.." )
+        self.logger.log( "[CHIPSEC] Sending NMI#..." )
         interrupts.send_NMI()
         self.logger.log( "[CHIPSEC] (nmi) time elapsed {:.3f}".format(time.time() -t) )
 

--- a/chipsec/utilcmd/interrupts_cmd.py
+++ b/chipsec/utilcmd/interrupts_cmd.py
@@ -39,7 +39,7 @@ class SMICommand(BaseCommand):
     """
     >>> chipsec_util smi count
     >>> chipsec_util smi send <thread_id> <SMI_code> <SMI_data> [RAX] [RBX] [RCX] [RDX] [RSI] [RDI]
-    >>> chipsec_util smi smmc <RT_code_start> <RT_code_end> <GUID> <payload_loc> <payload_file|payload_string>
+    >>> chipsec_util smi smmc <RT_code_start> <RT_code_end> <GUID> <payload_loc> <payload_file|payload_string> [port]
 
     Examples:
 
@@ -73,6 +73,7 @@ class SMICommand(BaseCommand):
         parser_smmc.add_argument('guid', type=str, help='GUID')
         parser_smmc.add_argument('payload_loc', type=lambda x: int(x, 16), help='Payload Location (hex)')
         parser_smmc.add_argument('payload', type=str, help='Payload')
+        parser_smmc.add_argument('port', type=lambda x: int(x, 16), nargs='?', default=0x0, help='Port (hex) [default=0]')
         parser_smmc.set_defaults(func=self.smi_smmc)
 
         parser.parse_args(self.argv[2:], namespace=self)
@@ -99,7 +100,7 @@ class SMICommand(BaseCommand):
             return
         self.logger.log("Found \'smmc\' structure at 0x{:x}".format(smmc_loc))
 
-        ReturnStatus = self.interrupts.send_smmc_SMI(smmc_loc, self.guid, self.payload, self.payload_loc)
+        ReturnStatus = self.interrupts.send_smmc_SMI(smmc_loc, self.guid, self.payload, self.payload_loc, CommandPort=self.port)
         #TODO Translate ReturnStatus to EFI_STATUS enum
         self.logger.log("ReturnStatus: {:x}".format(ReturnStatus))
 


### PR DESCRIPTION
**ATTN CHIPSEC Community:**

**CALL FOR FEEDBACK**

In an effort to align the utill commands, **interrupts_cmd.py** is adding `send` command.  This will change the default behavior of a long established command-line invocation.

Any comments FOR or AGAINST, please post in comments.  

**For instance:**

Previous 'read' command looked like this...
`python chipsec_util.py smi 0x0 0xDE 0x0 `

Will now look like...
`python chipsec_util.py smi send 0x0 0xDE 0x0`