### PR TITLE
Create exceptions.py for chipsec exceptions

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -33,6 +33,8 @@ import xml.etree.ElementTree as ET
 from chipsec.helper.oshelper import OsHelper, OsHelperError
 from chipsec.hal import cpu, io, iobar, mmio, msgbus, msr, pci, physmem, ucode, igd
 from chipsec.hal.pci import PCI_HDR_RID_OFF
+from chipsec.exceptions import UnknownChipsetError, DeviceNotFoundError, CSReadError
+from chipsec.exceptions import RegisterNotFoundError, RegisterTypeNotFoundError
 
 from chipsec.logger import logger
 from chipsec.defines import is_hex
@@ -71,10 +73,6 @@ class Cfg:
         self.LOCKEDBY      = {}
         self.XML_CONFIG_LOADED = False
 
-class CSReadError(RuntimeError):
-    def __init__(self, msg):
-        super(CSReadError, self).__init__(msg)
-
 
 ##################################################################################
 # Functionality defining current chipset
@@ -104,18 +102,6 @@ def f_xml(self, x):
 def map_xmlname(self, x):
     return x.split('.')[0]
 
-
-class UnknownChipsetError(RuntimeError):
-    pass
-
-class DeviceNotFoundError(RuntimeError):
-    pass
-
-class RegisterNotFoundError(RuntimeError):
-    pass
-
-class RegisterTypeNotFoundError(RuntimeError):
-    pass
 
 class Chipset:
 

--- a/chipsec/exceptions.py
+++ b/chipsec/exceptions.py
@@ -1,0 +1,137 @@
+#!/usr/bin/python
+#CHIPSEC: Platform Security Assessment Framework
+#Copyright (c) 2021, Intel Corporation
+#
+#This program is free software; you can redistribute it and/or
+#modify it under the terms of the GNU General Public License
+#as published by the Free Software Foundation; Version 2.
+#
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program; if not, write to the Free Software
+#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#Contact information:
+#chipsec@intel.com
+#
+
+#Chipset
+class UnknownChipsetError(RuntimeError):
+    pass
+
+class DeviceNotFoundError(RuntimeError):
+    pass
+
+class RegisterNotFoundError(RuntimeError):
+    pass
+
+class RegisterTypeNotFoundError(RuntimeError):
+    pass
+
+class CSReadError(RuntimeError):
+    def __init__(self, msg):
+        super(CSReadError, self).__init__(msg)
+
+#HAL
+class AcpiRuntimeError (RuntimeError):
+    pass
+
+class CmosRuntimeError (RuntimeError):
+    pass
+class CmosAccessError (RuntimeError):
+    pass
+
+class CPURuntimeError (RuntimeError):
+    pass
+
+class CpuIDRuntimeError (RuntimeError):
+    pass
+
+class IGDRuntimeError (RuntimeError):
+    pass
+
+class PortIORuntimeError (RuntimeError):
+    pass
+
+class IOBARRuntimeError (RuntimeError):
+    pass
+
+class IOBARNotFoundError (RuntimeError):
+    pass
+
+class IOMMUError (RuntimeError):
+    pass
+
+class MsgBusRuntimeError (RuntimeError):
+    pass
+
+class MsrRuntimeError (RuntimeError):
+    pass
+
+class PciRuntimeError (RuntimeError):
+    pass
+class PciDeviceNotFoundError (RuntimeError):
+    pass
+
+class MemoryRuntimeError (RuntimeError):
+    pass
+
+class MemoryAccessError (RuntimeError):
+    pass
+
+class SpiRuntimeError (RuntimeError):
+    pass
+
+class SpiAccessError (RuntimeError):
+    pass
+
+class TpmRuntimeError (RuntimeError):
+    pass
+
+class VirtualMemoryRuntimeError (RuntimeError):
+    pass
+
+class VirtualMemoryAccessError (RuntimeError):
+    pass
+
+class VMMRuntimeError (RuntimeError):
+    pass
+
+class InvalidMemoryAddress (RuntimeError):
+    pass
+
+#OS Helper
+class OsHelperError (RuntimeError):
+    def __init__(self, msg, errorcode):
+        super(OsHelperError, self).__init__(msg)
+        self.errorcode = errorcode
+
+class HWAccessViolationError (OsHelperError):
+    pass
+
+class UnimplementedAPIError (OsHelperError):
+    def __init__(self, api_name):
+        super(UnimplementedAPIError, self).__init__("'{}' is not implemented".format(api_name), 0)
+
+class UnimplementedNativeAPIError (UnimplementedAPIError):
+    def __init__(self, api_name):
+        super(UnimplementedNativeAPIError, self).__init__(api_name)
+
+class DALHelperError (RuntimeError):
+    pass
+
+class EfiHelperError (RuntimeError):
+    pass
+
+# Logger
+
+class LoggerError (RuntimeWarning):
+    pass
+
+# tools
+class BadSMIDetected (RuntimeError):
+    pass

--- a/chipsec/hal/acpi.py
+++ b/chipsec/hal/acpi.py
@@ -33,12 +33,10 @@ from collections import namedtuple
 from chipsec.logger import logger, print_buffer
 from chipsec.file import read_file
 from chipsec.defines import bytestostring
+from chipsec.exceptions import UnimplementedNativeAPIError
 
 from chipsec.hal import acpi_tables, hal_base, uefi
 from chipsec.helper import oshelper
-
-class AcpiRuntimeError (RuntimeError):
-    pass
 
 # ACPI Table Header Format
 ACPI_TABLE_HEADER_FORMAT = '=4sIBB6s8sI4sI'
@@ -400,7 +398,7 @@ class ACPI(hal_base.HALBase):
 
             self.get_table_list_from_SDT(sdt, is_xsdt)
             self.get_DSDT_from_FADT()
-        except oshelper.UnimplementedNativeAPIError:
+        except UnimplementedNativeAPIError:
             # 2. If didn't work, try using get_ACPI_table if a helper implemented
             #    reading ACPI tables via native API which some OS may provide
             if logger().HAL: logger().log( "[acpi] trying to enumerate ACPI tables using get_ACPI_table..." )
@@ -484,7 +482,7 @@ class ACPI(hal_base.HALBase):
                     t_size = self.cs.mem.read_physical_mem_dword( table_address + 4 )
                     t_data = self.cs.mem.read_physical_mem( table_address, t_size )
                     acpi_tables_data.append( t_data )
-            except oshelper.UnimplementedNativeAPIError:
+            except UnimplementedNativeAPIError:
                 # 2. If didn't work, try using get_ACPI_table if a helper implemented
                 #    reading ACPI tables via native API which some OS may provide
                 if logger().HAL: logger().log( "[acpi] trying to extract ACPI table using get_ACPI_table..." )

--- a/chipsec/hal/cmos.py
+++ b/chipsec/hal/cmos.py
@@ -43,11 +43,6 @@ usage:
 from chipsec.hal import hal_base
 import chipsec.logger
 
-class CmosRuntimeError (RuntimeError):
-    pass
-class CmosAccessError (RuntimeError):
-    pass
-
 CMOS_ADDR_PORT_LOW  = 0x70
 CMOS_DATA_PORT_LOW  = 0x71
 CMOS_ADDR_PORT_HIGH = 0x72

--- a/chipsec/hal/cpu.py
+++ b/chipsec/hal/cpu.py
@@ -35,9 +35,6 @@ VMM_VMWARE  = 0x3
 VMM_KVM     = 0x4
 
 
-class CPURuntimeError (RuntimeError):
-    pass
-
 ########################################################################################################
 #
 # CORES HAL Component

--- a/chipsec/hal/cpuid.py
+++ b/chipsec/hal/cpuid.py
@@ -29,9 +29,6 @@ usage:
 from chipsec.hal import hal_base
 from chipsec.logger import logger
 
-class CpuIDRuntimeError (RuntimeError):
-    pass
-
 class CpuID(hal_base.HALBase):
 
     def __init__(self, cs):

--- a/chipsec/hal/igd.py
+++ b/chipsec/hal/igd.py
@@ -36,8 +36,6 @@ from chipsec.hal import hal_base
 from chipsec.logger import print_buffer
 from chipsec.defines import bytestostring
 
-class IGDRuntimeError (RuntimeError):
-    pass
 
 class IGD(hal_base.HALBase):
 

--- a/chipsec/hal/io.py
+++ b/chipsec/hal/io.py
@@ -34,8 +34,6 @@ usage:
 
 from chipsec.logger import logger
 
-class PortIORuntimeError (RuntimeError):
-    pass
 
 class PortIO:
 

--- a/chipsec/hal/iobar.py
+++ b/chipsec/hal/iobar.py
@@ -32,13 +32,9 @@ usage:
 
 from chipsec.hal import hal_base
 from chipsec.logger import logger
+from chispec.error import IOBARNotFoundError
 
 DEFAULT_IO_BAR_SIZE = 0x100
-
-class IOBARRuntimeError (RuntimeError):
-    pass
-class IOBARNotFoundError (RuntimeError):
-    pass
 
 class IOBAR(hal_base.HALBase):
 

--- a/chipsec/hal/iommu.py
+++ b/chipsec/hal/iommu.py
@@ -27,6 +27,7 @@ Access to IOMMU engines
 """
 
 from chipsec.hal import hal_base, mmio, paging
+from chipec.error import IOMMUError
 
 IOMMU_ENGINE_DEFAULT = 'VTD'
 IOMMU_ENGINE_GFX     = 'GFXVTD'
@@ -37,9 +38,6 @@ IOMMU_ENGINES = {
   IOMMU_ENGINE_DEFAULT: 'VTBAR'
 }
 
-
-class IOMMUError (RuntimeError):
-    pass
 
 class IOMMU(hal_base.HALBase):
 

--- a/chipsec/hal/msgbus.py
+++ b/chipsec/hal/msgbus.py
@@ -37,6 +37,8 @@ usage:
 """
 
 from chipsec.hal import hal_base
+from chipsec.exceptions import RegisterNotFoundError
+
 
 #
 # IOSF Message bus message opcodes
@@ -81,9 +83,6 @@ class MessageBusPort_Quark:
     UNIT_SOC   = 0x31
 
 
-class MsgBusRuntimeError (RuntimeError):
-    pass
-
 class MsgBus(hal_base.HALBase):
 
     def __init__(self, cs):
@@ -116,7 +115,7 @@ class MsgBus(hal_base.HALBase):
             elif self.cs.register_has_field("P2SB_HIDE", "HIDE"):
                 self.p2sbHide = {'reg': 'P2SB_HIDE', 'field': 'HIDE'}
             else:
-                raise self.cs.RegisterNotFoundError ('RegisterNotFound: P2SBC')
+                raise RegisterNotFoundError ('RegisterNotFound: P2SBC')
 
         hidden = not self.cs.is_device_enabled('P2SBC')
         if hide:

--- a/chipsec/hal/msr.py
+++ b/chipsec/hal/msr.py
@@ -55,9 +55,6 @@ MemType = {
     MTRR_MEMTYPE_WB: 'Writeback (WB)'
 }
 
-class MsrRuntimeError (RuntimeError):
-    pass
-
 class Msr:
 
     def __init__( self, cs ):

--- a/chipsec/hal/paging.py
+++ b/chipsec/hal/paging.py
@@ -39,9 +39,6 @@ ADDR_4KB   = 0xFFFFFFFFFFFFF000 & MAXPHYADDR
 ADDR_2MB   = 0xFFFFFFFFFFE00000 & MAXPHYADDR
 ADDR_1GB   = 0xFFFFFFFFC0000000 & MAXPHYADDR
 
-class InvalidMemoryAddress (RuntimeError):
-    pass
-
 
 class c_translation(object):
 

--- a/chipsec/hal/pci.py
+++ b/chipsec/hal/pci.py
@@ -46,12 +46,7 @@ from chipsec.logger import logger, pretty_print_hex_buffer
 from chipsec.file import write_file
 from chipsec.hal.pcidb import VENDORS, DEVICES
 from chipsec.helper import oshelper
-
-
-class PciRuntimeError (RuntimeError):
-    pass
-class PciDeviceNotFoundError (RuntimeError):
-    pass
+from chipsec.exceptions import OsHelperError
 
 #
 # PCI configuration header registers
@@ -284,7 +279,7 @@ class Pci:
                     vid = did_vid & 0xFFFF
                     did = (did_vid >> 16) & 0xFFFF
                     devices.append((b, d, f, vid, did))
-            except oshelper.OsHelperError:
+            except OsHelperError:
                 if logger().HAL:
                     logger().log("[pci] unable to access B/D/F: {:d}/{:d}/{:d}".format(b, d, f))
         return devices

--- a/chipsec/hal/physmem.py
+++ b/chipsec/hal/physmem.py
@@ -35,11 +35,6 @@ import sys
 from chipsec.hal.hal_base import HALBase
 from chipsec.logger import print_buffer
 
-class MemoryRuntimeError (RuntimeError):
-    pass
-
-class MemoryAccessError (RuntimeError):
-    pass
 
 class Memory(HALBase):
     def __init__( self, cs ):

--- a/chipsec/hal/smbus.py
+++ b/chipsec/hal/smbus.py
@@ -32,6 +32,7 @@ Access to SMBus Controller
 """
 
 from chipsec.hal import iobar, hal_base
+from chipsec.exceptions import IOBARNotFoundError, RegisterNotFoundError
 
 SMBUS_COMMAND_QUICK         = 0
 SMBUS_COMMAND_BYTE          = 1
@@ -64,7 +65,7 @@ class SMBus(hal_base.HALBase):
             (sba_base, sba_size) = self.iobar.get_IO_BAR_base_address( 'SMBUS_BASE' )
             return sba_base
         else:
-            raise iobar.IOBARNotFoundError ('IOBARAccessError: SMBUS_BASE')
+            raise IOBARNotFoundError ('IOBARAccessError: SMBUS_BASE')
 
     def get_SMBus_HCFG( self ):
         if self.cs.is_register_defined( 'SMBUS_HCFG' ):
@@ -72,7 +73,7 @@ class SMBus(hal_base.HALBase):
             if self.logger.HAL: self.cs.print_register( 'SMBUS_HCFG', reg_value )
             return reg_value
         else:
-            raise self.cs.RegisterNotFoundError ('RegisterNotFound: SMBUS_HCFG')
+            raise RegisterNotFoundError ('RegisterNotFound: SMBUS_HCFG')
 
     def display_SMBus_info( self ):
         if self.logger.HAL: self.logger.log( "[smbus] SMBus Base Address: 0x{:04X}".format(self.get_SMBus_Base_Address()) )

--- a/chipsec/hal/spi.py
+++ b/chipsec/hal/spi.py
@@ -52,6 +52,7 @@ from chipsec.logger import print_buffer, print_buffer_bytes
 from chipsec.hal import hal_base, mmio
 from chipsec.helper import oshelper
 from chipsec.hal.spi_jedec_ids import JEDEC_ID
+from chipsec.exceptions import SpiRuntimeError
 
 SPI_READ_WRITE_MAX_DBC = 64
 SPI_READ_WRITE_DEF_DBC = 4
@@ -184,12 +185,6 @@ def get_SPI_region(flreg):
     range_limit = ((flreg & PCH_RCBA_SPI_FREGx_LIMIT_MASK) >> 4)
     range_limit |= SPI_FLA_PAGE_MASK
     return (range_base, range_limit)
-
-class SpiRuntimeError (RuntimeError):
-    pass
-
-class SpiAccessError (RuntimeError):
-    pass
 
 
 class SPI(hal_base.HALBase):

--- a/chipsec/hal/tpm.py
+++ b/chipsec/hal/tpm.py
@@ -32,12 +32,8 @@ from collections import namedtuple
 
 from chipsec.logger import print_buffer
 from chipsec.hal import hal_base
-from chipsec.hal import acpi
-
 import chipsec.hal.tpm12_commands
 
-class TpmRuntimeError (RuntimeError):
-    pass
 
 COMMANDREADY = 0x40
 TPMGO = 0x20

--- a/chipsec/hal/uefi_common.py
+++ b/chipsec/hal/uefi_common.py
@@ -403,7 +403,7 @@ def parse_auth_var(db, decode_dir):
             var_name = codecs.decode(db[tof:tof +name_size], 'utf-16')
         except UnicodeDecodeError:
             logger().warn("Unable to decode {}".format(db[tof:tof +name_size]))
-            var_name = "CHIPSEC ERROR!"
+            var_name = "chipsec.exceptions!"
         tof += name_size
         sig_data = db[tof:tof +cert_data_size]
         entries.append(sig_data)

--- a/chipsec/hal/virtmem.py
+++ b/chipsec/hal/virtmem.py
@@ -34,12 +34,9 @@ import struct
 
 from chipsec.logger import logger, print_buffer
 from chipsec.hal import hal_base
+from chipsec.exceptions import VirtualMemoryAccessError, VirtualMemoryRuntimeError
 
-class MemoryRuntimeError (RuntimeError):
-    pass
 
-class MemoryAccessError (RuntimeError):
-    pass
 
 class VirtMemory(hal_base.HALBase):
     def __init__( self, cs ):

--- a/chipsec/hal/vmm.py
+++ b/chipsec/hal/vmm.py
@@ -33,10 +33,6 @@ import struct
 from chipsec.logger import logger, pretty_print_hex_buffer
 import chipsec.hal.pcidb
 
-class VMMRuntimeError (RuntimeError):
-    pass
-
-
 class VMM:
 
     def __init__( self, cs ):

--- a/chipsec/helper/dal/dalhelper.py
+++ b/chipsec/helper/dal/dalhelper.py
@@ -33,11 +33,9 @@ from chipsec.logger import logger
 import itpii
 from ctypes import *
 from chipsec.helper.basehelper import Helper
+from chipsec.exceptions import DALHelperError
 
 SYSTEM_HALTED = True
-
-class DALHelperError (RuntimeError):
-    pass
 
 
 class DALHelper(Helper):

--- a/chipsec/helper/efi/efihelper.py
+++ b/chipsec/helper/efi/efihelper.py
@@ -47,8 +47,6 @@ from chipsec.logger import logger
 from chipsec.helper.oshelper import get_tools_path
 from chipsec.helper.basehelper import Helper
 
-class EfiHelperError (RuntimeError):
-    pass
 
 _tools = {
   chipsec.defines.COMPRESSION_TYPE_TIANO: 'TianoCompress.efi',

--- a/chipsec/helper/file/filehelper.py
+++ b/chipsec/helper/file/filehelper.py
@@ -27,7 +27,7 @@ from sys import version
 
 import chipsec.file
 from chipsec.logger import logger
-from chipsec.helper.oshelper import OsHelperError, UnimplementedAPIError
+from chipsec.exceptions import OsHelperError, UnimplementedAPIError
 from chipsec.helper.basehelper import Helper
 from chipsec.defines import bytestostring
 

--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -38,7 +38,7 @@ import sys
 import shutil
 
 from chipsec import defines
-from chipsec.helper.oshelper import OsHelperError, HWAccessViolationError, UnimplementedAPIError, UnimplementedNativeAPIError, get_tools_path
+from chipsec.exceptions import OsHelperError, UnimplementedAPIError, UnimplementedNativeAPIError, get_tools_path
 from chipsec.helper.basehelper import Helper
 from chipsec.logger import logger
 import chipsec.file

--- a/chipsec/helper/oshelper.py
+++ b/chipsec/helper/oshelper.py
@@ -31,6 +31,7 @@ import sys
 
 import chipsec.file
 from chipsec.logger import logger
+from chipsec.exceptions import UnimplementedAPIError, OsHelperError
 
 avail_helpers = []
 
@@ -40,21 +41,6 @@ def f_mod_zip(x):
 def map_modname_zip(x):
     return (x.rpartition('.')[0]).replace('/', '.')
 
-class OsHelperError (RuntimeError):
-    def __init__(self, msg, errorcode):
-        super(OsHelperError, self).__init__(msg)
-        self.errorcode = errorcode
-
-class HWAccessViolationError (OsHelperError):
-    pass
-
-class UnimplementedAPIError (OsHelperError):
-    def __init__(self, api_name):
-        super(UnimplementedAPIError, self).__init__("'{}' is not implemented".format(api_name), 0)
-
-class UnimplementedNativeAPIError (UnimplementedAPIError):
-    def __init__(self, api_name):
-        super(UnimplementedNativeAPIError, self).__init__(api_name)
 
 def get_tools_path():
     return os.path.normpath( os.path.join(chipsec.file.get_main_dir(), chipsec.file.TOOLS_DIR) )

--- a/chipsec/helper/osx/osxhelper.py
+++ b/chipsec/helper/osx/osxhelper.py
@@ -26,7 +26,7 @@ import shutil
 
 import chipsec
 import chipsec.defines
-from chipsec.helper.oshelper import OsHelperError, HWAccessViolationError, UnimplementedAPIError, UnimplementedNativeAPIError
+from chipsec.exceptions import OsHelperError, UnimplementedAPIError
 from chipsec.helper.basehelper import Helper
 from chipsec.logger import logger
 

--- a/chipsec/helper/rwe/rwehelper.py
+++ b/chipsec/helper/rwe/rwehelper.py
@@ -42,7 +42,8 @@ import winerror
 from win32file import FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OVERLAPPED, INVALID_HANDLE_VALUE
 import win32api, win32process, win32security, win32file, win32serviceutil
 
-from chipsec.helper.oshelper import OsHelperError, HWAccessViolationError, UnimplementedAPIError, UnimplementedNativeAPIError, get_tools_path
+from chipsec.helper.oshelper import get_tools_path
+from chipsec.exceptions import OsHelperError, HWAccessViolationError, UnimplementedAPIError, UnimplementedNativeAPIError
 from chipsec.helper.basehelper import Helper
 from chipsec.logger import logger, print_buffer
 import chipsec.file

--- a/chipsec/helper/win/win32helper.py
+++ b/chipsec/helper/win/win32helper.py
@@ -43,7 +43,7 @@ import winerror
 from win32file import FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OVERLAPPED, INVALID_HANDLE_VALUE
 import win32api, win32process, win32security, win32file, win32serviceutil
 
-from chipsec.helper.oshelper import OsHelperError, HWAccessViolationError, UnimplementedAPIError, UnimplementedNativeAPIError
+from chipsec.exceptions import OsHelperError, HWAccessViolationError, UnimplementedAPIError, UnimplementedNativeAPIError
 from chipsec.helper.basehelper import Helper
 from chipsec.defines import stringtobytes, bytestostring
 from chipsec.logger import logger

--- a/chipsec/logger.py
+++ b/chipsec/logger.py
@@ -133,9 +133,6 @@ class ColorLogger( pyLogging.Formatter ):
         def log_color( self, message, record ):
             return message
 
-class LoggerError (RuntimeWarning):
-    pass
-
 class Logger:
 
     """Class for logging to console, text file, XML."""

--- a/chipsec/modules/common/cpu/spectre_v2.py
+++ b/chipsec/modules/common/cpu/spectre_v2.py
@@ -125,7 +125,7 @@ References:
 """
 
 from chipsec.module_common import BaseModule, MTAG_CPU, MTAG_HWCONFIG, MTAG_SMM, ModuleResult
-from chipsec.helper.oshelper import HWAccessViolationError, UnimplementedAPIError
+from chipsec.exceptions import HWAccessViolationError, UnimplementedAPIError
 from chipsec.defines import BIT26, BIT27, BIT29
 
 TAGS = [MTAG_CPU, MTAG_HWCONFIG, MTAG_SMM]

--- a/chipsec/modules/common/memlock.py
+++ b/chipsec/modules/common/memlock.py
@@ -32,7 +32,7 @@ MSR_LT_LOCK_MEMORY
 """
 
 from chipsec.module_common import BaseModule, ModuleResult
-from chipsec.helper.oshelper import HWAccessViolationError
+from chipsec.exceptions import HWAccessViolationError
 
 _MODULE_NAME = 'memlock'
 

--- a/chipsec/modules/common/smm_code_chk.py
+++ b/chipsec/modules/common/smm_code_chk.py
@@ -22,7 +22,7 @@ Once set to '1', any CPU that attempts to execute SMM code not within the ranges
 As such, enabling and locking this bit is an important step in mitigating SMM call-out vulnerabilities.
 This CHIPSEC module simply reads the register and checks that SMM_Code_Chk_En is set and locked.
 """
-from chipsec.helper.oshelper import HWAccessViolationError
+from chipsec.exceptions import HWAccessViolationError
 from chipsec.module_common import BaseModule, ModuleResult, MTAG_BIOS, MTAG_SMM
 
 TAGS = [MTAG_BIOS, MTAG_SMM]

--- a/chipsec/modules/tools/cpu/sinkhole.py
+++ b/chipsec/modules/tools/cpu/sinkhole.py
@@ -29,7 +29,7 @@ The Memory Sinkhole by Christopher Domas: https://www.blackhat.com/docs/us-15/ma
 """
 
 from chipsec.module_common   import BaseModule, ModuleResult, MTAG_SMM
-from chipsec.helper.oshelper import HWAccessViolationError
+
 
 TAGS = [MTAG_SMM]
 

--- a/chipsec/modules/tools/smm/smm_ptr.py
+++ b/chipsec/modules/tools/smm/smm_ptr.py
@@ -74,6 +74,7 @@ from chipsec.module_common import BaseModule, ModuleResult
 from chipsec.file import write_file
 from chipsec.logger import print_buffer_bytes
 from chipsec.hal.interrupts import Interrupts
+from chipsec.exceptions import BadSMIDetected
 
 #logger.VERBOSE = False
 
@@ -142,9 +143,6 @@ _DEFAULT_GPRS     = {'rax': _FILL_VALUE_QWORD, 'rbx': _FILL_VALUE_QWORD, 'rcx': 
 
 _pth = 'smm_ptr'
 
-
-class BadSMIDetected (RuntimeError):
-    pass
 
 class smi_desc( object ):
     def __init__(self):

--- a/chipsec/utilcmd/acpi_cmd.py
+++ b/chipsec/utilcmd/acpi_cmd.py
@@ -29,7 +29,8 @@ from os.path import exists as path_exists
 from time import time
 from argparse import ArgumentParser
 
-from chipsec.hal.acpi   import ACPI, AcpiRuntimeError
+from chipsec.hal.acpi   import ACPI
+from chipsec.exceptions import AcpiRuntimeError
 from chipsec.command    import BaseCommand
 
 # ###################################################################

--- a/chipsec/utilcmd/chipset_cmd.py
+++ b/chipsec/utilcmd/chipset_cmd.py
@@ -27,7 +27,7 @@ usage as a standalone utility:
 """
 
 from chipsec.command    import BaseCommand
-from chipsec.chipset    import UnknownChipsetError
+from chipsec.exceptions    import UnknownChipsetError
 
 # ###################################################################
 #

--- a/chipsec/utilcmd/cmos_cmd.py
+++ b/chipsec/utilcmd/cmos_cmd.py
@@ -23,7 +23,8 @@ from time   import time
 from argparse   import ArgumentParser
 
 from chipsec.command    import BaseCommand
-from chipsec.hal.cmos   import CMOS, CmosRuntimeError
+from chipsec.hal.cmos   import CMOS
+from chipsec.exceptions import CmosRuntimeError
 
 
 class CMOSCommand(BaseCommand):

--- a/chipsec/utilcmd/cpu_cmd.py
+++ b/chipsec/utilcmd/cpu_cmd.py
@@ -22,7 +22,8 @@
 from time   import time
 from argparse   import ArgumentParser
 
-from chipsec.hal.cpu    import CPU, CPURuntimeError
+from chipsec.hal.cpu    import CPU
+from chipsec.exceptions import CPURuntimeError
 from chipsec.command import BaseCommand
 
 # ###################################################################

--- a/chipsec/utilcmd/io_cmd.py
+++ b/chipsec/utilcmd/io_cmd.py
@@ -29,6 +29,7 @@ from argparse import ArgumentParser
 
 from chipsec.hal import iobar
 from chipsec.command import BaseCommand
+from chipsec.exceptions import IOBARRuntimeError
 
 
 class PortIOCommand(BaseCommand):
@@ -102,7 +103,7 @@ class PortIOCommand(BaseCommand):
     def run(self):
         try:
             self._iobar = iobar.IOBAR( self.cs)
-        except iobar.IOBARRuntimeError as msg:
+        except IOBARRuntimeError as msg:
             self.logger.log(msg)
             return
 

--- a/chipsec/utilcmd/iommu_cmd.py
+++ b/chipsec/utilcmd/iommu_cmd.py
@@ -27,6 +27,7 @@ Command-line utility providing access to IOMMU engines
 from chipsec.command import BaseCommand
 from chipsec.hal     import acpi, iommu
 from argparse        import ArgumentParser
+from chipsec.exceptions import IOMMUError, AcpiRuntimeError
 import time
 
 
@@ -85,7 +86,7 @@ class IOMMUCommand(BaseCommand):
     def iommu_engine(self, cmd):
         try:
             _iommu = iommu.IOMMU(self.cs)
-        except iommu.IOMMUError as msg:
+        except IOMMUError as msg:
             print (msg)
             return
 
@@ -101,7 +102,7 @@ class IOMMUCommand(BaseCommand):
         if 'config' == cmd:
             try:
                 _acpi = acpi.ACPI( self.cs )
-            except acpi.AcpiRuntimeError as msg:
+            except AcpiRuntimeError as msg:
                 print (msg)
                 return
 

--- a/chipsec/utilcmd/spi_cmd.py
+++ b/chipsec/utilcmd/spi_cmd.py
@@ -35,7 +35,8 @@ The file rom.bin will contain the full binary of the SPI flash. It can then be p
 import time
 import os
 from chipsec.command import BaseCommand
-from chipsec.hal.spi import SPI, SpiRuntimeError, BIOS
+from chipsec.hal.spi import SPI, BIOS
+from chipsec.exceptions   import SpiRuntimeError
 from argparse        import ArgumentParser
 
 

--- a/chipsec/utilcmd/tpm_cmd.py
+++ b/chipsec/utilcmd/tpm_cmd.py
@@ -23,6 +23,7 @@
 from chipsec.command import BaseCommand
 from chipsec.hal     import tpm_eventlog
 from chipsec.hal     import tpm
+from chipsec.exceptions   import TpmRuntimeError
 from argparse        import ArgumentParser
 
 class TPMCommand(BaseCommand):
@@ -88,7 +89,7 @@ class TPMCommand(BaseCommand):
         if self.func != self.tpm_parse:
             try:
                 self._tpm = tpm.TPM(self.cs)
-            except tpm.TpmRuntimeError as msg:
+            except TpmRuntimeError as msg:
                 self.logger.log(msg)
                 return
 

--- a/chipsec/utilcmd/vmm_cmd.py
+++ b/chipsec/utilcmd/vmm_cmd.py
@@ -24,8 +24,9 @@ import time
 import re
 
 from chipsec.command    import BaseCommand
-from chipsec.hal.vmm    import VMM, VMMRuntimeError, get_virtio_devices, VirtIO_Device
+from chipsec.hal.vmm    import VMM, get_virtio_devices, VirtIO_Device
 from chipsec.hal.pci    import print_pci_devices
+from chipsec.exceptions      import VMMRuntimeError
 from argparse           import ArgumentParser
 
 

--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -58,7 +58,7 @@ import traceback
 from collections import OrderedDict
 try:
     import zipfile
-except:
+except ImportError:
     pass
 
 import chipsec.file
@@ -70,6 +70,7 @@ from chipsec import chipset
 from chipsec.helper import oshelper
 from chipsec.logger import logger
 from chipsec.testcase import *
+from chipsec.exceptions import UnknownChipsetError, OsHelperError
 
 try:
     import importlib
@@ -479,7 +480,7 @@ class ChipsecMain:
         if self._load_config:
             try:
                 self._cs.init( self._platform, self._pch, (not self._no_driver), self._driver_exists, self._to_file, self._from_file )
-            except chipset.UnknownChipsetError as msg:
+            except UnknownChipsetError as msg:
                 logger().error( "Platform is not supported ({}).".format(str(msg)) )
                 if self._unknownPlatform:
                     logger().error('To specify a cpu please use -p command-line option')
@@ -489,7 +490,7 @@ class ChipsecMain:
                     if self.failfast: raise msg
                     return  ExitCode.EXCEPTION
                 logger().warn("Platform dependent functionality is likely to be incorrect")
-            except oshelper.OsHelperError as os_helper_error:
+            except OsHelperError as os_helper_error:
                 logger().error(str(os_helper_error))
                 if logger().DEBUG: logger().log_bad(traceback.format_exc())
                 if self.failfast: raise os_helper_error

--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -35,7 +35,7 @@ import platform
 from chipsec.defines import get_version, get_message
 from chipsec.helper import oshelper
 from chipsec.logger  import logger
-from chipsec.chipset import UnknownChipsetError
+from chipsec.exceptions import UnknownChipsetError
 from chipsec.testcase import ExitCode
 from chipsec.chipset import cs
 from chipsec.file import get_main_dir

--- a/tests/software/mock_helper.py
+++ b/tests/software/mock_helper.py
@@ -20,6 +20,7 @@ import struct
 
 from chipsec.helper import oshelper
 from chipsec.helper.basehelper import Helper
+from chipsec.exceptions import UnimplementedAPIError
 
 
 class TestHelper(Helper):
@@ -284,7 +285,7 @@ class SPIHelper(TestHelper):
             raise Exception("Write to outside of SPIBAR")
 
     def map_io_space(self, base, size, cache_type):
-        raise oshelper.UnimplementedAPIError("Not implemented")
+        raise UnimplementedAPIError("Not implemented")
 
 class ValidChipsetHelper(TestHelper):
     def read_pci_reg(self, bus, device, function, address, size):

--- a/tests/software/test_cs.py
+++ b/tests/software/test_cs.py
@@ -17,7 +17,7 @@
 #
 import unittest
 
-from chipsec.chipset import UnknownChipsetError
+from chipsec.exceptions import UnknownChipsetError
 from tests.software import cs
 from tests.software import mock_helper
 


### PR DESCRIPTION
Create a new exceptions.py file at the chipsec level to hold all chipsec exceptions.
This will help to avoid circular dependencies in the future.

Signed-off-by: brentholtsclaw <brent.holtsclaw@intel.com>