### PR TITLE
Fixes some register definitions.

### DIFF
--- a/chipsec/cfg/8086/apl.xml
+++ b/chipsec/cfg/8086/apl.xml
@@ -307,11 +307,11 @@ document id 334818/334819
     </register>
 
     <!-- MCHBAR -->
-    <register name="GFXVTBAR" type="mmio" bar="MCHBAR" offset="0x6C80" size="8" desc="Processor Graphics VT-d MMIO Base Address">
+    <register name="GFXVTBAR" type="mmio" bar="MCHBAR" offset="0x6C88" size="8" desc="Processor Graphics VT-d MMIO Base Address">
       <field name="Enable" bit="0"  size="1" desc="Enable"/>
       <field name="Base"   bit="12" size="27" desc="GFX VTD Base Address"/>
     </register>
-    <register name="VTBAR" type="mmio" bar="MCHBAR" offset="0x6C88" size="8" desc="VT-d MMIO Base Address">
+    <register name="VTBAR" type="mmio" bar="MCHBAR" offset="0x6C80" size="8" desc="VT-d MMIO Base Address">
       <field name="Enable" bit="0"  size="1"  desc="Enable"/>
       <field name="Base"   bit="12" size="27" desc="VTD Base Address"/>
     </register>
@@ -373,7 +373,7 @@ document id 334818/334819
     <!-- CPU MSRs                     -->
     <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
     <register name="MSR_POWER_MISC" type="msr" msr="0x120" desc="MISC" />
-    
+
     <!-- MSR_SMM_FEATURE_CONTROL -->
     <register name="MSR_SMM_FEATURE_CONTROL" type="msr" msr="0x4E0" desc="Enhanced SMM Feature Control">
       <field name="LOCK"            bit="0" size="1"  desc="Lock bit" />

--- a/chipsec/cfg/8086/cfl.xml
+++ b/chipsec/cfg/8086/cfl.xml
@@ -47,7 +47,7 @@ XML configuration file for Coffee Lake
   <!-- #################################### -->
   <mmio>
     <bar name="GTTMMADR" bus="0" dev="2"    fun="0" reg="0x10" width="8" mask="0x7FFF000000"                     desc="Graphics Translation Table Range"/>
-    <bar name="HDABAR"   bus="0" dev="0x1F" fun="3" reg="0x10" width="8" mask="0xFFFFFFFFFFFFC000" size="0x1000" desc="HD Audio Base"/> 
+    <bar name="HDABAR"   bus="0" dev="0x1F" fun="3" reg="0x10" width="8" mask="0xFFFFFFFFFFFFC000" size="0x1000" desc="HD Audio Base"/>
     <bar name="SPIBAR"   bus="0" dev="0x1F" fun="5" reg="0x10" width="4" mask="0xFFFFF000"         size="0x1000" desc="SPI Controller Register Range" offset="0x0"/>
     <bar name="PWRMBASE" register="PWRMBASE" base_field="BA" size="0x1000" fixed_address="0xFE000000" desc="Power Management Register Range"/>
     <bar name="SBREGBAR" register="SBREG_BAR" base_field="RBA" size="0x1000000" fixed_address="0xFD000000" desc="Sideband Register Access BAR"/>
@@ -194,31 +194,31 @@ XML configuration file for Coffee Lake
     </register>
     <register name="FREG6" undef="Flash Region 6 not defined for this platform" />
     <register name="PR0" type="mmio" bar="SPIBAR" offset="0x84" size="4" desc="Protected Range 0">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR1" type="mmio" bar="SPIBAR" offset="0x88" size="4" desc="Protected Range 1">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR2" type="mmio" bar="SPIBAR" offset="0x8C" size="4" desc="Protected Range 2">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR3" type="mmio" bar="SPIBAR" offset="0x90" size="4" desc="Protected Range 3">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR4" type="mmio" bar="SPIBAR" offset="0x94" size="4" desc="Protected Range 4">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
@@ -279,7 +279,7 @@ XML configuration file for Coffee Lake
     <register name="ECTRL" type="mm_msgbus" port="0xB8" offset="0x0004" size="4" desc="DCI Control Register">
       <field name="ENABLE" bit="4" size="1"/>
     </register>
-    
+
     <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
     <!-- I/O registers (I/O ports)    -->
     <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->

--- a/chipsec/cfg/8086/icl.xml
+++ b/chipsec/cfg/8086/icl.xml
@@ -49,6 +49,7 @@ chipsec@intel.com
   <!-- #################################### -->
   <mmio>
     <bar name="GTTMMADR" bus="0" dev="2"    fun="0" reg="0x10" width="8" mask="0x7FFF000000"                     desc="Graphics Translation Table Range"/>
+    <bar name="MCHBAR"   bus="0" dev="0"    fun="0" reg="0x48" width="8" mask="0x7FFFFF0000" size="0x8000" enable_bit="0" desc="Host Memory Mapped Register Range"/>
   </mmio>
 
   <!-- #################################### -->

--- a/chipsec/cfg/8086/kbl.xml
+++ b/chipsec/cfg/8086/kbl.xml
@@ -44,7 +44,7 @@ http://www.intel.com/content/www/us/en/processors/core/core-technical-resources.
   <!-- #################################### -->
   <mmio>
     <bar name="GTTMMADR" bus="0" dev="2"    fun="0" reg="0x10" width="8" mask="0x7FFF000000"                     desc="Graphics Translation Table Range"/>
-    <bar name="HDABAR"   bus="0" dev="0x1F" fun="3" reg="0x10" width="8" mask="0xFFFFFFFFFFFFC000" size="0x1000" desc="HD Audio Base"/> 
+    <bar name="HDABAR"   bus="0" dev="0x1F" fun="3" reg="0x10" width="8" mask="0xFFFFFFFFFFFFC000" size="0x1000" desc="HD Audio Base"/>
     <bar name="SPIBAR"   bus="0" dev="0x1F" fun="5" reg="0x10" width="4" mask="0xFFFFF000"         size="0x1000" desc="SPI Controller Register Range" offset="0x0"/>
     <bar name="PWRMBASE" register="PWRMBASE" base_field="BA" size="0x1000" fixed_address="0xFE000000" desc="Power Management Register Range"/>
     <bar name="SBREGBAR" register="SBREG_BAR" base_field="RBA" size="0x1000000" fixed_address="0xFD000000" desc="Sideband Register Access BAR"/>
@@ -191,31 +191,31 @@ http://www.intel.com/content/www/us/en/processors/core/core-technical-resources.
     </register>
     <register name="FREG6" undef="Flash Region 6 not defined for this platform" />
     <register name="PR0" type="mmio" bar="SPIBAR" offset="0x84" size="4" desc="Protected Range 0">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR1" type="mmio" bar="SPIBAR" offset="0x88" size="4" desc="Protected Range 1">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR2" type="mmio" bar="SPIBAR" offset="0x8C" size="4" desc="Protected Range 2">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR3" type="mmio" bar="SPIBAR" offset="0x90" size="4" desc="Protected Range 3">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR4" type="mmio" bar="SPIBAR" offset="0x94" size="4" desc="Protected Range 4">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
@@ -257,7 +257,7 @@ http://www.intel.com/content/www/us/en/processors/core/core-technical-resources.
       <field name="EO_4k_VALID"        bit="28" size="1" desc="4k Erase Valid"/>
       <field name="EO_64k_VALID"       bit="29" size="1" desc="64k Erase Valid"/>
       <field name="CPPTV"              bit="31" size="1" desc="Component Property Parameter Table Valid"/>
-    </register>  
+    </register>
 
     <!-- PCH RTC registers -->
     <register name="RC" type="mm_msgbus" port="0xC3" offset="0x3400" size="4" desc="RTC Configuration">

--- a/chipsec/cfg/8086/pch_1xx.xml
+++ b/chipsec/cfg/8086/pch_1xx.xml
@@ -50,7 +50,7 @@ XML configuration file for 100 series PCH based platforms
   <!--                                      -->
   <!-- #################################### -->
   <mmio>
-    <bar name="HDABAR"   bus="0" dev="0x1F" fun="3" reg="0x10" width="8" mask="0xFFFFFFFFFFFFC000" size="0x1000" desc="HD Audio Base"/> 
+    <bar name="HDABAR"   bus="0" dev="0x1F" fun="3" reg="0x10" width="8" mask="0xFFFFFFFFFFFFC000" size="0x1000" desc="HD Audio Base"/>
     <bar name="SPIBAR"   bus="0" dev="0x1F" fun="5" reg="0x10" width="4" mask="0xFFFFF000"         size="0x1000" desc="SPI Controller Register Range" offset="0x0"/>
     <bar name="PWRMBASE" register="PWRMBASE" base_field="BA" size="0x1000" fixed_address="0xFE000000" desc="Power Management Register Range"/>
     <bar name="SBREGBAR" register="SBREG_BAR" base_field="RBA" size="0x1000000" fixed_address="0xFD000000" desc="Sideband Register Access BAR"/>
@@ -196,31 +196,31 @@ XML configuration file for 100 series PCH based platforms
     </register>
     <register name="FREG6" undef="Flash Region 6 not defined for this platform" />
     <register name="PR0" type="mmio" bar="SPIBAR" offset="0x84" size="4" desc="Protected Range 0">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR1" type="mmio" bar="SPIBAR" offset="0x88" size="4" desc="Protected Range 1">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR2" type="mmio" bar="SPIBAR" offset="0x8C" size="4" desc="Protected Range 2">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR3" type="mmio" bar="SPIBAR" offset="0x90" size="4" desc="Protected Range 3">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR4" type="mmio" bar="SPIBAR" offset="0x94" size="4" desc="Protected Range 4">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
@@ -262,7 +262,7 @@ XML configuration file for 100 series PCH based platforms
       <field name="EO_4k_VALID"        bit="28" size="1" desc="4k Erase Valid"/>
       <field name="EO_64k_VALID"       bit="29" size="1" desc="64k Erase Valid"/>
       <field name="CPPTV"              bit="31" size="1" desc="Component Property Parameter Table Valid"/>
-    </register>  
+    </register>
 
     <!-- PCH RTC registers -->
     <register name="RC" type="mm_msgbus" port="0xC3" offset="0x3400" size="4" desc="RTC Configuration">

--- a/chipsec/cfg/8086/pch_2xx.xml
+++ b/chipsec/cfg/8086/pch_2xx.xml
@@ -85,7 +85,7 @@ XML configuration file for 200 series PCH based platforms
     <!-- Power Management Controller -->
     <register name="ABASE" type="pcicfg" bus="0" dev="0x1f" fun="2" offset="0x40" size="4" desc="ACPI Base Address">
       <field name="STYPE" bit="0" size="1" desc="Space Type (always 1 - I/O space)"/>
-      <field name="BA"    bit="8" size="8" desc="Base Address"/>
+      <field name="BA"    bit="8" size="24" desc="Base Address"/>
     </register>
     <register name="ACTL" type="pcicfg" bus="0" dev="0x1f" fun="2" offset="0x44" size="4" desc="ACPI Control">
       <field name="SCIS"    bit="0" size="2" desc="SCI IRQ Select"/>

--- a/chipsec/cfg/8086/pch_2xx.xml
+++ b/chipsec/cfg/8086/pch_2xx.xml
@@ -185,31 +185,31 @@ XML configuration file for 200 series PCH based platforms
     </register>
     <register name="FREG6" undef="Flash Region 6 not defined for this platform" />
     <register name="PR0" type="mmio" bar="SPIBAR" offset="0x84" size="4" desc="Protected Range 0">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR1" type="mmio" bar="SPIBAR" offset="0x88" size="4" desc="Protected Range 1">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR2" type="mmio" bar="SPIBAR" offset="0x8C" size="4" desc="Protected Range 2">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR3" type="mmio" bar="SPIBAR" offset="0x90" size="4" desc="Protected Range 3">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR4" type="mmio" bar="SPIBAR" offset="0x94" size="4" desc="Protected Range 4">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>

--- a/chipsec/cfg/8086/pch_3xx.xml
+++ b/chipsec/cfg/8086/pch_3xx.xml
@@ -269,7 +269,7 @@ https://www.intel.com/content/www/us/en/products/docs/chipsets/300-series-chipse
     </register>
 
     <!-- DCI registers -->
-    <register name="ECTRL" type="mm_msgbus" port="0x71" offset="0x0004" size="4" desc="DCI Control Register">
+    <register name="ECTRL" type="mm_msgbus" port="0xB8" offset="0x0004" size="4" desc="DCI Control Register">
       <field name="ENABLE" bit="4" size="1"/>
     </register>
 

--- a/chipsec/cfg/8086/pch_3xx.xml
+++ b/chipsec/cfg/8086/pch_3xx.xml
@@ -54,8 +54,8 @@ https://www.intel.com/content/www/us/en/products/docs/chipsets/300-series-chipse
   <!--                                      -->
   <!-- #################################### -->
   <io>
-    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
-    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x80" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x80" fixed_address="0x1800" desc="ACPI Base Address"/>
     <bar name="TCOBASE"    register="TCOBASE"  base_field="TCOBA" size="0x20"  desc="TCO Base Address"/>
 
     <!-- old definition -->
@@ -269,7 +269,7 @@ https://www.intel.com/content/www/us/en/products/docs/chipsets/300-series-chipse
     </register>
 
     <!-- DCI registers -->
-    <register name="ECTRL" type="mm_msgbus" port="0xB8" offset="0x0004" size="4" desc="DCI Control Register">
+    <register name="ECTRL" type="mm_msgbus" port="0x71" offset="0x0004" size="4" desc="DCI Control Register">
       <field name="ENABLE" bit="4" size="1"/>
     </register>
 

--- a/chipsec/cfg/8086/pch_3xxop.xml
+++ b/chipsec/cfg/8086/pch_3xxop.xml
@@ -45,8 +45,8 @@ https://www.intel.com/content/www/us/en/products/docs/chipsets/300-series-chipse
   <!--                                      -->
   <!-- #################################### -->
   <io>
-    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
-    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x80" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x80" fixed_address="0x1800" desc="ACPI Base Address"/>
     <bar name="TCOBASE"    register="TCOBASE"  base_field="TCOBA" size="0x20"  desc="TCO Base Address"/>
 
     <!-- old definition -->
@@ -84,9 +84,9 @@ https://www.intel.com/content/www/us/en/products/docs/chipsets/300-series-chipse
     </register>
 
     <!-- Power Management Controller -->
-    <register name="ABASE" type="pcicfg" bus="0" dev="0x1f" fun="2" offset="0x40" size="4" desc="ACPI Base Address">
-      <field name="STYPE" bit="0" size="1" desc="Space Type (always 1 - I/O space)"/>
-      <field name="BA"    bit="8" size="8" desc="Base Address"/>
+    <register name="ABASE" type="pcicfg" bus="0" dev="0x1f" fun="2" offset="0x20" size="4" desc="ACPI Base Address">
+      <field name="STYPE" bit="0" size="1" desc="Space Type"/>
+      <field name="BA"    bit="7" size="25" desc="Base Address"/>
     </register>
     <register name="PWRMBASE" type="pcicfg" bus="0" dev="0x1f" fun="2" offset="0x10" size="8" desc="PM Base Address">
       <field name="STYPE" bit="0"  size="1"  desc="Space Type (always 0 - memory space)"/>
@@ -261,7 +261,7 @@ https://www.intel.com/content/www/us/en/products/docs/chipsets/300-series-chipse
     </register>
 
     <!-- DCI registers -->
-    <register name="ECTRL" type="mm_msgbus" port="0xB8" offset="0x0004" size="4" desc="DCI Control Register">
+    <register name="ECTRL" type="mm_msgbus" port="0x71" offset="0x0004" size="4" desc="DCI Control Register">
       <field name="ENABLE" bit="4" size="1"/>
     </register>
 

--- a/chipsec/cfg/8086/pch_3xxop.xml
+++ b/chipsec/cfg/8086/pch_3xxop.xml
@@ -261,7 +261,7 @@ https://www.intel.com/content/www/us/en/products/docs/chipsets/300-series-chipse
     </register>
 
     <!-- DCI registers -->
-    <register name="ECTRL" type="mm_msgbus" port="0x71" offset="0x0004" size="4" desc="DCI Control Register">
+    <register name="ECTRL" type="mm_msgbus" port="0xB8" offset="0x0004" size="4" desc="DCI Control Register">
       <field name="ENABLE" bit="4" size="1"/>
     </register>
 

--- a/chipsec/cfg/8086/pch_495.xml
+++ b/chipsec/cfg/8086/pch_495.xml
@@ -46,8 +46,8 @@ XML configuration file for the 495 series PCH
   <!--                                      -->
   <!-- #################################### -->
   <io>
-    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
-    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x80" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x80" fixed_address="0x1800" desc="ACPI Base Address"/>
     <bar name="TCOBASE"    register="TCOBASE"  base_field="TCOBA" size="0x20"  desc="TCO Base Address"/>
 
     <!-- old definition -->
@@ -268,7 +268,7 @@ XML configuration file for the 495 series PCH
     </register>
 
     <!-- DCI registers -->
-    <register name="ECTRL" type="mm_msgbus" port="0xB8" offset="0x0004" size="4" desc="DCI Control Register">
+    <register name="ECTRL" type="mm_msgbus" port="0x71" offset="0x0004" size="4" desc="DCI Control Register">
       <field name="LOCK"   bit="0" size="1"/>
       <field name="ENABLE" bit="4" size="1"/>
     </register>

--- a/chipsec/cfg/8086/pch_495.xml
+++ b/chipsec/cfg/8086/pch_495.xml
@@ -268,7 +268,7 @@ XML configuration file for the 495 series PCH
     </register>
 
     <!-- DCI registers -->
-    <register name="ECTRL" type="mm_msgbus" port="0x71" offset="0x0004" size="4" desc="DCI Control Register">
+    <register name="ECTRL" type="mm_msgbus" port="0xB8" offset="0x0004" size="4" desc="DCI Control Register">
       <field name="LOCK"   bit="0" size="1"/>
       <field name="ENABLE" bit="4" size="1"/>
     </register>

--- a/chipsec/cfg/8086/pch_4xxh.xml
+++ b/chipsec/cfg/8086/pch_4xxh.xml
@@ -70,8 +70,8 @@ chipsec@intel.com
   <!--                                      -->
   <!-- #################################### -->
   <io>
-    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
-    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x80" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x80" fixed_address="0x1800" desc="ACPI Base Address"/>
     <bar name="TCOBASE"    register="TCOBASE"  base_field="TCOBA" size="0x20"  desc="TCO Base Address"/>
     <bar name="SMBUS_BASE" bus="0" dev="0x1F" fun="4" reg="0x20" mask="0xFFE0"     size="0x80"  desc="SMBus Base Address"/>
   </io>

--- a/chipsec/cfg/8086/pch_4xxlp.xml
+++ b/chipsec/cfg/8086/pch_4xxlp.xml
@@ -44,8 +44,8 @@
   <!--                                      -->
   <!-- #################################### -->
   <io>
-    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
-    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x80" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x80" fixed_address="0x1800" desc="ACPI Base Address"/>
     <bar name="TCOBASE"    register="TCOBASE"  base_field="TCOBA" size="0x20"  desc="TCO Base Address"/>
 
     <!-- old definition -->
@@ -87,9 +87,9 @@
       <field name="STYPE" bit="0" size="1" desc="Space Type (always 1 - I/O space)"/>
       <field name="BA"    bit="7" size="25" desc="Base Address"/>
     </register>
-    <register name="PWRMBASE" type="pcicfg" device="PMC" offset="0x10" size="4" desc="PM Base Address">
+    <register name="PWRMBASE" type="pcicfg" device="PMC" offset="0x10" size="8" desc="PM Base Address">
       <field name="STYPE" bit="0"  size="1"  desc="Space Type (always 0 - memory space)"/>
-      <field name="BA"    bit="12" size="19" desc="Base Address"/>
+      <field name="BA"    bit="12" size="52" desc="Base Address"/>
     </register>
     <register name="GEN_PMCON_1" type="mmio" bar="PWRMBASE" offset="0x1020" size="4" desc="General PM Configuration A">
       <field name="ESPI_SMI_LOCK"    bit="8" size="1" desc="ESPI_SMI_LOCK"/>
@@ -268,7 +268,7 @@
     </register>
 
     <!-- DCI registers -->
-    <register name="ECTRL" type="mm_msgbus" port="0xB8" offset="0x0004" size="4" desc="DCI Control Register">
+    <register name="ECTRL" type="mm_msgbus" port="0x71" offset="0x0004" size="4" desc="DCI Control Register">
       <field name="LOCK"   bit="0" size="1"/>
       <field name="ENABLE" bit="4" size="1"/>
     </register>

--- a/chipsec/cfg/8086/pch_4xxlp.xml
+++ b/chipsec/cfg/8086/pch_4xxlp.xml
@@ -268,7 +268,7 @@
     </register>
 
     <!-- DCI registers -->
-    <register name="ECTRL" type="mm_msgbus" port="0x71" offset="0x0004" size="4" desc="DCI Control Register">
+    <register name="ECTRL" type="mm_msgbus" port="0xB8" offset="0x0004" size="4" desc="DCI Control Register">
       <field name="LOCK"   bit="0" size="1"/>
       <field name="ENABLE" bit="4" size="1"/>
     </register>

--- a/chipsec/cfg/8086/pch_5xxh.xml
+++ b/chipsec/cfg/8086/pch_5xxh.xml
@@ -79,10 +79,10 @@ http://www.intel.com/content/www/us/en/processors/core/core-technical-resources.
   <!--                                      -->
   <!-- #################################### -->
   <io>
-    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
-    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x80" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x80" fixed_address="0x1800" desc="ACPI Base Address"/>
     <bar name="TCOBASE"    register="TCOBASE"  base_field="TCOBA" size="0x20"  desc="TCO Base Address"/>
-    <bar name="SMBUS_BASE" register="SBA"      base_filed="BA"    size="0x20"  desc="SMBus Base Address"/>
+    <bar name="SMBUS_BASE" register="SBA"      base_field="BA"    size="0x20"  desc="SMBus Base Address"/>
   </io>
 
   <!-- #################################### -->

--- a/chipsec/cfg/8086/pch_5xxlp.xml
+++ b/chipsec/cfg/8086/pch_5xxlp.xml
@@ -74,10 +74,10 @@ http://www.intel.com/content/www/us/en/processors/core/core-technical-resources.
   <!--                                      -->
   <!-- #################################### -->
   <io>
-    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
-    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x100" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="ABASE"      register="ABASE"    base_field="BA"    size="0x80" fixed_address="0x1800" desc="ACPI Base Address"/>
+    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x80" fixed_address="0x1800" desc="ACPI Base Address"/>
     <bar name="TCOBASE"    register="TCOBASE"  base_field="TCOBA" size="0x20"  desc="TCO Base Address"/>
-    <bar name="SMBUS_BASE" register="SBA"      base_filed="BA"    size="0x20"  desc="SMBus Base Address"/>
+    <bar name="SMBUS_BASE" register="SBA"      base_field="BA"    size="0x20"  desc="SMBus Base Address"/>
   </io>
 
   <!-- #################################### -->

--- a/chipsec/cfg/8086/skl.xml
+++ b/chipsec/cfg/8086/skl.xml
@@ -49,7 +49,7 @@ http://www.intel.com/content/www/us/en/processors/core/core-technical-resources.
   <!-- #################################### -->
   <mmio>
     <bar name="GTTMMADR" bus="0" dev="2"    fun="0" reg="0x10" width="8" mask="0x7FFF000000"                     desc="Graphics Translation Table Range"/>
-    <bar name="HDABAR"   bus="0" dev="0x1F" fun="3" reg="0x10" width="8" mask="0xFFFFFFFFFFFFC000" size="0x1000" desc="HD Audio Base"/> 
+    <bar name="HDABAR"   bus="0" dev="0x1F" fun="3" reg="0x10" width="8" mask="0xFFFFFFFFFFFFC000" size="0x1000" desc="HD Audio Base"/>
     <bar name="SPIBAR"   bus="0" dev="0x1F" fun="5" reg="0x10" width="4" mask="0xFFFFF000"         size="0x1000" desc="SPI Controller Register Range" offset="0x0"/>
     <bar name="PWRMBASE" register="PWRMBASE" base_field="BA" size="0x1000" fixed_address="0xFE000000" desc="Power Management Register Range"/>
     <bar name="SBREGBAR" register="SBREG_BAR" base_field="RBA" size="0x1000000" fixed_address="0xFD000000" desc="Sideband Register Access BAR"/>
@@ -196,31 +196,31 @@ http://www.intel.com/content/www/us/en/processors/core/core-technical-resources.
     </register>
     <register name="FREG6" undef="Flash Region 6 not defined for this platform" />
     <register name="PR0" type="mmio" bar="SPIBAR" offset="0x84" size="4" desc="Protected Range 0">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR1" type="mmio" bar="SPIBAR" offset="0x88" size="4" desc="Protected Range 1">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR2" type="mmio" bar="SPIBAR" offset="0x8C" size="4" desc="Protected Range 2">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR3" type="mmio" bar="SPIBAR" offset="0x90" size="4" desc="Protected Range 3">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>
     </register>
     <register name="PR4" type="mmio" bar="SPIBAR" offset="0x94" size="4" desc="Protected Range 4">
-      <field name="PRB" bit="0"  size="13"/>
+      <field name="PRB" bit="0"  size="15"/>
       <field name="RPE" bit="15" size="1"/>
       <field name="PRL" bit="16" size="15"/>
       <field name="WPE" bit="31" size="1"/>


### PR DESCRIPTION
Here I includes the following fixes:

1. GFXVTBAR and VTBAR have the opposite offset.
configs: apl.xml
 
2. PRB field of PRx have a wrong size it should be 15 according to the PCH's datasheet.
configs: cfl.xml, kbl.xml, skl.xml, pch_1xx.xml, pch_2xx.xml

3. Using the MCHBAR's mask indicated in the datasheet instead of using the common one.
configs: icl.xml

4. Changed the ABASE BAR size to the one indicated in the datasheet
configs: pch_3xx.xml, pch_3xxop.xml, pch_495.xml, pch_4xxh.xml, pch_4xxlp.xml, pch_5xxh.xml, pch_5xxlp.xml

5. Changes ECTRL port number (According vol 1 of those datasheets DCI port number is 0x71)
configs: pch_3xx.xml, pch_3xxop.xml, pch_495.xml, pch_4xxlp.xml

6. Fixes ABASE mask and offset
config: pch_3xxop.xml

7. Changed PWRMBASE BAR to also consider the HIGH part of the register.
config: pch_4xxlp.xml

8. Fixed 'base_filed' typo:
configs: pch_5xxh.xml, pch_5xxlp.xml 
