### PR TITLE
Always close the temporary log file when a test fails

### DIFF
--- a/tests/software/cs.py
+++ b/tests/software/cs.py
@@ -60,10 +60,11 @@ class TestChipsecCs(unittest.TestCase):
         logger.logger().HAL = True
         logger.logger().VERBOSE = True
         logger.logger().set_log_file(self.log_file)
-        _cs.init(platform, pch, True)
-        ret = getattr(_cs, arg.split()[0])()
-        logger.logger().close()
-        log = open(self.log_file, 'rb')
-        self.log = log.read()
-        log.close()
+        try:
+            _cs.init(platform, pch, True)
+            ret = getattr(_cs, arg.split()[0])()
+        finally:
+            logger.logger().close()
+        with open(self.log_file, 'rb') as log:
+            self.log = log.read()
         return ret

--- a/tests/software/util.py
+++ b/tests/software/util.py
@@ -62,11 +62,12 @@ class TestChipsecUtil(unittest.TestCase):
         util.VERBOSE = True
         logger.logger().HAL = True
         logger.logger().set_log_file(self.log_file)
-        err_code = util.main()
-        logger.logger().close()
-        log = open(self.log_file, 'rb')
-        self.log = log.read()
-        log.close()
+        try:
+            err_code = util.main()
+        finally:
+            logger.logger().close()
+        with open(self.log_file, 'rb') as log:
+            self.log = log.read()
         self.assertEqual(err_code, 0)
 
     def _assertLogValue(self, name, value):


### PR DESCRIPTION
When running `python setup.py test` on Windows, the following failure is reported:

    ======================================================================
    ERROR: test_platform_invalid (tests.software.test_cs.TestPlatformChipsecCs)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "d:\a\chipsec\chipsec\tests\software\cs.py", line 46, in tearDown
        os.remove(self.log_file)
    PermissionError: [WinError 32] The process cannot access the file
    because it is being used by another process:
    'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmpg5_6bcaz'

This is because when `_cs.init()` (in `tests/software/cs.py`) throws an exception, the temporary log file is not closed. Then the function `TestChipsecUtil.tearDown` attempts to remove the temporary file with `os.remove(self.log_file)` and it fails, as it is still used by the logger.

Fix this by putting `_cs.init()` inside a `try`/`finally` construction which always calls `logger.logger().close()` when an exception happens.

While at it, use `with open(...) as log` instead of `log.open()` + `log.close()`, which is a more usual way of reading files in Python.