### PR TITLE
Remove Ubuntu 20.10 from GitHub Actions CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,6 @@ jobs:
           - {name: "debian", tag: "10"}
           - {name: "debian", tag: "9"}
           - {name: "debian", tag: "8"}
-          - {name: "ubuntu", tag: "20.10"}
           - {name: "ubuntu", tag: "20.04"}
           - {name: "ubuntu", tag: "18.04"}
           - {name: "ubuntu", tag: "16.04"}


### PR DESCRIPTION
Ubuntu removed packages for Ubuntu 20.10 (Groovy Gorilla) on http://archive.ubuntu.com/ubuntu/dists/, so the container no longer works. This is normal, because this version was not a LTS (Long Term Support) release.