### PR TITLE
Dev 2.0.0 - Add register scoping to framework

### DIFF
--- a/chipsec/hal/cpu.py
+++ b/chipsec/hal/cpu.py
@@ -156,28 +156,35 @@ class CPU(hal_base.HALBase):
     # Return SMRAM region base, limit and size as defined by SMRR
     #
     def get_SMRR_SMRAM( self ):
+        tscope = self.cs.get_scope()
+        self.cs.set_scope("8086.MSR")
         (smram_base, smrrmask) = self.get_SMRR()
         smram_base &= smrrmask
         smram_size = ((~smrrmask)&0xFFFFFFFF) + 1
         smram_limit = smram_base + smram_size - 1
+        self.cs.set_scope(tscope)
         return (smram_base, smram_limit, smram_size)
 
     #
     # Returns TSEG base, limit and size
     #
     def get_TSEG( self ):
+        tscope = self.cs.get_scope()
         if self.cs.is_server():
+            self.cs.set_scope("8086.MemMap_VTd")
             # tseg register has base and limit
             tseg_base  = self.cs.read_register_field( 'TSEG_BASE',  'base',  preserve_field_position=True )
             tseg_limit = self.cs.read_register_field( 'TSEG_LIMIT', 'limit', preserve_field_position=True )
             tseg_limit += 0xFFFFF
         else:
+            self.cs.set_scope("8086.HOSTCTRL")
             # TSEG base is in TSEGMB, TSEG limit is BGSM - 1
             tseg_base  = self.cs.read_register_field( 'PCI0.0.0_TSEGMB', 'TSEGMB', preserve_field_position=True )
             bgsm       = self.cs.read_register_field( 'PCI0.0.0_BGSM', 'BGSM', preserve_field_position=True )
             tseg_limit =  bgsm - 1
 
         tseg_size = tseg_limit - tseg_base + 1
+        self.cs.set_scope(tscope)
         return (tseg_base, tseg_limit, tseg_size)
 
     #

--- a/chipsec/hal/iobar.py
+++ b/chipsec/hal/iobar.py
@@ -56,7 +56,7 @@ class IOBAR(hal_base.HALBase):
     # Get base address of I/O range by IO BAR name
     #
     def get_IO_BAR_base_address( self, bar_name ):
-        bar = self.cs.Cfg.IO_BARS[ bar_name ]
+        bar = self.cs.get_io_def(bar_name)
         if bar is None or bar == {}:
             raise IOBARNotFoundError ('IOBARNotFound: {}'.format(bar_name))
 

--- a/chipsec/hal/msgbus.py
+++ b/chipsec/hal/msgbus.py
@@ -184,6 +184,8 @@ class MsgBus(hal_base.HALBase):
         return self.msgbus_write_message(port, register, MessageBusOpcode.MB_OPCODE_REG_WRITE, data)
 
     def mm_msgbus_reg_read(self, port, register):
+        tscope = self.cs.get_scope()
+        self.cs.set_scope("8086.P2SBC")
         was_hidden = False
         if self.cs.is_register_defined('P2SBC'):
             was_hidden = self.__hide_p2sb(False)
@@ -191,6 +193,7 @@ class MsgBus(hal_base.HALBase):
         reg_val = self.cs.mmio.read_MMIO_reg_dword(mmio_addr, ((port & 0xFF) << 16) | (register & 0xFFFF))
         if self.cs.is_register_defined('P2SBC') and was_hidden:
             self.__hide_p2sb(True)
+        self.cs.set_scope(tscope)
         return reg_val
 
     def mm_msgbus_reg_write(self, port, register, data):

--- a/chipsec/hal/spi.py
+++ b/chipsec/hal/spi.py
@@ -231,8 +231,7 @@ class SPI(hal_base.HALBase):
             self.logger.log( "      FDATA0 offset = 0x{:04X}".format(self.fdata0_off) )
 
     def get_SPI_MMIO_base(self):
-        if self.mmio.is_MMIO_BAR_defined('SPIBAR'):
-            (spi_base, spi_size) = self.mmio.get_MMIO_BAR_base_address('SPIBAR')
+        (spi_base, spi_size) = self.mmio.get_MMIO_BAR_base_address('SPIBAR')
         if self.logger.HAL: self.logger.log( "[spi] SPI MMIO base: 0x{:016X} (assuming below 4GB)".format(spi_base) )
         return spi_base
 

--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -158,6 +158,7 @@ class ChipsecMain:
 
             if self.verify_module_tags( modx ):
                 result = modx.run( module_argv )
+                self._cs.set_scope(None)
             else:
                 return module_common.ModuleResult.SKIPPED
         except BaseException as msg:


### PR DESCRIPTION
Add register scoping into chipset.py and hal modules.  Accounts for changes to register names prefixed with VID.Parent
Adds functions get_scope and set_scope to chipset.py
Modify various functions to add scope functionality.

Signed-off-by: brentholtsclaw <brent.holtsclaw@intel.com>