### PR TITLE
Revert "extend chipsec_main search to both py and pyc"

### DIFF
--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -217,9 +217,8 @@ class ChipsecMain:
                 while len(subdirs) > 0:
                     subdirs.pop()
             for modx in mod_fnames:
-                if ((fnmatch.fnmatch( modx, '*.py' ) and not fnmatch.fnmatch( modx, '__init__.py' )) or
-                    (fnmatch.fnmatch( modx, '*.pyc' ) and not fnmatch.fnmatch( modx, '__init__.pyc' ))):
-                        self.load_module( os.path.join( dirname, modx ), self._module_argv )
+                if fnmatch.fnmatch( modx, '*.py*' ) and not fnmatch.fnmatch( modx, '__init__.py*' ):
+                    self.load_module( os.path.join( dirname, modx ), self._module_argv )
         self.Loaded_Modules.sort()
 
     def load_my_modules(self):

--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -217,7 +217,7 @@ class ChipsecMain:
                 while len(subdirs) > 0:
                     subdirs.pop()
             for modx in mod_fnames:
-                if fnmatch.fnmatch( modx, '*.py*' ) and not fnmatch.fnmatch( modx, '__init__.py*' ):
+                if fnmatch.fnmatch( modx, '*.py' ) and not fnmatch.fnmatch( modx, '__init__.py' ):
                     self.load_module( os.path.join( dirname, modx ), self._module_argv )
         self.Loaded_Modules.sort()
 


### PR DESCRIPTION
Reverts chipsec/chipsec#1289

Issue with subsequent runs:
ERROR: chipsec.modules.common.__pycache__.__init__.cpython-35
ERROR: chipsec.modules.common.__pycache__.bios_kbrd_buffer.cpython-35
ERROR: chipsec.modules.common.__pycache__.bios_smi.cpython-35
ERROR: chipsec.modules.common.__pycache__.bios_ts.cpython-35
ERROR: chipsec.modules.common.__pycache__.bios_wp.cpython-35
ERROR: chipsec.modules.common.__pycache__.debugenabled.cpython-35
ERROR: chipsec.modules.common.__pycache__.ia32cfg.cpython-35
ERROR: chipsec.modules.common.__pycache__.me_mfg_mode.cpython-35
ERROR: chipsec.modules.common.__pycache__.memconfig.cpython-35
ERROR: chipsec.modules.common.__pycache__.memlock.cpython-35
ERROR: chipsec.modules.common.__pycache__.remap.cpython-35
ERROR: chipsec.modules.common.__pycache__.rtclock.cpython-35

Looks like we need to strip out files in the __pycache__ folders if we want to use this. 