### PR TITLE
Logger: prefer WConio2 over the original WConio.

### DIFF
--- a/chipsec/logger.py
+++ b/chipsec/logger.py
@@ -34,11 +34,17 @@ import atexit
 from chipsec.testcase import TestCase, ChipsecResults
 import traceback
 try:
-    import WConio
+    # Prefer WConio2 over the original WConio as it is more up-to-date and better maintained.
+    # See https://pypi.org/project/WConio2/ for more details.
+    import WConio2 as WConio
     has_WConio = True
 except ImportError:
-    has_WConio = False
-    #raiseImportError('WConio package not installed. No colored output')
+    try:
+        import WConio
+        has_WConio = True
+    except ImportError:
+        has_WConio = False
+        #raiseImportError('WConio package not installed. No colored output')
 
 LOG_PATH                = os.path.join( os.getcwd(), "logs" )
 #LOG_STATUS_FILE_NAME    = ""


### PR DESCRIPTION
`WConio2` is superior to the original `WConio` as it is more up-to-date and better maintained.
See https://pypi.org/project/WConio2/ for more details.