### PR TITLE
Backport upstream commit to fix VLA parameter warning/error

### DIFF
--- a/chipsec_tools/compression/Brotli/dec/decode.c
+++ b/chipsec_tools/compression/Brotli/dec/decode.c
@@ -1942,8 +1942,10 @@ static uint32_t BrotliMaxDistanceSymbol(uint32_t ndirect, uint32_t npostfix) {
 }
 
 BrotliDecoderResult BrotliDecoderDecompress(
-    size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
-    uint8_t* decoded_buffer) {
+    size_t encoded_size,
+    const uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(encoded_size)],
+    size_t* decoded_size,
+    uint8_t decoded_buffer[BROTLI_ARRAY_PARAM(*decoded_size)]) {
   BrotliDecoderState s;
   BrotliDecoderResult result;
   size_t total_out = 0;

--- a/chipsec_tools/compression/Brotli/enc/encode.c
+++ b/chipsec_tools/compression/Brotli/enc/encode.c
@@ -1432,8 +1432,9 @@ static size_t MakeUncompressedStream(
 
 BROTLI_BOOL BrotliEncoderCompress(
     int quality, int lgwin, BrotliEncoderMode mode, size_t input_size,
-    const uint8_t* input_buffer, size_t* encoded_size,
-    uint8_t* encoded_buffer) {
+    const uint8_t input_buffer[BROTLI_ARRAY_PARAM(input_size)],
+    size_t* encoded_size,
+    uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(*encoded_size)]) {
   BrotliEncoderState* s;
   size_t out_size = *encoded_size;
   const uint8_t* input_start = input_buffer;


### PR DESCRIPTION
Brotli failed to build:
```
running build_ext
building compression executables
dec/decode.c:1945:41: error: argument 2 of type ‘const uint8_t *’ {aka ‘const unsigned char *’} declared as a pointer [-Werror=vla-parameter]
 1945 |     size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
      |                          ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
In file included from dec/decode.c:7:
./include/brotli/decode.h:204:19: note: previously declared as a variable length array ‘const uint8_t[*decoded_size]’ {aka ‘const unsigned char[*decoded_size]’}
  204 |     const uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(encoded_size)],
      |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
dec/decode.c:1946:14: error: argument 4 of type ‘uint8_t *’ {aka ‘unsigned char *’} declared as a pointer [-Werror=vla-parameter]
 1946 |     uint8_t* decoded_buffer) {
      |     ~~~~~~~~~^~~~~~~~~~~~~~
In file included from dec/decode.c:7:
./include/brotli/decode.h:206:13: note: previously declared as a variable length array ‘uint8_t[encoded_size]’ {aka ‘unsigned char[encoded_size]’}
  206 |     uint8_t decoded_buffer[BROTLI_ARRAY_PARAM(*decoded_size)]);
      |     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

Backporting this patch from upstream fixed the problem: https://github.com/google/brotli/commit/0a3944c8c99b8d10cc4325f721b7c273d2b41f7b