### PR TITLE
Change tostring to tobytes in linuxhelper.py

### DIFF
--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -778,7 +778,7 @@ class LinuxHelper(Helper):
             guid = 0
             attr = 0
         else:
-            data = buffer[base:base +new_size].tostring()
+            data = buffer[base:base +new_size].tobytes()
             attr = struct.unpack( "I", buffer[8:12])[0]
         return (off, buf, hdr, data, guid, attr)
 


### PR DESCRIPTION
Tested with Python3.7 and Python3.9

Python docs at https://docs.python.org/3/whatsnew/3.9.html#removed says that `tostring` was an alias to `tobytes` anyways. 
