### PR TITLE
Check the VID is present in the chipset dictionary

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -229,7 +229,7 @@ class Chipset:
 
         if platform_code is None:
         #platform code was not passed in try to determine based upon cpu id
-            if did in self.chipset_dictionary[vid] and len(self.chipset_dictionary[vid][did]) > 1 and cpuid in self.detection_dictionary.keys():
+            if vid in self.chipset_dictionary and did in self.chipset_dictionary[vid] and len(self.chipset_dictionary[vid][did]) > 1 and cpuid in self.detection_dictionary.keys():
                 for item in self.chipset_dictionary[vid][did]:
                     if self.detection_dictionary[cpuid] == item['code']:
                         #matched processor with detection value
@@ -241,7 +241,7 @@ class Chipset:
                         self.did = did
                         self.rid = rid
                         break
-            elif did in self.chipset_dictionary[vid]:
+            elif vid in self.chipset_dictionary and did in self.chipset_dictionary[vid]:
                 _unknown_platform = False
                 data_dict       = self.chipset_dictionary[vid][ did ][0]
                 self.code       = data_dict['code'].upper()


### PR DESCRIPTION
On some platforms (e.g. VirtualBox) where there is no PCI device at `00:00.0`, VID/DID reads for platform detection return `0xFFFF`.
This PR simply extends the check for a known platform to ensure the VID is known before checking the DID. See #1135.