### PR TITLE
Fix error message when the Linux kernel module fails to load

### DIFF
--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -168,7 +168,7 @@ class LinuxHelper(Helper):
         try:
             subprocess.check_output( [ "insmod", driver_path, a1, a2 ] )
         except Exception as err:
-            raise Exception("Could not start Linux Helper, are you running as Admin/root?\n\t{}.format(err)")
+            raise Exception("Could not start Linux Helper, are you running as Admin/root?\n\t{}".format(err))
         uid = gid = 0
         os.chown(self.DEVICE_NAME, uid, gid)
         os.chmod(self.DEVICE_NAME, 600)


### PR DESCRIPTION
On Arch Linux, `chipsec_main` fails:

    ################################################################
    ##                                                            ##
    ##  CHIPSEC: Platform Hardware Security Assessment Framework  ##
    ##                                                            ##
    ################################################################
    [CHIPSEC] Version 1.5.10
    [CHIPSEC] Arguments:

    insmod: ERROR: could not insert module /var/lib/dkms/chipsec/1.5.10/5.11.6-arch1-1/x86_64/module/chipsec.ko.xz: Operation not permitted
    ERROR: Message: "Could not start Linux Helper, are you running as Admin/root?
            {}.format(err)"

Showing `{}.format(err)` is a bug caused by a misplaced quote. With the quote in the right position, the error is clearer:

    ERROR: Message: "Could not start Linux Helper, are you running as Admin/root?
        Command '['insmod', '/var/lib/dkms/chipsec/1.5.10/5.11.6-arch1-1/x86_64/module/chipsec.ko.xz', '', '']' returned non-zero exit status 1."