### PR TITLE
Fix Makefile to work with DKMS

### DIFF
--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -1,7 +1,11 @@
-KERNEL_SRC_DIR ?= /lib/modules/`uname -r`/build
-#KERNEL_SRC_DIR = /usr/src/android/3.0-mid
-
 MACHINE ?= $(shell uname -m)
+
+DESTDIR	=
+MODDIR	= $(DESTDIR)/lib/modules
+KVERS	= $(shell uname -r)
+KVER	= $(KVERS)
+VMODDIR = $(MODDIR)/$(KVER)
+KSRC	= $(VMODDIR)/build
 
 ifeq (,$(filter %i686 %i386 %i586,$(MACHINE)))
 	elf-size := elf64
@@ -17,21 +21,20 @@ obj-m += chipsec.o
 all: chipsec
 
 check_kernel_dir:
-	@if [ ! -d $(KERNEL_SRC_DIR) ]; then \
-		echo "Unable to find the Linux source tree."; \
-		exit 1; \
+	@if [ ! -d $(KSRC) ]; then \
+	    echo "Unable to find the Linux source tree."; \
+	    exit 1; \
 	fi
 
-chipsec: check_kernel_dir clean
+chipsec: check_kernel_dir clean 
 	nasm -f $(elf-size) -o $(asm-path)/cpu.o $(asm-path)/cpu.asm
 	touch $(asm-path)/.cpu.o.cmd
 	@if [ `grep -c 'efi_call' /proc/kallsyms` != "0" ]; then \
-	    make CFLAGS_MODULE=-DHAS_EFI=1 -C $(KERNEL_SRC_DIR) M=${CURDIR} modules; \
+	    make CFLAGS_MODULE=-DHAS_EFI=1 -C $(KSRC) M=$(CURDIR) modules; \
 	else \
-	    make -C $(KERNEL_SRC_DIR) M=${CURDIR} modules; \
+	    make -C $(KSRC) M=$(CURDIR) modules; \
 	fi
 
 clean: check_kernel_dir
-	make -C $(KERNEL_SRC_DIR) M=${CURDIR} clean
+	make -C $(KSRC) M=$(CURDIR) clean
 	rm -f ${asm-path}/cpu.o
-


### PR DESCRIPTION
drivers/linux/Makefile:
* Replaced KERNEL_SRC_DIR variable with KSRC.
* Added KSRC variable which should enable successful DKMS compilation,
  as opposed to bailing out with "Unable to find the Linux source tree."

This patch has been tested on Black Arch.

Will be referencing this PR on a new issue along with the backstory.