### PR TITLE
Fix the access_uefispec module

### DIFF
--- a/chipsec/modules/common/uefi/access_uefispec.py
+++ b/chipsec/modules/common/uefi/access_uefispec.py
@@ -94,8 +94,8 @@ class access_uefispec(BaseModule):
         if data1 is None or data2 is None:
             return data1 != data2
 
-        oldstr = ":".join("{:02x}".format(ord(c)) for c in data1)
-        newstr = ":".join("{:02x}".format(ord(c)) for c in data2)
+        oldstr = ":".join("{:02x}".format(c) for c in data1)
+        newstr = ":".join("{:02x}".format(c) for c in data2)
 
         if oldstr != newstr:
             print (oldstr)

--- a/chipsec/modules/common/uefi/access_uefispec.py
+++ b/chipsec/modules/common/uefi/access_uefispec.py
@@ -134,11 +134,6 @@ class access_uefispec(BaseModule):
             self.logger.log_important( "Note that UEFI variables may still exist, OS just did not expose runtime UEFI Variable API to read them.\nYou can extract variables directly from ROM file via 'chipsec_util.py uefi nvram bios.bin' command and verify their attributes manually." )
             return ModuleResult.SKIPPED
 
-        bsnv_vars = []
-        bsnv_concern = []
-        rtnv_vars = []
-        rtnv_concern = []
-        modified_concern = []
         uefispec_concern = []
         ro_concern = []
 

--- a/chipsec/modules/common/uefi/access_uefispec.py
+++ b/chipsec/modules/common/uefi/access_uefispec.py
@@ -29,6 +29,7 @@ Returns failure if variable attributes are not as defined in `table 11 "Global V
 from chipsec.module_common import BaseModule, ModuleResult, MTAG_SECUREBOOT, MTAG_BIOS, OPT_MODIFY
 from chipsec.hal.uefi import UEFI, EFI_VARIABLE_NON_VOLATILE, EFI_VARIABLE_BOOTSERVICE_ACCESS, EFI_VARIABLE_RUNTIME_ACCESS, get_attr_string
 from chipsec.hal.uefi import EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS, EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS, EFI_VARIABLE_APPEND_WRITE
+from chipsec.hal.uefi_common import StatusCode
 
 
 TAGS = [MTAG_BIOS, MTAG_SECUREBOOT]
@@ -114,7 +115,7 @@ class access_uefispec(BaseModule):
         if baddata == origdata:
             baddata = 'A' *datalen #in case we failed to restore previously
         status = self._uefi.set_EFI_variable(name, guid, baddata)
-        if not status: self.logger.log_good('Writing EFI variable {} did not succeed.'.format(name))
+        if status != StatusCode.EFI_SUCCESS: self.logger.log_good('Writing EFI variable {} did not succeed.'.format(name))
         newdata  = self._uefi.get_EFI_variable(name, guid)
         if self.diff_var(newdata, origdata):
             self.logger.log_bad('Corruption of EFI variable of concern {}. Trying to recover.'.format(name))

--- a/chipsec/modules/common/uefi/access_uefispec.py
+++ b/chipsec/modules/common/uefi/access_uefispec.py
@@ -178,10 +178,11 @@ class access_uefispec(BaseModule):
                 self.logger.log('    {}'.format(name))
 
         if do_modify:
-            self.logger.log('')
-            self.logger.log_bad('Variables that should have been read-only and were not:')
-            for name in ro_concern:
-                self.logger.log('    {}'.format(name))
+            if ro_concern:
+                self.logger.log('')
+                self.logger.log_bad('Variables that should have been read-only and were not:')
+                for name in ro_concern:
+                    self.logger.log('    {}'.format(name))
 
         self.logger.log('')
 

--- a/chipsec/modules/common/uefi/access_uefispec.py
+++ b/chipsec/modules/common/uefi/access_uefispec.py
@@ -136,6 +136,7 @@ class access_uefispec(BaseModule):
 
         uefispec_concern = []
         ro_concern = []
+        rw_variables = []
 
         self.logger.log('[*] Testing UEFI variables ..')
         for name in vars.keys():
@@ -164,12 +165,15 @@ class access_uefispec(BaseModule):
 
                 if do_modify:
                     #self.logger.log('uefispec_ro_vars')
+                    self.logger.log("[*] Testing modification of {} ..".format(name))
                     if name in self.uefispec_ro_vars:
-                        self.logger.log("[*] Testing modification of {} ..".format(name))
                         if self.can_modify(name, guid, data):
                             ro_concern.append(name)
                             self.logger.log_bad("Variable {} should be read only.".format(name))
                             res = ModuleResult.FAILED
+                    else:
+                        if self.can_modify(name, guid, data):
+                            rw_variables.append(name)
 
         if uefispec_concern:
             self.logger.log('')
@@ -182,6 +186,12 @@ class access_uefispec(BaseModule):
                 self.logger.log('')
                 self.logger.log_bad('Variables that should have been read-only and were not:')
                 for name in ro_concern:
+                    self.logger.log('    {}'.format(name))
+
+            if rw_variables:
+                self.logger.log('')
+                self.logger.log_unknown('Variables that are read-write (manual investigation is required):')
+                for name in rw_variables:
                     self.logger.log('    {}'.format(name))
 
         self.logger.log('')


### PR DESCRIPTION
This PR fixes and augments the `access_uefispec` module in several ways:
* In `diff_var`, both `data1` and `data2` are of type `bytes`, so the call to `ord` used to fail.
* The module used to contain a lot of unreferenced variables.
* The error message about read-only variables that are in fact writable was logged even if no such variables were found.
* Often, vendor-specific variables (which are not part of the UEFI standard) contain sensitive security settings. By trying to modify these variables as well, we can get a much clearer picture of the possible attack surface.
* Fix status code check for `set_EFI_variable`.