### PR TITLE
Symbol lookup and various other fixes

### DIFF
--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -323,17 +323,13 @@ void *my_xlate_dev_mem_ptr(unsigned long phys)
 
 	// Not RAM, so it is some device (can be bios for example)
 	addr = (void __force *)IOREMAP_NO_CACHE(start, PAGE_SIZE);
-    
-    if (addr)
-    {
-        addr = (void *)((unsigned long)addr | (phys & ~PAGE_MASK));
-        return addr;
-    }
-    
-    addr = (void __force *)ioremap_prot(start, PAGE_SIZE,0);
-    
+
+	if (!addr)
+		addr = (void __force *)ioremap_prot(start, PAGE_SIZE,0);
+
 	if (addr)
 		addr = (void *)((unsigned long)addr | (phys & ~PAGE_MASK));
+
 	return addr;
 }
 

--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -37,7 +37,6 @@ chipsec@intel.com
 #endif
 
 
-#define _GNU_SOURCE
 #define CHIPSEC_VER_ 		1
 #define CHIPSEC_VER_MINOR	2
 

--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -811,7 +811,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 			return -EFAULT;
 		break;
 #else
-		return -EFAULT;
+		return -EOPNOTSUPP;
 #endif
 	}
 
@@ -841,7 +841,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 			return -EFAULT;
 		break;
 #else
-		return -EFAULT;
+		return -EOPNOTSUPP;
 #endif
 	}
 
@@ -902,7 +902,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 
 		break;
 #else
-		return -EFAULT;
+		return -EOPNOTSUPP;
 #endif
 	}
 
@@ -923,7 +923,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 			return -EFAULT;
 		break;
 #else
-		return -EFAULT;
+		return -EOPNOTSUPP;
 #endif
 	}
 
@@ -942,7 +942,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 			return -EFAULT;
 		break;
 #else
-		return -EFAULT;
+		return -EOPNOTSUPP;
 #endif
 	}
 
@@ -961,7 +961,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 			return -EFAULT;
 		break;
 #else
-		return -EFAULT;
+		return -EOPNOTSUPP;
 #endif
 
 	}
@@ -987,10 +987,10 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 
 		ptr[4] = val;	
 		if(copy_to_user((void*)ioctl_param, (void*)ptrbuf, (sizeof(long) * numargs)) > 0)
-			return -EFAULT;	
+			return -EFAULT;
 		break;
 #else
-		return -EFAULT;
+		return -EOPNOTSUPP;
 #endif
 	}
 
@@ -1015,7 +1015,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 
 		break;
 #else
-		return -EFAULT;
+		return -EOPNOTSUPP;
 #endif
 	}
     
@@ -1069,8 +1069,8 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 			return -EFAULT;
 		break;
 #else
-		return -EFAULT;
-#endif	
+		return -EOPNOTSUPP;
+#endif
 	}
     
     	case IOCTL_SWSMI:
@@ -1089,10 +1089,10 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 		__swsmi__((SMI_CTX *)ptr);
 
 		if(copy_to_user((void*)ioctl_param, (void*)ptrbuf, (sizeof(long) * numargs)) > 0)
-			return -EFAULT;	
+			return -EFAULT;
 		break;
 #else
-		return -EFAULT;
+		return -EOPNOTSUPP;
 #endif
 	}
     
@@ -1130,7 +1130,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 			return -EFAULT;
 		break;
 #else
-		return -EFAULT;
+		return -EOPNOTSUPP;
 #endif
         }
 	case IOCTL_WRCR:
@@ -1167,7 +1167,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 			return -EFAULT;
 		break;
 #else
-        return -EFAULT;
+        return -EOPNOTSUPP;
 #endif
         }
     case IOCTL_ALLOC_PHYSMEM:
@@ -1296,7 +1296,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 		if (data_size < sizeof(uint32_t) * 13)
 		{
 			printk(KERN_ALERT "[chipsec] ERROR: INVALID SIZE PARAMETER\n");
-			return -EFAULT;
+			return -EINVAL;
 		}
         
 		// allocate that much memory
@@ -1304,7 +1304,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 		if (!kbuf)
 		{
 			printk(KERN_ALERT "[chipsec] ERROR: STATUS_UNSUCCESSFUL - could not allocate memory\n" );
-			return -EFAULT;
+			return -ENOMEM;
 		}
 
 		// fill kbuf with user's buffer
@@ -1323,7 +1323,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
                 if (namelen > (data_size - sizeof(uint32_t) * 13))
 		{
 			printk(KERN_ALERT "[chipsec] ERROR: INVALID SIZE PARAMETER (namelen %u too big for data_size %lu)\n", namelen, data_size);
-			return -EFAULT;
+			return -EINVAL;
 		}
         
         // if name overflowed, we only work with the part that fit in kbuf
@@ -1332,7 +1332,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
         {
             kfree(kbuf);
             printk(KERN_ALERT "[chipsec] ERROR: STATUS_UNSUCCESSFUL - could not allocate memory\n" );
-            return -EFAULT;
+            return -ENOMEM;
         }
 
 		for(index=0; index < namelen; index++)
@@ -1409,7 +1409,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
         if (data_size < (sizeof(uint32_t) * 14))
         {
             printk(KERN_ALERT "[chipsec] ERROR: INVALID data_size PARAMETER\n");
-            return -EFAULT;
+            return -EINVAL;
         }
         
         // allocate that much memory
@@ -1417,7 +1417,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
         if (!kbuf)
         {
             printk(KERN_ALERT "[chipsec] ERROR: STATUS_UNSUCCESSFUL - could not allocate memory\n" );
-            return -EFAULT;
+            return -ENOMEM;
         }
 
         // fill kbuf with user's buffer
@@ -1440,7 +1440,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
         { 
             printk(KERN_ALERT "[chipsec] ERROR: INVALID name PARAMETER (namelen = %u)\n", namelen);
             kfree(kbuf);
-            return -EFAULT;
+            return -EINVAL;
         }
         
         // make sure size that was passed in actually fits
@@ -1448,7 +1448,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
         {
             printk(KERN_ALERT "[chipsec] ERROR: INVALID datalen PARAMETER (%u != %lu)\n", datalen, data_size - namelen - sizeof(uint32_t)*14);
             kfree(kbuf);
-            return -EFAULT;
+            return -EINVAL;
         }
         
         // if name overflowed, we only work with the part that fit in kbuf
@@ -1457,7 +1457,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
         {
             printk(KERN_ALERT "[chipsec] ERROR: STATUS_UNSUCCESSFUL - could not allocate memory\n" );
             kfree(kbuf);
-            return -EFAULT;
+            return -ENOMEM;
         }
 
         for(index=0; index < namelen; index++)
@@ -1602,7 +1602,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 			return -EFAULT;
 		break;
 #else
-		return -EFAULT;
+		return -EOPNOTSUPP;
 #endif
 	}
 
@@ -1678,16 +1678,16 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
         }
 
         if(copy_to_user((void*)ioctl_param, (void*)ptrbuf, (sizeof(long) * numargs)) > 0)
-          return -EFAULT;	
+          return -EFAULT;
         break;
 #else
-        return -EFAULT;
+        return -EOPNOTSUPP;
 #endif
     }
 
    
 	default:
-		return -EFAULT;
+		return -EINVAL;
 	}
 	return 0;
 }

--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -1933,7 +1933,7 @@ init_module (void)
 	if (ret)
 	{
 		printk("Chipsec symbol lookup failed\n");
-		return -1;
+		return -EOPNOTSUPP;
 	}
 	ret = misc_register(&chipsec_dev);
 	if (ret)

--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -1322,6 +1322,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 
                 if (namelen > (data_size - sizeof(uint32_t) * 13))
 		{
+			kfree(kbuf);
 			printk(KERN_ALERT "[chipsec] ERROR: INVALID SIZE PARAMETER (namelen %u too big for data_size %lu)\n", namelen, data_size);
 			return -EINVAL;
 		}

--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -304,7 +304,7 @@ ReadIOPort(
  *         physical address is mapped
  */
 
-void *my_xlate_dev_mem_ptr(unsigned long phys)
+static void *my_xlate_dev_mem_ptr(unsigned long phys)
 {
 
 	void *addr=NULL;
@@ -335,7 +335,7 @@ void *my_xlate_dev_mem_ptr(unsigned long phys)
 
 // Our own implementation of unxlate_dev_mem_ptr
 // (so we can read highmem and other)
-void my_unxlate_dev_mem_ptr(unsigned long phys,void *addr)
+static void my_unxlate_dev_mem_ptr(unsigned long phys,void *addr)
 {
 	unsigned long pfn = PFN_DOWN(phys); //get page number
 


### PR DESCRIPTION
This branch fixes a few issues related to symbol resolving on kernels >= 5.10 commit 84f33831ea6f3d7771c4b3601df1734a9ef74850 already tried to address. However, this commit had some issues, e.g. failing on kernels that have `CONFIG_KPROBES` disabled. Commit https://github.com/chipsec/chipsec/commit/a1e5f3d23a36e695aae69defb2e55d445dcc4ec8 takes care of that by providing a fallback via `sprint_symbol()`. Other issues are mentioned in the commit log of https://github.com/chipsec/chipsec/commit/20ecdcf7266eca331dd4f4f8111e5bff0556eb04.

The remaining commits fix smaller issues, like providing proper return values for errors (https://github.com/chipsec/chipsec/commit/bd98472b2c3f8d3ecc0a96d52eff9241b1250215, https://github.com/chipsec/chipsec/commit/3e0761798caf650da1e4568f2bfdaf9f538d6236), improving error handling (https://github.com/chipsec/chipsec/commit/ecfcbfb5c4b1b07765ec6b55fb40ddd84ed9c7c6), fixing a memory leak (https://github.com/chipsec/chipsec/commit/76ecba2b9574a8cffcec14a0e13ec9af18545b3e) or general code cleanups (https://github.com/chipsec/chipsec/commit/32491db934f90efdc33ff654797108be9dbdcfd2, https://github.com/chipsec/chipsec/commit/ad0dc90be96c5157e12dec7b9a18295b0014db8e, https://github.com/chipsec/chipsec/commit/53f77125d97943b98d5685525511ff2bac873cef).