### PR TITLE
Simplify the Makefile used by Linux kernel module

### DIFF
--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -1,5 +1,3 @@
-MACHINE ?= $(shell uname -m)
-
 DESTDIR	=
 MODDIR	= $(DESTDIR)/lib/modules
 KVERS	= $(shell uname -r)
@@ -7,16 +5,18 @@ KVER	= $(KVERS)
 VMODDIR = $(MODDIR)/$(KVER)
 KSRC	= $(VMODDIR)/build
 
-ifeq (,$(filter %i686 %i386 %i586,$(MACHINE)))
-	elf-size := elf64
-	asm-path := amd64
-else
-	elf-size := elf32
-	asm-path := i386
-endif
-
-chipsec-objs := chipsec_km.o $(asm-path)/cpu.o
 obj-m += chipsec.o
+chipsec-objs-y := chipsec_km.o
+chipsec-objs-$(CONFIG_X86_32) += i386/cpu.o
+chipsec-objs-$(CONFIG_X86_64) += amd64/cpu.o
+chipsec-objs := $(chipsec-objs-y)
+
+quiet_cmd_nasm32 = NASM_32 $@
+      cmd_nasm32 = nasm -f elf32 -o $@ $<
+
+quiet_cmd_nasm64 = NASM_64 $@
+      cmd_nasm64 = nasm -f elf64 -o $@ $<
+
 
 all: chipsec
 
@@ -26,15 +26,14 @@ check_kernel_dir:
 	    exit 1; \
 	fi
 
-chipsec: check_kernel_dir clean 
-	nasm -f $(elf-size) -o $(asm-path)/cpu.o $(asm-path)/cpu.asm
-	touch $(asm-path)/.cpu.o.cmd
-	@if [ `grep -c 'efi_call' /proc/kallsyms` != "0" ]; then \
-	    make CFLAGS_MODULE=-DHAS_EFI=1 -C $(KSRC) M=$(CURDIR) modules; \
-	else \
-	    make -C $(KSRC) M=$(CURDIR) modules; \
-	fi
+chipsec: check_kernel_dir clean
+	make -C $(KSRC) M=$(CURDIR) modules
 
 clean: check_kernel_dir
 	make -C $(KSRC) M=$(CURDIR) clean
-	rm -f ${asm-path}/cpu.o
+
+$(obj)/i386/cpu.o: $(src)/i386/cpu.asm
+	$(call if_changed,nasm32)
+
+$(obj)/amd64/cpu.o: $(src)/amd64/cpu.asm
+	$(call if_changed,nasm64)


### PR DESCRIPTION
Several improvements

* Drop the detection of EFI through kallsyms. This detection is no longer useful since commit 2c0c4c9fd125 ("Using CONFIG_EFI instead of user defined HAS_EFI (#1036)") replaced `HAS_EFI` with `CONFIG_EFI`.

* Use `...-objs-y` and `...-objs-$(CONFIG_...)` logic to choose which `cpu.asm` file is being built. This is something that other modules do in Linux kernel source.

* Introduce `quiet_cmd_...` and `cmd_...` definition in order to use the build system of the kernel to compile `cpu.asm` with NASM. This should prevent issues like the one mentioned in 2210002bab95 ("Fixed build error on latest Ubuntu") from happening again. Moreover this makes the custom clean command `rm -f ${asm-path}/cpu.o` no longer necessary.

* Remove variables which become unused after these changes. Now, all that `Makefile` needs is a kernel directory, specified with `KSRC`.

This change has been tested on a test system running Ubuntu 20.10 and on GitHub Actions workers running Ubuntu 16.04, 18.04 and 20.04 on Linux 5.4.0-1040-azure. It has also been compile-tested on many other Linux distributions using a work-in-progress GitHub Actions configuration (https://github.com/fishilico/chipsec/actions/runs/661200380).