### PR TITLE
Modify swsmi asm to break up B2 and B3

### DIFF
--- a/chipsec/hal/interrupts.py
+++ b/chipsec/hal/interrupts.py
@@ -39,6 +39,7 @@ from chipsec.hal.acpi_tables import UEFI_TABLE
 from chipsec.defines import bytestostring
 
 SMI_APMC_PORT = 0xB2
+SMI_DATA_PORT = 0xB3
 
 NMI_TCO1_CTL = 0x8 # NMI_NOW is bit [8] in TCO1_CTL (or bit [1] in TCO1_CTL + 1)
 NMI_NOW      = 0x1
@@ -62,9 +63,10 @@ class Interrupts(hal_base.HALBase):
         return self.cs.helper.send_sw_smi( thread_id, SMI_code_data, _rax, _rbx, _rcx, _rdx, _rsi, _rdi )
 
     def send_SMI_APMC( self, SMI_code_port_value, SMI_data_port_value ):
-        SMI_code_data = (SMI_data_port_value << 8 | SMI_code_port_value)
-        if logger().HAL: logger().log( "[intr] sending SMI via APMC ports: code 0xB2 <- 0x{:02X}, data 0xB3 <- 0x{:02X} (0x{:04X})".format(SMI_code_port_value, SMI_data_port_value, SMI_code_data) )
-        return self.cs.io.write_port_word( SMI_APMC_PORT, SMI_code_data )
+        if logger().HAL:
+            logger().log("[intr] sending SMI via APMC ports: code 0xB2 <- 0x{:02X}, data 0xB3 <- 0x{:02X}".format(SMI_code_port_value, SMI_data_port_value))
+        self.cs.io.write_port_byte( SMI_DATA_PORT, SMI_data_port_value )
+        return self.cs.io.write_port_byte( SMI_APMC_PORT, SMI_code_port_value )
 
 
 

--- a/drivers/linux/amd64/cpu.asm
+++ b/drivers/linux/amd64/cpu.asm
@@ -419,10 +419,9 @@ __swsmi__:
     mov rdi, r12 ; rdi_value
 
     ; this OUT instruction will write WORD value (smi_code_data) to ports 0xB2 and 0xB3 (SW SMI control and data ports)
-    push rax
-    shr ax, 8
+    ror ax, 8
     out 0B3h, al
-    pop rax
+    ror ax, 8
     out 0B2h, al
 
     mov r12, rdi ; rdi_value

--- a/drivers/linux/amd64/cpu.asm
+++ b/drivers/linux/amd64/cpu.asm
@@ -418,7 +418,8 @@ __swsmi__:
 
     mov rdi, r12 ; rdi_value
 
-    ; this OUT instruction will write WORD value (smi_code_data) to ports 0xB2 and 0xB3 (SW SMI control and data ports)
+    ; these OUT instructions will write BYTE value (smi_code_data) to port 0xB3 then port 0xB3 (SW SMI control and data ports)
+    ; the writes need to be broken up as some systems will drop the interrupt if the port size is larger than a BYTE
     ror ax, 8
     out 0B3h, al
     ror ax, 8

--- a/drivers/linux/amd64/cpu.asm
+++ b/drivers/linux/amd64/cpu.asm
@@ -419,7 +419,11 @@ __swsmi__:
     mov rdi, r12 ; rdi_value
 
     ; this OUT instruction will write WORD value (smi_code_data) to ports 0xB2 and 0xB3 (SW SMI control and data ports)
-    out 0B2h, ax
+    push rax
+    shr ax, 8
+    out 0B3h, al
+    pop rax
+    out 0B2h, al
 
     mov r12, rdi ; rdi_value
     pop rdi

--- a/drivers/win7/amd64/cpu.asm
+++ b/drivers/win7/amd64/cpu.asm
@@ -407,7 +407,13 @@ _swsmi PROC FRAME
     xchg rdi, [r10+30h]  ; //rdi value
 
     ; this OUT instruction will write WORD value (smi_code_data) to ports 0xB2 and 0xB3 (SW SMI control and data ports)
-    out 0B2h, ax ; 0xB2
+    push rax
+    .pushreg rax
+    .endprolog
+    shr ax, 8
+    out 0B3h, al ; 0xB3
+    pop rax
+    out 0B2h, al ; 0xB2
 
     ; some SM handlers return data/errorcode in GPRs, need to return this to the caller
     xchg [r10+08h], rax  ; //rax value

--- a/drivers/win7/amd64/cpu.asm
+++ b/drivers/win7/amd64/cpu.asm
@@ -407,12 +407,9 @@ _swsmi PROC FRAME
     xchg rdi, [r10+30h]  ; //rdi value
 
     ; this OUT instruction will write WORD value (smi_code_data) to ports 0xB2 and 0xB3 (SW SMI control and data ports)
-    push rax
-    .pushreg rax
-    .endprolog
-    shr ax, 8
+    ror ax, 8
     out 0B3h, al ; 0xB3
-    pop rax
+    ror ax, 8
     out 0B2h, al ; 0xB2
 
     ; some SM handlers return data/errorcode in GPRs, need to return this to the caller

--- a/drivers/win7/amd64/cpu.asm
+++ b/drivers/win7/amd64/cpu.asm
@@ -406,7 +406,8 @@ _swsmi PROC FRAME
     xchg rsi, [r10+28h]  ; //rsi value
     xchg rdi, [r10+30h]  ; //rdi value
 
-    ; this OUT instruction will write WORD value (smi_code_data) to ports 0xB2 and 0xB3 (SW SMI control and data ports)
+    ; these OUT instructions will write BYTE value (smi_code_data) to port 0xB3 then port 0xB3 (SW SMI control and data ports)
+    ; the writes need to be broken up as some systems will drop the interrupt if the port size is larger than a BYTE
     ror ax, 8
     out 0B3h, al ; 0xB3
     ror ax, 8


### PR DESCRIPTION
We noticed on certain systems that SMI were being triggered and dropped. Digging a little deeper we found that 0xB2 needed to be a BYTE. Please see:
[PchSmmSw.c](https://github.com/tianocore/edk2-platforms/blob/aa3f6fd542e99dde4206537b095f1a2201275e75/Silicon/Intel/CoffeelakeSiliconPkg/Pch/PchSmiDispatcher/Smm/PchSmmSw.c#L314)

 //
    // If the IO address is not "BYTE" "WRITE" to "R_PCH_IO_APM_CNT (0xB2)", skip it.
    //
    if ((SmiIoInfo.IoPort != R_PCH_IO_APM_CNT) ||
        (SmiIoInfo.IoType != EFI_SMM_SAVE_STATE_IO_TYPE_OUTPUT) ||
        (SmiIoInfo.IoWidth != EFI_SMM_SAVE_STATE_IO_WIDTH_UINT8))
    {
      continue;
    }

Signed-off-by: brentholtsclaw <brent.holtsclaw@intel.com>