### PR TITLE
Create hal.locks and util_cmd.lock_check_cmd

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -1220,18 +1220,23 @@ class Chipset:
             reg_data = self.read_register(reg, cpu_thread, bus)
             reg_data = [reg_data]
         if logger().VERBOSE or with_print:
-            for rd in reg_data:
-                self.print_register(reg, rd)
-        return self.get_register_field_all(reg, reg_data, field)
+            if reg_data:
+                for rd in reg_data:
+                    self.print_register(reg, rd)
+            else:
+                self.logger.log("Register has no data")
+        if reg_data:
+            return self.get_register_field_all(reg, reg_data, field)
+        return reg_data
 
     def set_lock(self, lock_name, lock_value, cpu_thread=0, bus=None):
         lock = self.Cfg.LOCKS[lock_name]
         reg     = lock['register']
         field   = lock['field']
         if bus is None:
-            reg_data = self.read_register(reg, cpu_thread, 0)
-            reg_data = self.set_register_field(reg, reg_data, field, lock_value)
-            return self.write_register_all_single(reg, reg_data, cpu_thread)
+            reg_data = self.read_register_all(reg, cpu_thread)
+            reg_data = self.set_register_field_all(reg, reg_data, field, lock_value)
+            return self.write_register_all(reg, reg_data, cpu_thread)
         else:
             reg_data = self.read_register(reg, cpu_thread, bus)
             reg_data = self.set_register_field(reg, reg_data, field, lock_value)

--- a/chipsec/defines.py
+++ b/chipsec/defines.py
@@ -119,10 +119,19 @@ MASK_32b = 0xFFFFFFFF
 MASK_64b = 0xFFFFFFFFFFFFFFFF
 
 
-def scan_single_bit_mask(mask):
-    for bit in range(0, 7):
-        if mask>>bit  == 1:
-            return bit
+def bit(bit_num):
+    return int(1 << bit_num)
+
+
+def is_set(val, bit_mask):
+    return bool(val & bit_mask != 0)
+
+
+def scan_single_bit_mask(bit_mask):
+    for bit_num in range(0, 7):
+        if bit_mask >> bit_num == 1:
+            return bit_num
+
 
 #
 # Compression Types

--- a/chipsec/hal/iobar.py
+++ b/chipsec/hal/iobar.py
@@ -32,6 +32,7 @@ usage:
 from chipsec.hal import hal_base
 from chipsec.logger import logger
 from chipsec.exceptions import IOBARNotFoundError
+from chipsec.exceptions import CSReadError
 
 DEFAULT_IO_BAR_SIZE = 0x100
 
@@ -95,6 +96,8 @@ class IOBAR(hal_base.HALBase):
         size = int(bar['size'], 16) if ('size' in bar) else DEFAULT_IO_BAR_SIZE
 
         if logger().HAL: logger().log( '[iobar] {}: 0x{:04X} (size = 0x{:X})'.format(bar_name, base, size) )
+        if base == 0:
+            raise CSReadError("MMIO BAR ({}) base address is 0".format(bar_name))
         return base, size
 
 

--- a/chipsec/hal/locks.py
+++ b/chipsec/hal/locks.py
@@ -26,11 +26,11 @@ from chipsec.exceptions import CSReadError, HWAccessViolationError
 
 
 class LockResult:
-    DEFINED = bit(0)
-    HAS_CONFIG = bit(1)
-    LOCKED = bit(2)
-    CAN_READ = bit(3)
-    INCONSISTENT = bit(4)
+    DEFINED = bit(0)  # lock exists within configuration
+    HAS_CONFIG = bit(1)  # lock configuration exists
+    LOCKED = bit(2)  # lock matches value within xml
+    CAN_READ = bit(3)  # system is able to access the lock
+    INCONSISTENT = bit(4)  # all lock results do not match
 
 
 class locks(HALBase):
@@ -49,15 +49,15 @@ class locks(HALBase):
             res |= LockResult.DEFINED
         try:
             self.cs.get_locked_value(lock_name)
-            self.cs.get_lock(lock_name, bus=bus)
             res |= LockResult.HAS_CONFIG
+            self.cs.get_lock(lock_name, bus=bus)
             res |= LockResult.CAN_READ
         except KeyError:
             pass
         except CSReadError:
-            res |= LockResult.HAS_CONFIG
+            pass
         except HWAccessViolationError:
-            res |= LockResult.HAS_CONFIG
+            pass
         return res
 
     def is_locked(self, lock_name, bus=None):

--- a/chipsec/hal/locks.py
+++ b/chipsec/hal/locks.py
@@ -1,0 +1,75 @@
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2019-2021, Intel Corporation
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Contact information:
+# chipsec@intel.com
+#
+
+__version__ = '1.0'
+
+from chipsec.defines import bit, is_set
+from chipsec.hal.hal_base import HALBase
+from chipsec.exceptions import CSReadError, HWAccessViolationError
+
+
+class LockResult:
+    DEFINED = bit(0)
+    HAS_CONFIG = bit(1)
+    LOCKED = bit(2)
+    CAN_READ = bit(3)
+    INCONSISTENT = bit(4)
+
+
+class locks(HALBase):
+    def __init__(self, cs):
+        super(locks, self).__init__(cs)
+
+    def get_locks(self):
+        """
+        Return a list of locks defined within the configuration file
+        """
+        return self.cs.get_lock_list()
+
+    def lock_valid(self, lock_name, bus=None):
+        res = 0
+        if self.cs.is_lock_defined(lock_name):
+            res |= LockResult.DEFINED
+        try:
+            self.cs.get_locked_value(lock_name)
+            self.cs.get_lock(lock_name, bus=bus)
+            res |= LockResult.HAS_CONFIG
+            res |= LockResult.CAN_READ
+        except KeyError:
+            pass
+        except CSReadError:
+            res |= LockResult.HAS_CONFIG
+        except HWAccessViolationError:
+            res |= LockResult.HAS_CONFIG
+        return res
+
+    def is_locked(self, lock_name, bus=None):
+        """
+        Return whether the lock has the value setting
+        """
+        res = self.lock_valid(lock_name, bus)
+        if is_set(res, LockResult.HAS_CONFIG) and is_set(res, LockResult.CAN_READ):
+            locked = self.cs.get_locked_value(lock_name)
+            lock_setting = self.cs.get_lock(lock_name, bus=bus)
+            if not all(lock_setting[0] == elem for elem in lock_setting):
+                res |= LockResult.INCONSISTENT
+            if all(locked == elem for elem in lock_setting):
+                res |= LockResult.LOCKED
+        return res

--- a/chipsec/hal/mmio.py
+++ b/chipsec/hal/mmio.py
@@ -45,6 +45,7 @@ usage:
 """
 
 from chipsec.hal import hal_base
+from chipsec.exceptions import CSReadError
 
 DEFAULT_MMIO_BAR_SIZE = 0x1000
 
@@ -217,7 +218,7 @@ class MMIO(hal_base.HALBase):
 
         if self.logger.HAL: self.logger.log( '[mmio] {}: 0x{:016X} (size = 0x{:X})'.format(bar_name, base, size) )
         if base == 0:
-            raise Exception
+            raise CSReadError("MMIO BAR ({}) base address is 0".format(bar_name))
         return base, size
 
     #

--- a/chipsec/utilcmd/lock_check_cmd.py
+++ b/chipsec/utilcmd/lock_check_cmd.py
@@ -31,6 +31,7 @@ class LOCKCHECKCommand(BaseCommand):
     """
     >>> chipsec_util check list
     >>> chipsec_util check lock <lockname>
+    >>> chipsec_util check lock <lockname1, lockname2, ...>
     >>> chipsec_util check all
 
     Examples:

--- a/chipsec/utilcmd/lock_check_cmd.py
+++ b/chipsec/utilcmd/lock_check_cmd.py
@@ -24,6 +24,7 @@ from argparse import ArgumentParser
 from chipsec.command import BaseCommand
 from chipsec.hal.locks import locks, LockResult
 from chipsec.defines import is_set
+from chipsec.chipset import CONSISTENCY_CHECKING
 
 
 class LOCKCHECKCommand(BaseCommand):
@@ -142,8 +143,7 @@ KEY:
         return res
 
     def run(self):
-        self.logger.log("This module works best when CONSISTENCY_CHECKING is turned on")
-        self.logger.log("To enable CONSISTENCY_CHECKING change the option to True within chipset.py")
+        CONSISTENCY_CHECKING = True
         self.logger.set_always_flush(True)
         try:
             self._locks = locks(self.cs)

--- a/chipsec/utilcmd/lock_check_cmd.py
+++ b/chipsec/utilcmd/lock_check_cmd.py
@@ -1,0 +1,159 @@
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2021, Intel Corporation
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Contact information:
+# chipsec@intel.com
+#
+
+from time import time
+from argparse import ArgumentParser
+
+from chipsec.command import BaseCommand
+from chipsec.hal.locks import locks, LockResult
+from chipsec.defines import is_set
+
+
+class LOCKCHECKCommand(BaseCommand):
+    """
+    >>> chipsec_util check list
+    >>> chipsec_util check lock <lockname>
+    >>> chipsec_util check all
+
+    Examples:
+
+    >>> chipsec_util check list
+    >>> chipsec_util check lock DebugLock
+    >>> chipsec_util check all
+    """
+
+    version = "0.5"
+
+    def requires_driver(self):
+        parser = ArgumentParser(prog='chipsec_util check', usage=LOCKCHECKCommand.__doc__)
+
+        parser_lockname = ArgumentParser(add_help=False)
+        parser_lockname.add_argument('lockname', type=str, nargs='+', help="locknames")
+
+        subparsers = parser.add_subparsers()
+
+        # list
+        parser_list = subparsers.add_parser('list')
+        parser_list.set_defaults(func=self.list_locks)
+
+        # checkall
+        parser_checkall = subparsers.add_parser('all')
+        parser_checkall.set_defaults(func=self.checkall_locks)
+
+        # check
+        parser_check = subparsers.add_parser('lock', parents=[parser_lockname])
+        parser_check.set_defaults(func=self.check_lock)
+
+        parser.parse_args(self.argv[2:], namespace=self)
+
+        return True
+
+    def log_key(self):
+        self.logger.log("""
+KEY:
+\tLock Name - Name of Lock within configuration file
+\tState - Lock Configuration
+\t\tUndefined - Lock is not defined within configuration
+\t\tUndoc -  Lock is missing configuration information
+\t\tHidden - Lock is in a disabled or hidden state (unable to read the lock)
+\t\tUnlocked - Lock does not match value within configuration
+\t\tLocked - Lock matches value within configuration
+\t\tRW/O - Lock is identified as register is RW/O""")
+
+    def log_header(self):
+        ret = '{:^27}|{:^16}|{:^16}\n{}'.format('Lock Name', 'State', 'Consistent', '-' * 58)
+        if not self.logger.HAL:
+            self.logger.log(ret)
+        return "\n\n{}".format(ret)
+
+    def list_locks(self):
+        self.logger.log('Locks identified within the configuration:')
+        for lock in self._locks.get_locks():
+            self.logger.log(lock)
+        self.logger.log('')
+        return
+
+    def checkall_locks(self):
+        locks = self._locks.get_locks()
+        if not locks:
+            self.logger.log('Did not find any locks')
+            return
+        res = self.log_header()
+        if self.logger.VERBOSE:
+            self.log_key()
+        for lock in locks:
+            is_locked = self._locks.is_locked(lock)
+            res = "{}\n{}".format(res, self.check_log(lock, is_locked))
+        if self.logger.HAL:
+            self.logger.log(res)
+        return
+
+    def check_lock(self):
+        res = self.log_header()
+        if self.logger.VERBOSE:
+            self.log_key()
+        for lock in self.lockname:
+            is_locked = self._locks.is_locked(lock)
+            res = "{}\n{}".format(res, self.check_log(lock, is_locked))
+        if self.logger.HAL:
+            self.logger.log(res)
+        return
+
+    def check_log(self, lock, is_locked):
+        consistent = "N/A"
+        if not is_set(is_locked, LockResult.DEFINED):
+            res_str = 'Undefined'
+        elif not is_set(is_locked, LockResult.HAS_CONFIG):
+            res_str = 'Undoc'
+        elif not is_set(is_locked, LockResult.CAN_READ):
+            res_str = 'Hidden'
+        elif self.cs.get_lock_type(lock) == "RW/O":
+            res_str = 'RW/O'
+        elif is_set(is_locked, LockResult.LOCKED):
+            res_str = 'Locked'
+        elif not is_set(is_locked, LockResult.LOCKED):
+            res_str = 'UnLocked'
+        else:
+            res_str = 'Unknown'
+        if res_str in ["RW/O", "Locked", "UnLocked"] and is_set(is_locked, LockResult.INCONSISTENT):
+            consistent = "No"
+        elif res_str in ["RW/O", "Locked", "UnLocked"] and not is_set(is_locked, LockResult.INCONSISTENT):
+            consistent = "Yes"
+        res = '{:27}|  {:14}|{:^16}'.format(lock[:26], res_str, consistent)
+        if not self.logger.HAL:
+            self.logger.log(res)
+        return res
+
+    def run(self):
+        self.logger.log("This module works best when CONSISTENCY_CHECKING is turned on")
+        self.logger.log("To enable CONSISTENCY_CHECKING change the option to True within chipset.py")
+        self.logger.set_always_flush(True)
+        try:
+            self._locks = locks(self.cs)
+        except Exception as msg:
+            self.logger.log(msg)
+            return
+        t = time()
+        self.func()
+        self.logger.set_always_flush(False)
+        self.logger.log("[CHIPSEC] (Lock Check) time elapsed {:.3f}".format(time() - t))
+
+
+commands = {'check': LOCKCHECKCommand}


### PR DESCRIPTION
Create
hal.locks - functionality to gather state information based upon locks defined within a configuration
util_cmd.lock_check_cmd - Use the hal locks functionality to print out the state of one or more locks identified within the configuration

Modify
chipset.py - fix up get_lock and set_lock functionality
hal.mmio.py - raise CSReadError exception when cannot read the MMIOBAR opposed to generic exception
hal.iobar - raise CSReadError exception when cannot read the IOBar
defines - add bit and is_set functions

Depends on #1235 
Signed-off-by: brentholtsclaw <brent.holtsclaw@intel.com>