### PR TITLE
Fix TPM locality memory mapping bug caused by argparse changes

### DIFF
--- a/chipsec/utilcmd/tpm_cmd.py
+++ b/chipsec/utilcmd/tpm_cmd.py
@@ -58,12 +58,12 @@ class TPMCommand(BaseCommand):
 
         parser_command = subparsers.add_parser('command')
         parser_command.add_argument('command_name', type=str, help='Command')
-        parser_command.add_argument('locality', type=int, choices=[0,1,2,3,4], help='Locality')
+        parser_command.add_argument('locality', type=str, choices=['0','1','2','3','4'], help='Locality')
         parser_command.add_argument('command_parameters', nargs='*', type=int, help='Command Parameters')
         parser_command.set_defaults(func=self.tpm_command)
 
         parser_state = subparsers.add_parser('state')
-        parser_state.add_argument('locality', type=int, choices=[0,1,2,3,4], help='Locality')
+        parser_state.add_argument('locality', type=str, choices=['0','1','2','3','4'], help='Locality')
         parser_state.set_defaults(func=self.tpm_state)
         parser.parse_args(self.argv[2:], namespace=self)
         return True


### PR DESCRIPTION
After implementation of argparse, the locality parameter for `chipsec_util tpm state <locality>` is now interpreted as an int rather than as a string. Address mapping needs to be updated accordingly.