### PR TITLE
Add new Comet Lake configs

### DIFF
--- a/chipsec/cfg/8086/cml.xml
+++ b/chipsec/cfg/8086/cml.xml
@@ -13,7 +13,9 @@
     <sku did="0x3E33" name="CometLake" code="CML" longname="CometLake v1 U6 Core" />
     <sku did="0x9B51" name="CometLake" code="CML" longname="CometLake v1/v2 U6 Core" />
     <sku did="0x9B61" name="CometLake" code="CML" longname="CometLake U" />
+    <sku did="0x9B63" name="CometLake" code="CML" longname="CometLake" />
     <sku did="0x9B71" name="CometLake" code="CML" longname="CometLake U" />
+    <sku did="0x9B73" name="CometLake" code="CML" longname="CometLake" />
   </info>
 
   <!-- #################################### -->

--- a/chipsec/cfg/8086/pch_4xx.xml
+++ b/chipsec/cfg/8086/pch_4xx.xml
@@ -31,6 +31,7 @@ chipsec@intel.com
   <info>
     <sku did="0xA3C8" name="B460" code="PCH_4xx" longname="400 series PCH B460" />
     <sku did="0xA3DA" name="H410" code="PCH_4xx" longname="400 series PCH H410" />
+    <sku did="0x0684" name="H470" code="PCH_4xx" longname="400 series PCH H470" />
   </info>
 
   <!-- #################################### -->

--- a/chipsec/cfg/8086/pch_4xx.xml
+++ b/chipsec/cfg/8086/pch_4xx.xml
@@ -31,11 +31,6 @@ chipsec@intel.com
   <info>
     <sku did="0xA3C8" name="B460" code="PCH_4xx" longname="400 series PCH B460" />
     <sku did="0xA3DA" name="H410" code="PCH_4xx" longname="400 series PCH H410" />
-    <sku did="0x0684" name="H470" code="PCH_4xx" longname="400 series PCH H470" />
-    <sku did="0x0685" name="Z490" code="PCH_4xx" longname="400 series PCH Z490" />
-    <sku did="0x0687" name="Q470" code="PCH_4xx" longname="400 series PCH Q470" />
-    <sku did="0x068C" name="QM480" code="PCH_4xx" longname="400 series PCH QM480" />
-    <sku did="0x0697" name="W480" code="PCH_4xx" longname="400 series PCH W480" />
   </info>
 
   <!-- #################################### -->

--- a/chipsec/cfg/8086/pch_4xx.xml
+++ b/chipsec/cfg/8086/pch_4xx.xml
@@ -32,6 +32,10 @@ chipsec@intel.com
     <sku did="0xA3C8" name="B460" code="PCH_4xx" longname="400 series PCH B460" />
     <sku did="0xA3DA" name="H410" code="PCH_4xx" longname="400 series PCH H410" />
     <sku did="0x0684" name="H470" code="PCH_4xx" longname="400 series PCH H470" />
+    <sku did="0x0685" name="Z490" code="PCH_4xx" longname="400 series PCH Z490" />
+    <sku did="0x0687" name="Q470" code="PCH_4xx" longname="400 series PCH Q470" />
+    <sku did="0x068C" name="QM480" code="PCH_4xx" longname="400 series PCH QM480" />
+    <sku did="0x0697" name="W480" code="PCH_4xx" longname="400 series PCH W480" />
   </info>
 
   <!-- #################################### -->

--- a/chipsec/cfg/8086/pch_4xxh.xml
+++ b/chipsec/cfg/8086/pch_4xxh.xml
@@ -28,9 +28,14 @@ chipsec@intel.com
   <!--                                      -->
   <!-- #################################### -->
   <info>
+    <sku did="0x0684" name="H470" code="PCH_4xx" longname="400 series PCH (CML-H) H470" />
+    <sku did="0x0685" name="Z490" code="PCH_4xx" longname="400 series PCH (CML-H) Z490" />
+    <sku did="0x0687" name="Q470" code="PCH_4xx" longname="400 series PCH (CML-H) Q470" />
+    <sku did="0x068C" name="QM480" code="PCH_4xx" longname="400 series PCH (CML-H) QM480" />
     <sku did="0x068D" name="HM470" code="PCH_4xxH" longname="400 series PCH (CML-H) HM470" />
     <sku did="0x068E" name="QM490" code="PCH_4xxH" longname="400 series PCH (CML-H) QM490" />
     <sku did="0x069A" name="H420E" code="PCH_4xxH" longname="400 series PCH (CML-H) H420E" />
+    <sku did="0x0697" name="W480" code="PCH_4xx" longname="400 series PCH (CML-H) W480" />
   </info>
 
   <!-- #################################### -->


### PR DESCRIPTION
While doing security requirements testing on various Lenovo ThinkCentre configs (M70/M70q) I got multiple unsupported CometLake platforms, here are the relevant device ID:

- CPU 9b63 (Core i3 10100 and 10100T)
- CPU 9b73 (Celeron G5905 and G5905T)
- PCH 0684 (H470)