### PR TITLE
Generate 12-byte fake TPM event in EFIFirmwareBlob test

### DIFF
--- a/tests/software/test_tpm_eventlog.py
+++ b/tests/software/test_tpm_eventlog.py
@@ -43,7 +43,7 @@ class TestTpmEventLogChipsecUtil(util.TestChipsecUtil):
         self.assertIn(b"EV_PREBOOT_CERT", self.log)
 
     def test_tpm_eventlog_firmware_blob(self):
-        data = struct.pack("QQ", 0xABABABABFEFEFEFE, 0x12345678)
+        data = struct.pack("QL", 0xABABABABFEFEFEFE, 0x12345678)
         blob_event = self._tpm12_event(0x0, 0x80000008, b"\x00" *20, data)
         self._parse_eventlog([blob_event])
         self.assertIn(b"EV_EFI_PLATFORM_FIRMWARE_BLOB", self.log)


### PR DESCRIPTION
Currently `test_tpm_eventlog_firmware_blob` generates a TPM event with 16 bytes (`struct.pack("QQ",...)`) to check the decoding of `EFIFirmwareBlob`. But the code expects a "native unsigned long", as documented in `chipsec/hal/tpm_eventlog.py`:

    class EFIFirmwareBlob(TcgPcrEvent):
        # Although [4] 9.2.5 mentions UNIT64 for the length, [1] 7.7 uses
        # a UINTN. Use a native unsigned long to cover the most general case.
        _event_fmt = "@QL"

On Windows, the size of `unsigned long` is 32 bits, and the test fails:

      File "d:\a\chipsec\chipsec\chipsec\hal\tpm_eventlog.py", line 115, in __init__
        base, length = struct.unpack(self._event_fmt, self.event)
    struct.error: unpack requires a buffer of 12 bytes

Use `"QL"` in the test in order to fix this test on Windows.