### PR TITLE
SMI CommBuffer amendments & bugfixes

### DIFF
--- a/chipsec/hal/interrupts.py
+++ b/chipsec/hal/interrupts.py
@@ -176,14 +176,14 @@ MdeModulePkg/Core/PiSmmCore/PiSmmCorePrivateData.h
         
         if self.logger.VERBOSE:
             self.logger.log("[*] Communication buffer on input")
-            print_buffer_bytes(self.cs.mem.read_physical_mem(payload_loc, payload_sz))
+            print_buffer_bytes(self.cs.mem.read_physical_mem(payload_loc, len(data_hdr)))
             self.logger.log("")
 
         self.send_SMI_APMC(0x0, 0x0)
         
         if self.logger.VERBOSE:
             self.logger.log("[*] Communication buffer on output")
-            print_buffer_bytes(self.cs.mem.read_physical_mem(payload_loc, payload_sz))
+            print_buffer_bytes(self.cs.mem.read_physical_mem(payload_loc, len(data_hdr)))
             self.logger.log("")
 
         ReturnStatus = struct.unpack("Q", self.cs.mem.read_physical_mem(smmc + ReturnStatus_offset, 8))[0]

--- a/chipsec/hal/interrupts.py
+++ b/chipsec/hal/interrupts.py
@@ -171,7 +171,7 @@ MdeModulePkg/Core/PiSmmCore/PiSmmCorePrivateData.h
         ReturnStatus_offset = BufferSize_offset + 8
 
         self.cs.mem.write_physical_mem(smmc + CommBuffer_offset, 8, struct.pack("Q", payload_loc))
-        self.cs.mem.write_physical_mem(smmc + BufferSize_offset, 8, struct.pack("Q", payload_sz))
+        self.cs.mem.write_physical_mem(smmc + BufferSize_offset, 8, struct.pack("Q", len(data_hdr)))
         self.cs.mem.write_physical_mem(payload_loc, len(data_hdr), data_hdr)
         
         if self.logger.VERBOSE:

--- a/chipsec/hal/interrupts.py
+++ b/chipsec/hal/interrupts.py
@@ -34,7 +34,7 @@ import struct
 import uuid
 
 from chipsec.hal import hal_base
-from chipsec.logger import logger
+from chipsec.logger import logger, print_buffer_bytes
 from chipsec.hal.acpi import ACPI
 from chipsec.hal.acpi_tables import UEFI_TABLE
 from chipsec.defines import bytestostring
@@ -173,7 +173,18 @@ MdeModulePkg/Core/PiSmmCore/PiSmmCorePrivateData.h
         self.cs.mem.write_physical_mem(smmc + CommBuffer_offset, 8, struct.pack("Q", payload_loc))
         self.cs.mem.write_physical_mem(smmc + BufferSize_offset, 8, struct.pack("Q", payload_sz))
         self.cs.mem.write_physical_mem(payload_loc, len(data_hdr), data_hdr)
+        
+        if self.logger.VERBOSE:
+            self.logger.log("[*] Communication buffer on input")
+            print_buffer_bytes(self.cs.mem.read_physical_mem(payload_loc, payload_sz))
+            self.logger.log("")
+
         self.send_SMI_APMC(0x0, 0x0)
+        
+        if self.logger.VERBOSE:
+            self.logger.log("[*] Communication buffer on output")
+            print_buffer_bytes(self.cs.mem.read_physical_mem(payload_loc, payload_sz))
+            self.logger.log("")
 
         ReturnStatus = struct.unpack("Q", self.cs.mem.read_physical_mem(smmc + ReturnStatus_offset, 8))[0]
         return ReturnStatus

--- a/chipsec/hal/uefi_common.py
+++ b/chipsec/hal/uefi_common.py
@@ -185,6 +185,17 @@ EFI_STATUS_DICT = {
   StatusCode.EFI_HTTP_ERROR: "EFI_HTTP_ERROR"
 }
 
+EFI_MAX_BIT = 0x80000000_00000000
+
+def EFI_ERROR_STR( error ):
+    """
+    Translates an EFI_STATUS value into its corresponding textual representation.
+    """
+    error &= ~EFI_MAX_BIT
+    try:
+        return EFI_STATUS_DICT[error]
+    except KeyError:
+        return "UNKNOWN"
 
 EFI_GUID_FMT = "16s"
 EFI_GUID_SIZE = struct.calcsize(EFI_GUID_FMT)

--- a/chipsec/utilcmd/interrupts_cmd.py
+++ b/chipsec/utilcmd/interrupts_cmd.py
@@ -23,9 +23,10 @@
 import time
 import os
 
-from chipsec.command        import BaseCommand
-from chipsec.hal.interrupts import Interrupts
-from argparse               import ArgumentParser
+from chipsec.command         import BaseCommand
+from chipsec.hal.interrupts  import Interrupts
+from chipsec.hal.uefi_common import EFI_ERROR_STR
+from argparse                import ArgumentParser
 
 
 # ###################################################################
@@ -102,7 +103,7 @@ class SMICommand(BaseCommand):
 
         ReturnStatus = self.interrupts.send_smmc_SMI(smmc_loc, self.guid, self.payload, self.payload_loc, CommandPort=self.port)
         #TODO Translate ReturnStatus to EFI_STATUS enum
-        self.logger.log("ReturnStatus: {:x}".format(ReturnStatus))
+        self.logger.log("ReturnStatus: 0x{:x} ({})".format(ReturnStatus, EFI_ERROR_STR(ReturnStatus)))
 
 
     def smi_send(self):


### PR DESCRIPTION
* Print textual representation of the status returned by `send_smmc_SMI`.

![image](https://user-images.githubusercontent.com/8438963/111143876-ff4cb700-858e-11eb-9c5d-33ab278e48d0.png)

* Dump the communication buffer before and after triggering the SMI. In some cases such as [SmmLockBox](https://github.com/tianocore/edk2/blob/master/MdeModulePkg/Include/Guid/SmmLockBox.h), the communication buffer holds additional status codes that should be inspected upon returning from the SMI.

![image](https://user-images.githubusercontent.com/8438963/111144118-4f2b7e00-858f-11eb-9d8d-0a45477e1aff.png)

* Bug fix when writing comm buffer size to 'smmc' structure: according to EDK the size should include the `HeaderGuid` and `MessageLength` members of `EFI_SMM_COMMUNICATE_HEADER`:
```
TempCommSize = OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data) + CommunicateHeader->MessageLength;
```