### PR TITLE
Fix malformed EFI Section GUID unpacking crash

### DIFF
--- a/chipsec/hal/spi_uefi.py
+++ b/chipsec/hal/spi_uefi.py
@@ -176,7 +176,7 @@ def build_efi_modules_tree( _uefi, fwtype, data, Size, offset, polarity ):
                     logger().warn("Creating fake GUID of 0000-00-00-0000000")
                     guid0 = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
                 else:
-                    guid0 = struct.unpack(EFI_GUID_FMT, sec.Image[sec.HeaderSize:sec.HeaderSize + EFI_GUID_SIZE])
+                    guid0 = struct.unpack(EFI_GUID_FMT, sec.Image[sec.HeaderSize:sec.HeaderSize + EFI_GUID_SIZE])[0]
                     sec.DataOffset = len(sec.Image) - 1
             else:
                 guid0, sec.DataOffset, sec.Attributes = struct.unpack(EFI_GUID_DEFINED_SECTION, sec.Image[sec.HeaderSize:sec.HeaderSize + EFI_GUID_DEFINED_SECTION_size])


### PR DESCRIPTION
The result of struct.unpack() is always a tuple, but bytes are expected (i.e. GUID)