### PR TITLE
Revert "Backport patch for DKMS 3.0 regression"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,8 +57,6 @@ jobs:
       if: matrix.distro.name == 'archlinux'
       run: |
         pacman -Syu --noconfirm dkms linux${{ matrix.distro.variant }}-headers nasm
-        # Fix regression from DKMS 3.0, fixed upstream in https://github.com/dell/dkms/pull/178
-        sed '/^    check_module_args \$action$/d' -i /usr/bin/dkms
 
     - name: Install CentOS dependencies
       if: matrix.distro.name == 'centos'


### PR DESCRIPTION
This reverts commit 67912f14b93fbbef58117df19156899c246cddf4.

Arch Linux updated package dkms with the fix for the regression identified in https://github.com/chipsec/chipsec/pull/1307 (cf. https://github.com/archlinux/svntogit-packages/commit/6c421f4029acf143bf62c704ed965f9364723d71 and https://bugs.archlinux.org/task/72774). So the fix is no longer needed in GitHub Action workflow.