### PR TITLE
drivers/linux: fix getting physical address of GDT

### DIFF
--- a/chipsec/utilcmd/desc_cmd.py
+++ b/chipsec/utilcmd/desc_cmd.py
@@ -56,7 +56,7 @@ class IDTCommand(BaseCommand):
         else:
             self.logger.log( "[CHIPSEC] Dumping IDT of {:d} CPU threads".format(num_threads) )
             self.cs.msr.IDT_all( 4 )
-        self.logger.log( "[CHIPSEC] (acpi) time elapsed {:.3f}".format(time() -t) )
+        self.logger.log( "[CHIPSEC] (idt) time elapsed {:.3f}".format(time() -t) )
 
 class GDTCommand(BaseCommand):
     """
@@ -83,7 +83,7 @@ class GDTCommand(BaseCommand):
         else:
             self.logger.log( "[CHIPSEC] Dumping IDT of {:d} CPU threads".format(num_threads) )
             self.cs.msr.GDT_all( 4 )
-        self.logger.log( "[CHIPSEC] (acpi) time elapsed {:.3f}".format(time() -t) )
+        self.logger.log( "[CHIPSEC] (gdt) time elapsed {:.3f}".format(time() -t) )
 
 class LDTCommand(BaseCommand):
     """


### PR DESCRIPTION
Since kernel version 4.12 the GDT as seen by SGDT is only an r/o alias
mapping located at a fixed address not backed by a dedicated kernel
memory allocation. Later kernels moved it further to the "cpu entry
area", yet another alias mapping. All, just to mitigate all too easy
kernel address leaking in the name of KASLR. Anyhow, the fact that these
virtual addresses have no 'struct page' attached prevents us from using
virt_to_phys() to resolve its physical address. A full software page
table walk is required instead.

Luckily, slow_virt_to_phys() does just that. It was introduced in kernel
v3.9 so covers all affected kernels.

This fixes github issue #608.

While at it, extend the switch block to reject invalid descriptor code
arguments to not operate on uninitialized descriptor.

Signed-off-by: Mathias Krause <minipli@grsecurity.net>