### PR TITLE
Update 01.org mailing list link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Contact Us
 Mailing lists:
 
  * CHIPSEC users: [chipsec-users](https://groups.google.com/forum/#!forum/chipsec-users)
- * [CHIPSEC discussion list on 01.org](https://lists.01.org/mailman/listinfo/chipsec)
+ * [CHIPSEC discussion list on 01.org](https://lists.01.org/hyperkitty/list/chipsec@lists.01.org/)
 
 Twitter:
 


### PR DESCRIPTION
Signed-off-by: Nathaniel Mitchell <nathaniel.p.mitchell@intel.com> 

Per #1213. 
Google group name should be correct. Permissions got messed up, waiting on owner to help resolve. 