### PR TITLE
Detect presence of SKU entries

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -418,7 +418,7 @@ class Chipset:
                                         self.detection_dictionary[format(rdv_value,'X')] = _cfg.attrib['platform'].upper()
                                 else:
                                     self.detection_dictionary[dv.strip().upper()] = _cfg.attrib['platform'].upper()
-                        if _info.iter('sku'):
+                        if _info.find('sku') is not None:
                             _det = ""
                             _did = ""
                             for _sku in _info.iter('sku'):


### PR DESCRIPTION
The use of the iter method should not be used to determine if a SKU
entry exists as it will always return a tree iterator.  Instead the
find method is used to determine if at least one SKU entry is present.

Signed-off-by: Erik Bjorge <erik.c.bjorge@intel.com>