### PR TITLE
Support overriding Linux source path

### DIFF
--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -5,7 +5,7 @@ MODDIR	= $(DESTDIR)/lib/modules
 KVERS	= $(shell uname -r)
 KVER	= $(KVERS)
 VMODDIR = $(MODDIR)/$(KVER)
-KSRC	= $(VMODDIR)/build
+KSRC	?= $(VMODDIR)/build
 
 ifeq (,$(filter %i686 %i386 %i586,$(MACHINE)))
 	elf-size := elf64


### PR DESCRIPTION
It was previously possible to build Chipsec kernel module for a different Linux
kernel than the running one, and ff4a273 broke that possibility.

Bring that back just by giving a way to override the KSRC variable when calling
the Makefile.

Fix issue #1122