### PR TITLE
Move TPM register dumps to config file

### DIFF
--- a/chipsec/cfg/8086/tpm12.xml
+++ b/chipsec/cfg/8086/tpm12.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<configuration>
+<!--
+CHIPSEC: Platform Security Assessment Framework
+Copyright (c) 2021, Intel Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; Version 2.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+Contact information:
+chipsec@intel.com
+-->
+
+<!--
+XML configuration file for TPM address space
+-->
+  <registers>
+
+    <register name="TPM_ACCESS" type="memory" access="mmio" address="0xFED40000" offset="0x000" size="1" desc="TPM ACCESS">
+      <field name="tpmRegValidSts"   bit="7" size="1" desc="tpmRegValidSts"/>
+      <field name="reserved"         bit="6" size="1" desc="reserved"/>
+      <field name="activeLocality"   bit="5" size="1" desc="activeLocality"/>
+      <field name="beenSeized"       bit="4" size="1" desc="beenSeized"/>
+      <field name="Seize"            bit="3" size="1" desc="Seize"/>
+      <field name="pendingRequest"   bit="2" size="1" desc="pendingRequest"/>
+      <field name="requestUse"       bit="1" size="1" desc="requestUse"/>
+      <field name="tpmEstablishment" bit="0" size="1" desc="tpmEstablishment"/>
+    </register>
+
+    <register name="TPM_STS" type="memory" access="mmio" address="0xFED40018" offset="0x000" size="4" desc="TPM STATUS">
+      <field name="burstCount"    bit="8" size="24" desc="burstCount"/>
+      <field name="stsValid"      bit="7" size="1"  desc="stsValid"/>
+      <field name="commandReady"  bit="6" size="1"  desc="commandReady"/>
+      <field name="tpmGo"         bit="5" size="1"  desc="tpmGo"/>
+      <field name="dataAvail"     bit="4" size="1"  desc="dataAvail"/>
+      <field name="Expect"        bit="3" size="1"  desc="Expect"/>
+      <field name="Reserved"      bit="2" size="1"  desc="Reserved"/>
+      <field name="responseRetry" bit="1" size="1"  desc="responseRetry"/>
+      <field name="Reserved"      bit="0" size="1"  desc="Reserved"/>
+    </register>
+
+    <register name="TPM_DID_VID" type="memory" access="mmio" address="0xFED40F00" offset="0x000" size="4" desc="TPM DID/VID">
+      <field name="did" bit="16" size="16" desc="did"/>
+      <field name="vid" bit="0"  size="16" desc="vid"/>
+    </register>
+
+    <register name="TPM_RID" type="memory" access="mmio" address="0xFED40F04" offset="0x000" size="1" desc="TPM RID">
+      <field name="rid" bit="0" size="8" desc="rid"/>
+    </register>
+
+    <register name="TPM_INTF_CAPABILITY" type="memory" access="mmio" address="0xFED40014" offset="0x000" size="4" desc="TPM INTF CAPABILITY">
+      <field name="Reserved"                 bit="9" size="23" desc="Reserved"/>
+      <field name="BurstCountStatic"         bit="8" size="1"  desc="BurstCountStatic"/>
+      <field name="CommandReadyIntSupport"   bit="7" size="1"  desc="CommandReadyIntSupport"/>
+      <field name="InterruptEdgeFalling"     bit="6" size="1"  desc="InterruptEdgeFalling"/>
+      <field name="InterruptEdgeRising"      bit="5" size="1"  desc="InterruptEdgeRising"/>
+      <field name="InterruptLevelLow"        bit="4" size="1"  desc="InterruptLevelLow"/>
+      <field name="InterruptLevelHigh"       bit="3" size="1"  desc="InterruptLevelHigh"/>
+      <field name="LocalityChangeIntSupport" bit="2" size="1"  desc="LocalityChangeIntSupport"/>
+      <field name="stsValidIntSupport"       bit="1" size="1"  desc="stsValidIntSupport"/>
+      <field name="dataAvailIntSupport"      bit="0" size="1"  desc="dataAvailIntSupport"/>
+    </register>
+
+    <register name="TPM_INT_ENABLE" type="memory" access="mmio" address="0xFED40008" offset="0x000" size="4" desc="TPM INT ENABLE">
+      <field name="globalIntEnable"         bit="31" size="1"  desc="CommandReadyIntSupport"/>
+      <field name="Reserved"                bit="8"  size="23" desc="InterruptEdgeFalling"/>
+      <field name="commandReadyEnable"      bit="7"  size="1"  desc="InterruptEdgeRising"/>
+      <field name="reserved"                bit="5"  size="2"  desc="InterruptLevelLow"/>
+      <field name="typePolarity"            bit="3"  size="2"  desc="InterruptLevelHigh"/>
+      <field name="localityChangeIntEnable" bit="2"  size="1"  desc="LocalityChangeIntSupport"/>
+      <field name="stsValidIntEnable"       bit="1"  size="1"  desc="stsValidIntSupport"/>
+      <field name="dataAvailIntEnable"      bit="0"  size="1"  desc="dataAvailIntSupport"/>
+    </register>
+
+  </registers>
+
+  <controls>
+  </controls>
+
+</configuration>

--- a/chipsec/hal/tpm.py
+++ b/chipsec/hal/tpm.py
@@ -32,6 +32,7 @@ from collections import namedtuple
 
 from chipsec.logger import print_buffer
 from chipsec.hal import hal_base
+from chipsec.hal import acpi
 
 import chipsec.hal.tpm12_commands
 
@@ -329,141 +330,59 @@ class TPM(hal_base.HALBase):
         """
         View the contents of the register used to gain ownership of the TPM
         """
-        try:
-            Locality = LOCALITY[locality]
-        except:
-            if self.logger.HAL: self.logger.log_bad("Invalid locality value\n")
-            return
-
-        access_address = self.TPM_BASE | Locality| TPM_ACCESS
-        access_value = self.helper.read_mmio_reg( access_address, 1 )
-
-        self.logger.log( "================================================================" )
-        self.logger.log( "                        TPM Access" )
-        self.logger.log( "================================================================" )
-        self.logger.log( "\ttpmRegValidSts  : 0x{}".format(bin( access_value & ( 1<<7 ) )[2]) )
-        self.logger.log( "\treserved        : 0x{}".format(bin( access_value & ( 1<<6 ) )[2]) )
-        self.logger.log( "\tactiveLocality  : 0x{}".format(bin( access_value & ( 1<<5 ) )[2]) )
-        self.logger.log( "\tbeenSeized      : 0x{}".format(bin( access_value & ( 1<<4 ) )[2]) )
-        self.logger.log( "\tSeize           : 0x{}".format(bin( access_value & ( 1<<3 ) )[2]) )
-        self.logger.log( "\tpendingRequest  : 0x{}".format(bin( access_value & ( 1<<2 ) )[2]) )
-        self.logger.log( "\trequestUse      : 0x{}".format(bin( access_value & ( 1<<1 ) )[2]) )
-        self.logger.log( "\ttpmEstablishment: 0x{}".format(bin( access_value & ( 1<<0 ) )[2]) )
+        register = 'TPM_ACCESS'
+        self.dump_register(register, locality)
 
     def dump_status( self, locality ):
         """
         View general status details
         """
-        try:
-            Locality = LOCALITY[locality]
-        except:
-            if self.logger.HAL: self.logger.log_bad("Invalid locality value\n")
-            return
-
-        sts_address = self.TPM_BASE | Locality| TPM_STS
-        sts_value = self.helper.read_mmio_reg( sts_address, 4 )
-
-        self.logger.log( "================================================================" )
-        self.logger.log( "                         TPM Status" )
-        self.logger.log( "================================================================" )
-        self.logger.log( "\tburstCount   : 0x{:x}".format( ( sts_value>>8 ) & 0xFFFFFF ) )
-        self.logger.log( "\tstsValid     : 0x{}".format(bin( sts_value & ( 1<<7 ) )[2]) )
-        self.logger.log( "\tcommandReady : 0x{}".format(bin( sts_value & ( 1<<6 ) )[2]) )
-        self.logger.log( "\ttpmGo        : 0x{}".format(bin( sts_value & ( 1<<5 ) )[2]) )
-        self.logger.log( "\tdataAvail    : 0x{}".format(bin( sts_value & ( 1<<4 ) )[2]) )
-        self.logger.log( "\tExpect       : 0x{}".format(bin( sts_value & ( 1<<3 ) )[2]) )
-        self.logger.log( "\tReserved     : 0x{}".format(bin( sts_value & ( 1<<2 ) )[2]) )
-        self.logger.log( "\tresponseRetry: 0x{}".format(bin( sts_value & ( 1<<1 ) )[2]) )
-        self.logger.log( "\tReserved     : 0x{}".format(bin( sts_value & ( 1<<0 ) )[2]) )
+        register = 'TPM_STS'
+        self.dump_register(register, locality)
 
     def dump_didvid( self, locality ):
-        """ 
+        """
         TPM's Vendor and Device ID
         """
-        try:
-            Locality = LOCALITY[locality]
-        except:
-            if self.logger.HAL: self.logger.log_bad("Invalid locality value\n")
-            return
-
-        didvid_address = self.TPM_BASE | Locality| TPM_DIDVID
-        didvid_value = self.helper.read_mmio_reg( didvid_address, 4 )
-
-        self.logger.log( "================================================================" )
-        self.logger.log( "                           TPM DID VID" )
-        self.logger.log( "================================================================" )
-        self.logger.log( "\tdid: 0x{:x}".format( ( didvid_value>>16 ) & 0xFFFF ) )
-        self.logger.log( "\tvid: 0x{:x}".format( didvid_value & 0xFFFF) )
+        register = 'TPM_DID_VID'
+        self.dump_register(register, locality)
 
     def dump_rid( self, locality ):
         """
         TPM's Revision ID
         """
-        try:
-            Locality = LOCALITY[locality]
-        except:
-            if self.logger.HAL: self.logger.log_bad("Invalid locality value\n")
-            return
-
-        rid_address = self.TPM_BASE | Locality| TPM_RID
-        rid_value = self.helper.read_mmio_reg( rid_address, 1 )
-
-        self.logger.log( "================================================================" )
-        self.logger.log( "                             TPM RID" )
-        self.logger.log( "================================================================" )
-        self.logger.log( "\trid: 0x{:x}".format(rid_value) )
+        register = 'TPM_RID'
+        self.dump_register(register, locality)
 
     def dump_intcap( self, locality ):
         """
         Provides information of which interrupts that particular TPM supports
         """
-        try:
-            Locality = LOCALITY[locality]
-        except:
-            if self.logger.HAL: self.logger.log_bad("Invalid locality value\n")
-            return
-
-        intcap_address = self.TPM_BASE | Locality| TPM_INTCAP
-        intcap_value = self.helper.read_mmio_reg( intcap_address, 4 )
-
-        self.logger.log( "================================================================" )
-        self.logger.log( "                     TPM INTF CAPABILITY" )
-        self.logger.log( "================================================================" )
-        self.logger.log( "\tReserved                : 0x{:x}".format( ( intcap_value>>8 ) & 0xFFFFFE ) )
-        self.logger.log( "\tBurstCountStatic        : 0x{}".format(bin( intcap_value & ( 1<<8 ) )[2]) )
-        self.logger.log( "\tCommandReadyIntSupport  : 0x{}".format(bin( intcap_value & ( 1<<7 ) )[2]) )
-        self.logger.log( "\tInterruptEdgeFalling    : 0x{}".format(bin( intcap_value & ( 1<<6 ) )[2]) )
-        self.logger.log( "\tInterruptEdgeRising     : 0x{}".format(bin( intcap_value & ( 1<<5 ) )[2]) )
-        self.logger.log( "\tInterruptLevelLow       : 0x{}".format(bin( intcap_value & ( 1<<4 ) )[2]) )
-        self.logger.log( "\tInterruptLevelHigh      : 0x{}".format(bin( intcap_value & ( 1<<3 ) )[2]) )
-        self.logger.log( "\tLocalityChangeIntSupport: 0x{}".format(bin( intcap_value & ( 1<<2 ) )[2]) )
-        self.logger.log( "\tstsValidIntSupport      : 0x{}".format(bin( intcap_value & ( 1<<1 ) )[2]) )
-        self.logger.log( "\tdataAvailIntSupport     : 0x{}".format(bin( intcap_value & ( 1<<0 ) )[2]) )
+        register = 'TPM_INTF_CAPABILITY'
+        self.dump_register(register, locality)
 
     def dump_intenable( self, locality ):
         """
         View the contents of the register used to enable specific interrupts
         """
-        polType = { 0: "High Level", 1: "Low Level", 2: "Rising edge", 3: "Failing edge" }
+        register = 'TPM_INT_ENABLE'
+        self.dump_register(register, locality)
 
-        try:
-            Locality = LOCALITY[locality]
-        except:
-            if self.logger.HAL: self.logger.log_bad("Invalid locality value\n")
-            return
+    def log_register_header(self, register_name, locality):
+        num_spaces = 32 + (-len(register_name) // 2)  # ceiling division
+        self.logger.log( '=' * 64 )
+        self.logger.log( "{}{}_{}".format(' ' * num_spaces, register_name, locality) )
+        self.logger.log( '=' * 64 )
 
-        intenable_address = self.TPM_BASE | Locality| TPM_INTENABLE
-        intenable_value = self.helper.read_mmio_reg( intenable_address, 4 )
+    def dump_register(self, register_name, locality):
+        self.cs.Cfg.REGISTERS[register_name]['address'] = hex(int(self.cs.Cfg.REGISTERS[register_name]['address'], 16) ^ LOCALITY[locality])
+        register = self.cs.read_register_dict(register_name)
 
-        self.logger.log( "================================================================" )
-        self.logger.log( "                         TPM INT ENABLE" )
-        self.logger.log( "================================================================" )
-        self.logger.log( "\tglobalIntEnable        : 0x{}".format(bin( intenable_value & ( 1<<31 ) )[2]) )
-        self.logger.log( "\tReserved               : 0x{:x}".format( (intenable_value>>8) & 0x7FFFFF00 ) )
-        self.logger.log( "\tcommandReadyEnable     : 0x{}".format(bin( intenable_value & ( 1<<7 ) )[2]) )
-        self.logger.log( "\tReserved               : 0x{:x}".format( (intenable_value>>5) & 0x3  ) )
-        type = ( ( intenable_value>>3 ) & 0x3 )
-        self.logger.log( "\ttypePolarity           : 0x{:x}  {}".format( type, polType[type] ) )
-        self.logger.log( "\tlocalityChangeIntEnable: 0x{}".format(bin( intenable_value & ( 1<<2 ) )[2]) )
-        self.logger.log( "\tstsValidIntEnable      : 0x{}".format(bin( intenable_value & ( 1<<1 ) )[2]) )
-        self.logger.log( "\tdataAvailIntEnable     : 0x{}".format(bin( intenable_value & ( 1<<0 ) )[2]) )
+        self.log_register_header(register_name, locality)
+
+        max_field_len = 0
+        for field in register['FIELDS']:
+            if len(field) > max_field_len:
+                max_field_len = len(field)
+        for field in register['FIELDS']:
+            self.logger.log('\t{}{}: {}'.format(field, ' ' * (max_field_len-len(field)), hex(register['FIELDS'][field]['value'])))

--- a/chipsec/hal/tpm.py
+++ b/chipsec/hal/tpm.py
@@ -1,5 +1,5 @@
 #CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2020, Intel Corporation
+#Copyright (c) 2010-2021, Intel Corporation
 #
 #This program is free software; you can redistribute it and/or
 #modify it under the terms of the GNU General Public License

--- a/chipsec/utilcmd/tpm_cmd.py
+++ b/chipsec/utilcmd/tpm_cmd.py
@@ -85,11 +85,12 @@ class TPMCommand(BaseCommand):
 
 
     def run(self):
-        try:
-            self._tpm = tpm.TPM(self.cs)
-        except tpm.TpmRuntimeError as msg:
-            self.logger.log(msg)
-            return
+        if self.func != self.tpm_parse:
+            try:
+                self._tpm = tpm.TPM(self.cs)
+            except tpm.TpmRuntimeError as msg:
+                self.logger.log(msg)
+                return
 
         self.func()
 

--- a/chipsec/utilcmd/tpm_cmd.py
+++ b/chipsec/utilcmd/tpm_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # CHIPSEC: Platform Security Assessment Framework
 # Copyright (c) 2017, Google Inc
-# Copyright (c) 2010-2020, Intel Corporation
+# Copyright (c) 2010-2021, Intel Corporation
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License


### PR DESCRIPTION
TPM register dumps are currently hardcoded into the TPM HAL. By moving them to xml config files and implementing functionality to read the xml files, we can add more flexibility for register dumping, especially as we add support for TPM2.0 registers.

Signed-off-by: Kevin Sun <kevin.sun@intel.com>