### PR TITLE
Warn about missing debug logs in init function

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -368,6 +368,10 @@ class Chipset:
     ##################################################################################
 
     def init_xml_configuration(self):
+        # CAVEAT: this method may be called before command-line flags have been
+        # parsed. In that case, logger().DEBUG will be False even if `-d` is
+        # used. Switch it to True in logger.py directly if you need to debug
+        # this function.
         self.pch_dictionary = dict()
         self.chipset_dictionary = dict()
         self.device_dictionary = dict()


### PR DESCRIPTION
This closes chipsec/chipsec#1243.

Signed-off-by: Gabriel Kerneis <gabriel.kerneis@ssi.gouv.fr>