### PR TITLE
Add lock and lockedby to configuration

### DIFF
--- a/chipsec/cfg/template.xml
+++ b/chipsec/cfg/template.xml
@@ -51,7 +51,7 @@ Template for XML configuration file
   <!--                                      -->
   <!-- #################################### -->
   <registers>
-    <register name="[UNIQUE REGISTER NAME]" type="msr|mmio|io|iobar|pcicfg|mmcfg|msgbus|memory" desc="[REGISTER DESCRIPTION]" />
+    <register name="[UNIQUE REGISTER NAME]" type="msr|mmio|io|iobar|pcicfg|mmcfg|msgbus|memory" desc="[REGISTER DESCRIPTION]" lockedby="[LOCK NAME]" />
   </registers>
 
   <!-- #################################### -->
@@ -62,5 +62,14 @@ Template for XML configuration file
   <controls>
     <control name="[UNIQUE CONTROL NAME]" register="[REGISTER NAME WITH THIS CONTROL]" field="[CONTROL FIELD NAME WITHIN REGISTER]" desc="[CONTROL DESCRIPTION]" />
   </controls>
+
+  <!-- #################################### -->
+  <!--                                      -->
+  <!-- Locks                                -->
+  <!--                                      -->
+  <!-- #################################### -->
+  <locks>
+    <lock name="[UNIQUE LOCK NAME]" register="[REGISTER NAME WITH THIS LOCK]" field="[LOCK FIELD NAME WITHIN REGISTER]" value="[VALUE TO INDICATE LOCK IS SET]" desc="[LOCK DESCRIPTION]" />
+  </locks>
 
 </configuration>


### PR DESCRIPTION
Adds the ability to create locks within the configuration files and add attributes to register fields to show which lock.

Add get_lock, set_lock, is_lock_defined, get_locked_value, get_lock_desc, get_lock_list, get_lock_mask, and get_lockedby functions to access defined locks.

Signed-off-by: brentholtsclaw <brent.holtsclaw@intel.com>