### PR TITLE
Fix to mmio access in native mode

### DIFF
--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -607,9 +607,14 @@ class LinuxHelper(Helper):
                 self.native_map_io_space(bar_base, bar_size, 0)
                 region = self.memory_mapping(bar_base, bar_size)
                 if not region: logger().error("Unable to map region {:08x}".format(bar_base))
-            region.seek(bar_base + offset - region.start)
-            reg = region.read(size)
-            return defines.unpack1(reg, size)
+
+            # Create memoryview into mmap'ed region in dword granularity
+            region_mv = memoryview(region)
+            region_dw = region_mv.cast('I')
+            # read one DWORD
+            offset_in_region = (bar_base + offset - region.start) // 4
+            reg = region_dw[offset_in_region]
+            return reg
 
     def write_mmio_reg(self, phys_address, size, value):
         in_buf = struct.pack( "3" +self._pack, phys_address, size, value )
@@ -624,11 +629,16 @@ class LinuxHelper(Helper):
                 self.native_map_io_space(bar_base, bar_size, 0)
                 region = self.memory_mapping(bar_base, bar_size)
                 if not region: logger().error("Unable to map region {:08x}".format(bar_base))
-            region.seek(bar_base + offset - region.start)
-            written = region.write(reg)
-            if written != size:
-                logger().error("Unable to write all data to MMIO (wrote {:d} of {:d})".format(written, size))
 
+            # Create memoryview into mmap'ed region in dword granularity
+            region_mv = memoryview(region)
+            region_dw = region_mv.cast('I')
+            # Create memoryview containing data in dword
+            data_mv = memoryview(reg)
+            data_dw = data_mv.cast('I')
+            # write one DWORD
+            offset_in_region = (bar_base + offset - region.start) // 4
+            region_dw[offset_in_region] = data_dw[0]
 
     def get_ACPI_SDT( self ):
         raise UnimplementedAPIError( "get_ACPI_SDT" )


### PR DESCRIPTION
mmap() makes all the accesses to memory using a byte granularity,
when dealing with mmio registers that is not optimal and need to
perform the access at dword granularity

Signed-off-by: Ignacio Hernandez <ignacio.hernandez@intel.com>