### PR TITLE
 Introduce a new module to check that SMM_Code_Chk_En is configured properly.

### DIFF
--- a/chipsec/cfg/8086/apl.xml
+++ b/chipsec/cfg/8086/apl.xml
@@ -369,6 +369,12 @@ document id 334818/334819
     <!-- CPU MSRs                     -->
     <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
     <register name="MSR_POWER_MISC" type="msr" msr="0x120" desc="MISC" />
+    
+    <!-- MSR_SMM_FEATURE_CONTROL -->
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
   </registers>
 
   <!-- #################################### -->

--- a/chipsec/cfg/8086/bdw.xml
+++ b/chipsec/cfg/8086/bdw.xml
@@ -55,6 +55,10 @@ XML configuration for Broadwell based platforms
   <!--                                      -->
   <!-- #################################### -->
   <registers>
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
   </registers>
 
 </configuration>

--- a/chipsec/cfg/8086/bdx.xml
+++ b/chipsec/cfg/8086/bdx.xml
@@ -203,6 +203,10 @@ Intel (c) C610 Series Chipset and Intel (c) X99 Chipset Platform Controller Hub 
     </register>
 
     <!-- CPU Model Specific Registers -->
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
 
   </registers>
 

--- a/chipsec/cfg/8086/cfl.xml
+++ b/chipsec/cfg/8086/cfl.xml
@@ -289,6 +289,16 @@ XML configuration file for Coffee Lake
       <field name="TCO_LOCK" bit="12" size="1" desc="TCO Lock"/>
     </register>
 
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- CPU Model Specific Registers -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+    <!-- MSR_SMM_FEATURE_CONTROL -->
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
+
   </registers>
 
 

--- a/chipsec/cfg/8086/cml.xml
+++ b/chipsec/cfg/8086/cml.xml
@@ -83,6 +83,16 @@
     <!-- PCH TCOBASE (SMBus TCO) I/O registers -->
 
     <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- CPU Model Specific Registers -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+    <!-- MSR_SMM_FEATURE_CONTROL -->
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
+
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
     <!--      Undefined Registers     -->
     <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 

--- a/chipsec/cfg/8086/common.xml
+++ b/chipsec/cfg/8086/common.xml
@@ -616,6 +616,10 @@ Common (default) XML platform configuration file
       <field name="LOCK"           bit="30" size="1"  desc="Lock (set automatically on the first SMI)" />
       <field name="DEBUG_OCCURRED" bit="31" size="1"  desc="Debug Occurred (set by hardware)" />
     </register>
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
 
     <!-- SGX related Model Specific Registers (MSR) -->
     <!-- Check if CPUID(EAX=7,ECX=0):EBX[2] is set before accessing these registers-->

--- a/chipsec/cfg/8086/common.xml
+++ b/chipsec/cfg/8086/common.xml
@@ -616,10 +616,6 @@ Common (default) XML platform configuration file
       <field name="LOCK"           bit="30" size="1"  desc="Lock (set automatically on the first SMI)" />
       <field name="DEBUG_OCCURRED" bit="31" size="1"  desc="Debug Occurred (set by hardware)" />
     </register>
-    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
-      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
-      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
-    </register>
 
     <!-- SGX related Model Specific Registers (MSR) -->
     <!-- Check if CPUID(EAX=7,ECX=0):EBX[2] is set before accessing these registers-->

--- a/chipsec/cfg/8086/dnv.xml
+++ b/chipsec/cfg/8086/dnv.xml
@@ -175,6 +175,12 @@ XML configuration file for Denverton
       <field name="FW_INIT_COMPLETE"   bit="9"  size="1" desc="ME Firmware Initialization Complete" />
       <field name="UPDATE_IN_PROGRESS" bit="11" size="1" desc="ME Update In Progress" />
     </register>
+    
+    <!-- MSR_SMM_FEATURE_CONTROL -->
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
 
   </registers>
 

--- a/chipsec/cfg/8086/glk.xml
+++ b/chipsec/cfg/8086/glk.xml
@@ -275,6 +275,12 @@
     <register name="PRMRR_UNCORE_PHYBASE" undef="Not supported by GLK" />
     <register name="PRMRR_UNCORE_MASK" undef="Not supported by GLK" />
     <register name="BIOS_SE_SVN" undef="Not supported by GLK" />
+    
+    <!-- MSR_SMM_FEATURE_CONTROL -->
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
 
     <!-- Port I/O Registers -->
 

--- a/chipsec/cfg/8086/hsw.xml
+++ b/chipsec/cfg/8086/hsw.xml
@@ -58,6 +58,10 @@ XML configuration file for Haswell based platforms
   <!--                                      -->
   <!-- #################################### -->
   <registers>
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
   </registers>
 
 </configuration>

--- a/chipsec/cfg/8086/hsx.xml
+++ b/chipsec/cfg/8086/hsx.xml
@@ -203,7 +203,10 @@ Intel (c) C610 Series Chipset and Intel (c) X99 Chipset Platform Controller Hub 
     </register>
 
     <!-- CPU Model Specific Registers -->
-
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
   </registers>
 
 </configuration>

--- a/chipsec/cfg/8086/icl.xml
+++ b/chipsec/cfg/8086/icl.xml
@@ -91,6 +91,10 @@ chipsec@intel.com
       <field name="SoC_BIOS_DONE" bit="1" size="1" desc="SoC init done"/>
       <field name="IA_UNTRUSTED" bit="0" size="1" desc="Untrusted mode enable bit"/>
     </register>
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
     <register name="PRMRR_UNCORE_PHYBASE" undef="Not defined for the platform" />
     <register name="PRMRR_UNCORE_MASK" undef="Not defined for the platform" />
 

--- a/chipsec/cfg/8086/kbl.xml
+++ b/chipsec/cfg/8086/kbl.xml
@@ -332,6 +332,16 @@ http://www.intel.com/content/www/us/en/processors/core/core-technical-resources.
       <field name="TCO_LOCK" bit="12" size="1" desc="TCO Lock"/>
     </register>
 
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- CPU Model Specific Registers -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+    <!-- MSR_SMM_FEATURE_CONTROL -->
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
+
   </registers>
 
 

--- a/chipsec/cfg/8086/skl.xml
+++ b/chipsec/cfg/8086/skl.xml
@@ -337,6 +337,16 @@ http://www.intel.com/content/www/us/en/processors/core/core-technical-resources.
       <field name="TCO_LOCK" bit="12" size="1" desc="TCO Lock"/>
     </register>
 
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+    <!-- CPU Model Specific Registers -->
+    <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+    <!-- MSR_SMM_FEATURE_CONTROL -->
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
+
   </registers>
 
 

--- a/chipsec/cfg/8086/skx.xml
+++ b/chipsec/cfg/8086/skx.xml
@@ -66,6 +66,11 @@ Intel (c) Xeon Processor Scalable Family datasheet Vol. 2
       <field name="Enable" bit="0"  size="1"  desc="VTBAR enable"/>
     </register>
 
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
+
     <!-- PCH ABASE (PMBASE) I/O registers -->
 
 

--- a/chipsec/cfg/8086/whl.xml
+++ b/chipsec/cfg/8086/whl.xml
@@ -62,6 +62,10 @@ XML configuration file for Whiskey Lake
       <Field name="RESERVED" bit="3" size="23" desc="Reserved" />
       <Field name="PCIEXBAR" bit="26" size="13" desc="Base Address for PCI Express" />
     </register>
+    <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
+      <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />
+      <field name="SMM_Code_Chk_En" bit="2" size="1"  desc="Prevents SMM from executing code outside the ranges defined by the SMRR" />
+    </register>
   </registers>
 
   <!-- #################################### -->

--- a/chipsec/modules/common/smm_code_chk.py
+++ b/chipsec/modules/common/smm_code_chk.py
@@ -59,10 +59,10 @@ class smm_code_chk(BaseModule):
         # Check that all CPUs have the same value of MSR_SMM_FEATURE_CONTROL.
         if not all(_ == results[0] for _ in results):
             self.logger.log_failed_check( "MSR_SMM_FEATURE_CONTROL does not have the same value across all CPUs" )
-            return ModuleResult.ERROR
+            return ModuleResult.FAILED
         
         res = results[0] 
-        if res == ModuleResult.ERROR:
+        if res == ModuleResult.FAILED:
             self.logger.log_failed_check( "SMM_Code_Chk_En is enabled but not locked down" )
         elif res == ModuleResult.WARNING:
             self.logger.warn( """[*] SMM_Code_Chk_En is not enabled.

--- a/chipsec/modules/common/smm_code_chk.py
+++ b/chipsec/modules/common/smm_code_chk.py
@@ -1,3 +1,19 @@
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2021, SentinelOne
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 """
 SMM_Code_Chk_En is a bit found in the MSR_SMM_FEATURE_CONTROL register.
 Once set to '1', any CPU that attempts to execute SMM code not within the ranges defined by the SMRR will assert an unrecoverable MCE.

--- a/chipsec/modules/common/smm_code_chk.py
+++ b/chipsec/modules/common/smm_code_chk.py
@@ -1,0 +1,81 @@
+"""
+SMM_Code_Chk_En is a bit found in the MSR_SMM_FEATURE_CONTROL register.
+Once set to '1', any CPU that attempts to execute SMM code not within the ranges defined by the SMRR will assert an unrecoverable MCE.
+As such, enabling and locking this bit is an important step in mitigating SMM call-out vulnerabilities.
+This CHIPSEC module simply reads the register and checks that SMM_Code_Chk_En is set and locked.
+"""
+from chipsec.helper.oshelper import HWAccessViolationError
+from chipsec.module_common import BaseModule, ModuleResult, MTAG_BIOS, MTAG_SMM
+
+TAGS = [MTAG_BIOS, MTAG_SMM]
+
+class smm_code_chk(BaseModule):
+
+    def __init__(self):
+        BaseModule.__init__(self)
+
+    def is_supported(self):
+        # The Intel SDM states that MSR_SMM_FEATURE_CONTROL can only be accessed while the CPU executes in SMM.
+        # However, in reality many users report that there is no problem reading this register from outside of SMM.
+        # Just to be on the safe side of things, we'll verify we can read this register successfully before moving on.
+        try:
+            self.cs.read_register( 'MSR_SMM_FEATURE_CONTROL' )
+        except HWAccessViolationError:
+            self.res = ModuleResult.NOTAPPLICABLE
+            return False
+        else:
+            return True
+
+    def _check_SMM_Code_Chk_En(self, thread_id):
+        regval      = self.cs.read_register( 'MSR_SMM_FEATURE_CONTROL', thread_id )
+        lock        = self.cs.get_register_field( 'MSR_SMM_FEATURE_CONTROL', regval, 'LOCK' )
+        code_chk_en = self.cs.get_register_field( 'MSR_SMM_FEATURE_CONTROL', regval, 'SMM_Code_Chk_En' )
+
+        self.cs.print_register( 'MSR_SMM_FEATURE_CONTROL', regval )
+
+        if 1 == code_chk_en:
+            if 1 == lock:
+                res = ModuleResult.PASSED
+            else:
+                res = ModuleResult.FAILED
+        else:
+            # MSR_SMM_MCA_CAP (the register that reports enhanced SMM capabilities) can only be read from SMM.
+            # Thus, there is no way to tell whether the the CPU doesn't support SMM_Code_Chk_En in the first place,
+            # or the CPU supports SMM_Code_Chk_En but the BIOS forgot to enable it.
+            #
+            # In either case, there is nothing that prevents SMM code from executing instructions outside the ranges defined by the SMRRs,
+            # so we should at least issue a warning regarding that.
+            res = ModuleResult.WARNING
+
+        return res
+
+    def check_SMM_Code_Chk_En(self):
+        self.logger.start_test( "SMM_Code_Chk_En (SMM Call-Out) Protection" )
+
+        results = []
+        for tid in range(self.cs.msr.get_cpu_thread_count()):
+            results.append(self._check_SMM_Code_Chk_En(tid))
+
+        # Check that all CPUs have the same value of MSR_SMM_FEATURE_CONTROL.
+        if not all(_ == results[0] for _ in results):
+            self.logger.log_failed_check( "MSR_SMM_FEATURE_CONTROL does not have the same value across all CPUs" )
+            return ModuleResult.ERROR
+        
+        res = results[0] 
+        if res == ModuleResult.ERROR:
+            self.logger.log_failed_check( "SMM_Code_Chk_En is enabled but not locked down" )
+        elif res == ModuleResult.WARNING:
+            self.logger.warn( """[*] SMM_Code_Chk_En is not enabled.
+This can happen either because this feature is not supported by the CPU or because the BIOS forgot to enable it.
+Please consult the Intel SDM to determine whether or not your CPU supports SMM_Code_Chk_En.""" )
+        else:
+            self.logger.log_passed_check( "SMM_Code_Chk_En is enabled and locked down" )
+
+        return res
+
+    # --------------------------------------------------------------------------
+    # run( module_argv )
+    # Required function: run here all tests from this module
+    # --------------------------------------------------------------------------
+    def run( self, module_argv ):
+        return self.check_SMM_Code_Chk_En()

--- a/chipsec/modules/common/smm_code_chk.py
+++ b/chipsec/modules/common/smm_code_chk.py
@@ -31,6 +31,13 @@ class smm_code_chk(BaseModule):
         BaseModule.__init__(self)
 
     def is_supported(self):
+        if not self.cs.is_register_defined( 'MSR_SMM_FEATURE_CONTROL' ):
+            # The MSR_SMM_FEATURE_CONTROL register is available starting from:
+            # * 4th Generation Intel® Core™ Processors (Haswell microarchitecture)
+            # * Atom Processors Based on the Goldmont Microarchitecture
+            self.res = ModuleResult.NOTAPPLICABLE
+            return False
+
         # The Intel SDM states that MSR_SMM_FEATURE_CONTROL can only be accessed while the CPU executes in SMM.
         # However, in reality many users report that there is no problem reading this register from outside of SMM.
         # Just to be on the safe side of things, we'll verify we can read this register successfully before moving on.


### PR DESCRIPTION
Typical output looks like this:

![image](https://user-images.githubusercontent.com/8438963/108578779-8611c980-732c-11eb-80a4-ccad2c059f02.png)
