### PR TITLE
Fixed MMCFG definition for Jaketown and Ivytown.

### DIFF
--- a/chipsec/cfg/8086/ivt.xml
+++ b/chipsec/cfg/8086/ivt.xml
@@ -13,7 +13,18 @@ XML configuration file for Ivytown (Ivy Bridge-E) based platforms
     <sku did="0x0E00" name="Ivytown" code="IVT" longname="Server 3rd Generation Core Procesor (Ivytown CPU / Patsburg PCH)" />
   </info>
 
+  <mmio>
+    <bar name="MMCFG" register="MMCFG_BASE" base_field="mmcfg_base_addr" size="0x1000" desc="PCI Express Register Range"/>
+  </mmio>>
+
   <registers>
+    <!-- MMCFG -->
+    <register name="MMCFG_BASE"  type="pcicfg" bus="0" dev="5" fun="0" offset="0x84" size="4" desc="MMCFG Address Base">
+      <field name="mmcfg_base_addr" bit="26" size="6" desc="MMCFG Base Address"/>
+    </register>
+    <register name="MMCFG_LIMIT" type="pcicfg" bus="0" dev="5" fun="0" offset="0x88" size="4" desc="MMCFG Address Limit">
+      <field name="mmcfg_limit_addr" bit="26" size="6" desc="MMCFG Limit Address"/>
+    </register>
 
     <!-- B:D.F 00:12.6 -->
     <register name="PCI0.0.0_SMRAMC" type="pcicfg" bus="0" dev="12" fun="6" offset="0x4c" size="1" desc="System Management RAM Control">

--- a/chipsec/cfg/8086/jkt.xml
+++ b/chipsec/cfg/8086/jkt.xml
@@ -12,7 +12,18 @@ XML configuration file for Jaketown (Sandy Bridge-E) based platforms
     <sku did="0x3C00" name="Jaketown" code="JKT" longname="Server 2nd Generation Core Processor (Jaketown CPU / Patsburg PCH)" />
   </info>
 
+  <mmio>
+    <bar name="MMCFG" register="MMCFG_BASE" base_field="mmcfg_base_addr" size="0x1000" desc="PCI Express Register Range"/>
+  </mmio>>
+
   <registers>
+    <!-- MMCFG -->
+    <register name="MMCFG_BASE"  type="pcicfg" bus="0" dev="5" fun="0" offset="0x84" size="4" desc="MMCFG Address Base">
+      <field name="mmcfg_base_addr" bit="26" size="6" desc="MMCFG Base Address"/>
+    </register>
+    <register name="MMCFG_LIMIT" type="pcicfg" bus="0" dev="5" fun="0" offset="0x88" size="4" desc="MMCFG Address Limit">
+      <field name="mmcfg_limit_addr" bit="26" size="6" desc="MMCFG Limit Address"/>
+    </register>
 
     <!-- B:D.F 00:12.6 -->
     <register name="PCI0.0.0_SMRAMC" type="pcicfg" bus="0" dev="12" fun="6" offset="0x4c" size="1" desc="System Management RAM Control">


### PR DESCRIPTION
Here is a patch that fixes the definition of MMCFG for Jaketown and Ivytown, without this patch all MMCFG operations throws an exception due to an invalid base address.

I could find the right definition for Ivytown in the following datasheets:
**TITLE:** Intel Xeon Processor E7 v2 2800/4800/8800 Product Family, Vol 2
**DOCUMENT NUMBER:** 329595-002
**TITLE:** Intel Xeon Processor E5 v2 Product Family, Vol 2
**DOCUMENT NUMBER:** 329188-003

However, for Jaketown I couldn't find the proper datasheet, but I was able to test this same definition and seems to be ok.

**Jaketown tested on:**
**Machine:** HP DL360e Gen8
**CPU:** Intel Xeon E5-2403 (Sandy Bridge EN)

```
user@hp-dl360-gen8:~/gabi/chipsec$ sudo python chipsec_util.py mmcfg 0 0 0 0 4

################################################################
##                                                            ##
##  CHIPSEC: Platform Hardware Security Assessment Framework  ##
##                                                            ##
################################################################
[CHIPSEC] Version : 1.7.0
[CHIPSEC] OS      : Linux 4.15.0-147-generic #151-Ubuntu SMP Fri Jun 18 19:21:19 UTC 2021 x86_64
[CHIPSEC] Python  : 2.7.17 (64-bit)

****** Chipsec Linux Kernel module is licensed under GPL 2.0
[CHIPSEC] API mode: using CHIPSEC kernel module API
[CHIPSEC] Helper  : LinuxHelper (/home/user/gabi/chipsec/chipsec/helper/linux/chipsec.ko)
[CHIPSEC] Platform: Server 2nd Generation Core Processor (Jaketown CPU / Patsburg PCH)
[CHIPSEC]      VID: 8086
[CHIPSEC]      DID: 3C00
[CHIPSEC]      RID: 07
[CHIPSEC] PCH     : Intel C600/X79 series PCH
[CHIPSEC]      VID: 8086
[CHIPSEC]      DID: 1D41
[CHIPSEC]      RID: 05
[CHIPSEC] Executing command 'mmcfg' with args ['0', '0', '0', '0', '4']

[CHIPSEC] Reading MMCFG register (00:00.0 + 0x00): 0x3C008086

[CHIPSEC] (mmcfg) time elapsed 0.000
user@hp-dl360-gen8:~/gabi/chipsec$ sudo python chipsec_util.py mmcfg 0 0x1f 0 0 4

################################################################
##                                                            ##
##  CHIPSEC: Platform Hardware Security Assessment Framework  ##
##                                                            ##
################################################################
[CHIPSEC] Version : 1.7.0
[CHIPSEC] OS      : Linux 4.15.0-147-generic #151-Ubuntu SMP Fri Jun 18 19:21:19 UTC 2021 x86_64
[CHIPSEC] Python  : 2.7.17 (64-bit)

****** Chipsec Linux Kernel module is licensed under GPL 2.0
[CHIPSEC] API mode: using CHIPSEC kernel module API
[CHIPSEC] Helper  : LinuxHelper (/home/user/gabi/chipsec/chipsec/helper/linux/chipsec.ko)
[CHIPSEC] Platform: Server 2nd Generation Core Processor (Jaketown CPU / Patsburg PCH)
[CHIPSEC]      VID: 8086
[CHIPSEC]      DID: 3C00
[CHIPSEC]      RID: 07
[CHIPSEC] PCH     : Intel C600/X79 series PCH
[CHIPSEC]      VID: 8086
[CHIPSEC]      DID: 1D41
[CHIPSEC]      RID: 05
[CHIPSEC] Executing command 'mmcfg' with args ['0', '0x1f', '0', '0', '4']

[CHIPSEC] Reading MMCFG register (00:31.0 + 0x00): 0x1D418086

[CHIPSEC] (mmcfg) time elapsed 0.000
```

**Ivytown tested on:**
**Machine:** Lenovo ThinkServer RD340
**CPU:** Intel Xeon E5-2420 v2 (Ivy Bridge EN)
```
user@lenovo-rd340:~/gabi/chipsec$ sudo python chipsec_util.py mmcfg 0 0 0 0 4

################################################################
##                                                            ##
##  CHIPSEC: Platform Hardware Security Assessment Framework  ##
##                                                            ##
################################################################
[CHIPSEC] Version : 1.7.0
[CHIPSEC] OS      : Linux 4.15.0-135-generic #139-Ubuntu SMP Mon Jan 18 17:38:24 UTC 2021 x86_64
[CHIPSEC] Python  : 2.7.17 (64-bit)

****** Chipsec Linux Kernel module is licensed under GPL 2.0
[CHIPSEC] API mode: using CHIPSEC kernel module API
[CHIPSEC] Helper  : LinuxHelper (/home/user/gabi/chipsec/chipsec/helper/linux/chipsec.ko)
[CHIPSEC] Platform: Server 3rd Generation Core Procesor (Ivytown CPU / Patsburg PCH)
[CHIPSEC]      VID: 8086
[CHIPSEC]      DID: 0E00
[CHIPSEC]      RID: 04
[CHIPSEC] PCH     : Intel C600/X79 series PCH
[CHIPSEC]      VID: 8086
[CHIPSEC]      DID: 1D41
[CHIPSEC]      RID: 06
[CHIPSEC] Executing command 'mmcfg' with args ['0', '0', '0', '0', '4']

[CHIPSEC] Reading MMCFG register (00:00.0 + 0x00): 0xE008086

[CHIPSEC] (mmcfg) time elapsed 0.000
user@lenovo-rd340:~/gabi/chipsec$ sudo python chipsec_util.py mmcfg 0 0x1f 0 0 4

################################################################
##                                                            ##
##  CHIPSEC: Platform Hardware Security Assessment Framework  ##
##                                                            ##
################################################################
[CHIPSEC] Version : 1.7.0
[CHIPSEC] OS      : Linux 4.15.0-135-generic #139-Ubuntu SMP Mon Jan 18 17:38:24 UTC 2021 x86_64
[CHIPSEC] Python  : 2.7.17 (64-bit)

****** Chipsec Linux Kernel module is licensed under GPL 2.0
[CHIPSEC] API mode: using CHIPSEC kernel module API
[CHIPSEC] Helper  : LinuxHelper (/home/user/gabi/chipsec/chipsec/helper/linux/chipsec.ko)
[CHIPSEC] Platform: Server 3rd Generation Core Procesor (Ivytown CPU / Patsburg PCH)
[CHIPSEC]      VID: 8086
[CHIPSEC]      DID: 0E00
[CHIPSEC]      RID: 04
[CHIPSEC] PCH     : Intel C600/X79 series PCH
[CHIPSEC]      VID: 8086
[CHIPSEC]      DID: 1D41
[CHIPSEC]      RID: 06
[CHIPSEC] Executing command 'mmcfg' with args ['0', '0x1f', '0', '0', '4']

[CHIPSEC] Reading MMCFG register (00:31.0 + 0x00): 0x1D418086

[CHIPSEC] (mmcfg) time elapsed 0.000
```