### PR TITLE
Fix parsing of EDK-type boot script.

### DIFF
--- a/chipsec/hal/uefi_common.py
+++ b/chipsec/hal/uefi_common.py
@@ -31,7 +31,7 @@ from collections import namedtuple
 from uuid import UUID
 
 from chipsec.file import read_file, write_file
-from chipsec.logger import logger, dump_buffer
+from chipsec.logger import logger, dump_buffer, dump_buffer_bytes
 from chipsec.defines import bytestostring
 
 #from chipsec.helper.oshelper import helper
@@ -766,7 +766,7 @@ class S3BOOTSCRIPT_ENTRY():
     def __str__(self):
         entry_str = '' if self.index is None else ('[{:03d}] '.format(self.index))
         entry_str += ( 'Entry at offset 0x{:04X} (len = 0x{:X}, header len = 0x{:X}):'.format(self.offset_in_script, self.length, self.header_length) )
-        if self.data: entry_str = entry_str + '\nData:\n' + dump_buffer(self.data, 16)
+        if self.data: entry_str = entry_str + '\nData:\n' + dump_buffer_bytes(self.data, 16)
         if self.decoded_opcode: entry_str = entry_str + 'Decoded:\n' + str(self.decoded_opcode)
         return entry_str
 

--- a/chipsec/hal/uefi_platform.py
+++ b/chipsec/hal/uefi_platform.py
@@ -1272,8 +1272,8 @@ def id_s3bootscript_type( script, log_script=False ):
         if logger().HAL: logger().log('S3 Boot Script AA Parser')
         script_type = S3BootScriptType.EFI_BOOT_SCRIPT_TYPE_EDKCOMPAT
         if log_script: logger().log( '[uefi] Start opcode 0x{:X}'.format(start_op) )
-        script_header_length = 1 # skip start opcode
-        script_header_length += 0x34
+        # MdeModulePkg\Library\PiDxeS3BootScriptLib\BootScriptInternalFormat.h
+        script_header_length = struct.calcsize("<HBHLHH")
     else:
         if logger().HAL: logger().log('S3 Boot Script DEFAULT Parser')
         script_type = S3BootScriptType.EFI_BOOT_SCRIPT_TYPE_DEFAULT


### PR DESCRIPTION
* Fix wrong header length for EDK-type boot script. Based on EDK2, the boot script header has the following structure:
```
typedef struct {
  UINT16  OpCode;
  UINT8   Length;
  UINT16  Version;
  UINT32  TableLength;
  UINT16  Reserved[2];
} EFI_BOOT_SCRIPT_TABLE_HEADER;
```

* Dump boot script entries using `dump_buffer_bytes`.