### PR TITLE
Add registers for Intel TXT (Trusted Execution Technology)

### DIFF
--- a/chipsec/cfg/8086/common.xml
+++ b/chipsec/cfg/8086/common.xml
@@ -89,6 +89,7 @@ Common (default) XML platform configuration file
   <!-- #################################### -->
   <memory>
     <range name="Legacy DOS" access="dram" address="0x0"        size="0x100000"/>
+    <range name="TXT"        access="mmio" address="0xFED20000" size="0x20000"/>
     <range name="TPM"        access="mmio" address="0xFED40000" size="0x10000"/>
   </memory>
 

--- a/chipsec/cfg/8086/txt.xml
+++ b/chipsec/cfg/8086/txt.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<configuration>
+<!--
+Configuration of Intel TXT register, following the guide:
+
+    Intel® Trusted Execution Technology: Software Development Guide
+    Measured Launched Environment Developer's Guide
+    August 2016
+    Revision 013
+
+from https://web.archive.org/web/20170506220426/https://www.intel.com/content/www/us/en/software-developers/intel-txt-software-development-guide.html
+(and https://usermanual.wiki/Document/inteltxtsoftwaredevelopmentguide.1721028921 )
+
+Appendix B.1. (Intel® TXT Configuration Registers) details:
+
+    These registers are mapped into two regions of memory, representing the public and private configuration spaces.
+    [...]
+    The private space registers are mapped to the address range starting at FED20000H.
+    The public space registers are mapped to the address range starting at FED30000H.
+
+As chipsec usually runs in environments where the private space is not available,
+only the public space registers were described here.
+-->
+  <registers>
+
+    <register name="TXT_STS" type="memory" access="mmio" address="0xFED30000" offset="0x000" size="8" desc="TXT Status">
+      <field name="SENTER_DONE_STS" bit="0" size="1" desc="SENTER Done"/>
+      <field name="SEXIT_DONE_STS" bit="1" size="1" desc="SEXIT Done"/>
+      <field name="MEM_CONFIG_LOCK_STS" bit="6" size="1" desc="Memory Configuration Locked"/>
+      <field name="PRIVATE_OPEN_STS" bit="7" size="1" desc="Open-Private Command Performed"/>
+      <field name="TXT_LOCALITY1_OPEN_STS" bit="15" size="1" desc="Locality 1 Opened"/>
+      <field name="TXT_LOCALITY2_OPEN_STS" bit="16" size="1" desc="Locality 2 Opened"/>
+    </register>
+    <register name="TXT_ESTS" type="memory" access="mmio" address="0xFED30000" offset="0x008" size="8" desc="TXT Error Status">
+      <field name="TXT_RESET_STS" bit="0" size="1" desc="TXT Reset"/>
+    </register>
+    <register name="TXT_ERRORCODE" type="memory" access="mmio" address="0xFED30000" offset="0x030" size="8" desc="TXT Error Code (0xC0000001 when successful SINIT)">
+      <field name="TYPE2_MODULE_TYPE" bit="0" size="4" desc="Module Type (0 for BIOS ACM, 1 for SINIT)"/>
+      <field name="TYPE2_CLASS_CODE" bit="4" size="6" desc="Class Code"/>
+      <field name="TYPE2_MAJOR_ERROR_CODE" bit="10" size="5" desc="Major Error Code"/>
+      <field name="SOFTWARE_SOURCE" bit="15" size="1" desc="Software Source (0 for ACM, 1 of MLE)"/>
+      <field name="TYPE1_MINOR_ERROR_CODE" bit="16" size="12" desc="Minor Error Code"/>
+      <field name="TYPE1_RESERVED" bit="28" size="2" desc="Failure Condition Details"/>
+      <field name="SOFTWARE" bit="30" size="1" desc="Error reported by Software (0 for Processor)"/>
+      <field name="VALID" bit="30" size="1" desc="Valid Register Content"/>
+    </register>
+
+    <!-- TXT_CMD_RESET at offset 0x38 -->
+    <!-- TXT_CMD_CLOSE_PRIVATE at offset 0x48 -->
+
+    <register name="TXT_VER_FSBIF" type="memory" access="mmio" address="0xFED30000" offset="0x100" size="4" desc="TXT Front Side Bus Interface">
+      <field name="DEBUG_FUSE" bit="31" size="1" desc="Chipsec is Production Fused (0 for Debug)"/>
+    </register>
+    <register name="TXT_DIDVID" type="memory" access="mmio" address="0xFED30000" offset="0x110" size="8" desc="TXT Device ID">
+      <field name="VID" bit="0" size="16" desc="Vendor ID"/>
+      <field name="DID" bit="16" size="16" desc="Device ID"/>
+      <field name="RID" bit="32" size="16" desc="Revision ID"/>
+      <field name="EXTID" bit="48" size="16" desc="Extended ID"/>
+    </register>
+
+    <register name="TXT_VER_QPIIF" type="memory" access="mmio" address="0xFED30000" offset="0x200" size="4" desc="TXT Intel QuickPath Interconnect Interface">
+      <field name="DEBUG_FUSE" bit="31" size="1" desc="Chipsec is Production Fused (0 for Debug)"/>
+    </register>
+
+    <!-- TXT_CMD_UNLOCK_MEM_CONFIG at offset 0x218 -->
+
+    <register name="TXT_SINIT_BASE" type="memory" access="mmio" address="0xFED30000" offset="0x270" size="4" desc="SINIT Base Address"/>
+    <register name="TXT_SINIT_SIZE" type="memory" access="mmio" address="0xFED30000" offset="0x278" size="4" desc="SINIT Size"/>
+    <register name="TXT_MLE_JOIN" type="memory" access="mmio" address="0xFED30000" offset="0x290" size="4" desc="MLE Join Base Address"/>
+    <register name="TXT_HEAP_BASE" type="memory" access="mmio" address="0xFED30000" offset="0x300" size="4" desc="TXT Heap Base Address"/>
+    <register name="TXT_HEAP_SIZE" type="memory" access="mmio" address="0xFED30000" offset="0x308" size="4" desc="TXT Heap Size"/>
+    <register name="TXT_DPR" type="memory" access="mmio" address="0xFED30000" offset="0x330" size="4" desc="TXT DMA Protected Range">
+      <field name="LOCK" bit="0" size="1" desc="Lock Bits 19:0"/>
+      <field name="SIZE" bit="4" size="8" desc="Protected Memory Size (in MB)"/>
+      <field name="TOP" bit="20" size="12" desc="Top Address+1 of DPR (base of TSEG)"/>
+    </register>
+
+    <!-- TXT_CMD_OPEN_LOCALITY1 at offset 0x380 -->
+    <!-- TXT_CMD_CLOSE_LOCALITY1 at offset 0x388 -->
+    <!-- TXT_CMD_OPEN_LOCALITY2 at offset 0x390 -->
+    <!-- TXT_CMD_CLOSE_LOCALITY2 at offset 0x398 -->
+
+    <register name="TXT_PUBLIC_KEY_0" type="memory" access="mmio" address="0xFED30000" offset="0x400" size="8" desc="ACM Public Key Hash (bits 0:63)"/>
+    <register name="TXT_PUBLIC_KEY_1" type="memory" access="mmio" address="0xFED30000" offset="0x408" size="8" desc="ACM Public Key Hash (bits 64:127)"/>
+    <register name="TXT_PUBLIC_KEY_2" type="memory" access="mmio" address="0xFED30000" offset="0x410" size="8" desc="ACM Public Key Hash (bits 128:191)"/>
+    <register name="TXT_PUBLIC_KEY_3" type="memory" access="mmio" address="0xFED30000" offset="0x418" size="8" desc="ACM Public Key Hash (bits 192:255)"/>
+
+    <register name="TXT_PCH_DIDVID" type="memory" access="mmio" address="0xFED30000" offset="0x810" size="8" desc="TXT Platform Controller Hub Device ID">
+      <field name="VID" bit="0" size="16" desc="Vendor ID"/>
+      <field name="DID" bit="16" size="16" desc="Device ID"/>
+      <field name="RID" bit="32" size="16" desc="Revision ID"/>
+    </register>
+
+    <!-- TXT_CMD_SECRETS at offset 0x8E0 -->
+    <!-- TXT_CMD_NO_SECRETS at offset 0x8E8 -->
+
+    <register name="TXT_E2STS" type="memory" access="mmio" address="0xFED30000" offset="0x8F0" size="8" desc="TXT Extended Error Status">
+      <field name="SECRETS_STS" bit="1" size="1" desc="Secrets in Memory"/>
+    </register>
+  </registers>
+
+  <controls>
+  </controls>
+</configuration>


### PR DESCRIPTION
Hello,
When studying Intel TXT (Trusted Execution Technology), it is quite helpful to be able to directly read the content of some registers such as `TXT.ERRORCODE` and `TXT.DIDVID`.

This Pull Request creates a new configuration file with registers from a guide which was initially published on https://www.intel.com/content/www/us/en/software-developers/intel-txt-software-development-guide.html

This this, I was able to dump the content of registers in the "public space" related to Intel TXT with this small Python code:

```python
import chipsec.chipset

cs = chipsec.chipset.cs()
cs.init(platform_code=None, req_pch_code=None, start_driver=True)
for name in cs.Cfg.REGISTERS.keys():
    if name.startswith("TXT"):
        _ = cs.print_register_all(name)
```

On a system without Trusted Boot (so no SINIT was executed), this gives the following output:

```text
[*] TXT.STS = 0x0000000000000083 << TXT Status
    [00] SENTER.DONE.STS  = 1 << SENTER Done 
    [01] SEXIT.DONE.STS   = 1 << SEXIT Done 
    [06] MEM-CONFIG-LOCK.STS = 0 << Memory Configuration Locked 
    [07] PRIVATE-OPEN.STS = 1 << Open-Private Command Performed 
    [15] TXT.LOCALITY1.OPEN.STS = 0 << Locality 1 Opened 
    [16] TXT.LOCALITY2.OPEN.STS = 0 << Locality 2 Opened 
[*] TXT.ESTS = 0x0000000000000000 << TXT Error Status
    [00] TXT_RESET.STS    = 0 << TXT Reset 
[*] TXT.ERRORCODE = 0x0000000000000000 << TXT Error Code (0xC0000001 when successful SINIT)
    [00] TYPE2.MODULE_TYPE = 0 << Module Type (0 for BIOS ACM, 1 for SINIT) 
    [04] TYPE2.CLASS_CODE = 0 << Class Code 
    [10] TYPE2.MAJOR_ERROR_CODE = 0 << Major Error Code 
    [15] SOFTWARE_SOURCE  = 0 << Software Source (0 for ACM, 1 of MLE) 
    [16] TYPE1.MINOR_ERROR_CODE = 0 << Minor Error Code 
    [28] TYPE1.RESERVED   = 0 << Failure Condition Details 
    [30] SOFTWARE         = 0 << Error reported by Software (0 for Processor) 
    [30] VALID            = 0 << Valid Register Content 
[*] TXT.VER.FSBIF = 0xFFFFFFFF << TXT Front Side Bus Interface
    [31] DEBUG.FUSE       = 1 << Chipsec is Production Fused (0 for Debug) 
[*] TXT.DIDVID = 0x00000001B0088086 << TXT Device ID
    [00] VID              = 8086 << Vendor ID 
    [16] DID              = B008 << Device ID 
    [32] RID              = 1 << Revision ID 
    [48] EXTID            = 0 << Extended ID 
[*] TXT.VER.QPIIF = 0x9D003000 << TXT Intel QuickPath Interconnect Interface
    [31] DEBUG.FUSE       = 1 << Chipsec is Production Fused (0 for Debug) 
[*] TXT.SINIT.BASE = 0x00000000 << SINIT Base Address
[*] TXT.SINIT.SIZE = 0x00000000 << SINIT Size
[*] TXT.MLE.JOIN = 0x00000000 << MLE Join Base Address
[*] TXT.HEAP.BASE = 0x00000000 << TXT Heap Base Address
[*] TXT.HEAP.SIZE = 0x00000000 << TXT Heap Size
[*] TXT.DPR = 0x00000000 << TXT DMA Protected Range
    [00] LOCK             = 0 << Lock Bits 19:0 
    [04] SIZE             = 0 << Protected Memory Size (in MB) 
    [20] TOP              = 0 << Top Address+1 of DPR (base of TSEG) 
[*] TXT.PUBLIC.KEY_0 = 0x4A85DE53D8F0789C << ACM Public Key Hash (bits 0:63)
[*] TXT.PUBLIC.KEY_1 = 0x116AB8721C76472F << ACM Public Key Hash (bits 64:127)
[*] TXT.PUBLIC.KEY_2 = 0xD7AAC184A9664A16 << ACM Public Key Hash (bits 128:191)
[*] TXT.PUBLIC.KEY_3 = 0x112D1CB74F14E392 << ACM Public Key Hash (bits 192:255)
[*] TXT.PCH_DIDVID = 0x000000019D848086 << TXT Platform Controller Hub Device ID
    [00] VID              = 8086 << Vendor ID 
    [16] DID              = 9D84 << Device ID 
    [32] RID              = 1 << Revision ID 
[*] TXT.E2STS = 0x0000000000000004 << TXT Extended Error Status
    [01] SECRETS.STS      = 0 << Secrets in Memory 
```

I do not know whether integrating this in a command-line tool (or even integrating some checks about the `DEBUG.FUSE` bits in the main `chipsec` tool) would be useful, so I have not done such integration. If you want me to do this, I can work on it, either in this Pull Request or in a follow-up.