### PR TITLE
Add execeptions within cs.read_register

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -45,7 +45,7 @@ import traceback
 # DEBUG Flags
 QUIET_PCI_ENUM = True
 LOAD_COMMON = True
-CONSISTANCY_CHECKING = False
+CONSISTENCY_CHECKING = False
 
 class RegisterType:
     PCICFG    = 'pcicfg'
@@ -800,7 +800,7 @@ class Chipset:
             f = int(reg['fun'], 16)
             o = int(reg['offset'], 16)
             size = int(reg['size'], 16)
-            if self.pci.get_DIDVID(b, d, f) != (0xFFFF, 0xFFFF) and do_check and not CONSISTANCY_CHECKING:
+            if self.pci.get_DIDVID(b, d, f) != (0xFFFF, 0xFFFF) and do_check and not CONSISTENCY_CHECKING:
                 if   1 == size: reg_value = self.pci.read_byte ( b, d, f, o )
                 elif 2 == size: reg_value = self.pci.read_word ( b, d, f, o )
                 elif 4 == size: reg_value = self.pci.read_dword( b, d, f, o )

--- a/tests/software/mock_helper.py
+++ b/tests/software/mock_helper.py
@@ -256,6 +256,8 @@ class SPIHelper(TestHelper):
                 return self.RCBA_ADDR
             elif address == 0xDC:
                 return 0xDEADBEEF
+            elif address == 0x0:
+                return 0xAAAA8086
             else:
                 raise Exception("Unexpected PCI read")
         else:


### PR DESCRIPTION
Throw an exception when cannot read base for MMIO or IO bar.
Throw an exception when pci device is not enabled.

Signed-off-by: brentholtsclaw <brent.holtsclaw@intel.com>