### PR TITLE
[tests] Backport patch for DKMS 3.0 regression on Arch Linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,8 @@ jobs:
       if: matrix.distro.name == 'archlinux'
       run: |
         pacman -Syu --noconfirm dkms linux${{ matrix.distro.variant }}-headers nasm
+        # Fix regression from DKMS 3.0, fixed upstream in https://github.com/dell/dkms/pull/178
+        sed '/^    check_module_args \$action$/d' -i /usr/bin/dkms
 
     - name: Install CentOS dependencies
       if: matrix.distro.name == 'centos'


### PR DESCRIPTION
DKMS 3.0 broke `dkms add drivers/linux` (cf. https://github.com/chipsec/chipsec/pull/1305#issuecomment-970693380). This was fixed upstream in https://github.com/dell/dkms/pull/178.

While waiting for a new DKMS release which would be applied by Arch Linux maintainers, it is possible to work around the issue by removing some checks from the `dkms` script. Add a `sed` command which does that.