### PR TITLE
Linux driver fixes and cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,15 @@ chipsec.egg-info
 dist
 build
 
+# Linux driver
+chipsec/helper/linux/*.ko
+drivers/linux/**/.*.cmd
+drivers/linux/*.ko
+drivers/linux/*.mod
+drivers/linux/*.mod.c
+drivers/linux/Module.symvers
+drivers/linux/modules.order
+
 # Windows driver
 .vs/
 chipsec/helper/win/win7_amd64/

--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -1231,7 +1231,7 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
         if( !va )
         {
             printk(KERN_ALERT "[chipsec] ERROR: STATUS_UNSUCCESSFUL - could not allocate memory\n" );
-            return -EFAULT;
+            return -ENOMEM;
         }
          
         memset(va, 0, NumberOfBytes);
@@ -1245,7 +1245,8 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
         tmp = kmalloc(sizeof(struct allocated_mem_list), GFP_KERNEL);
         if (tmp == NULL) {
             printk(KERN_ALERT "[chipsec] ERROR: STATUS_UNSUCCESSFUL - could not allocate memory\n");
-            return -EFAULT;
+            kfree(va);
+            return -ENOMEM;
         }
 
         tmp->va = va;

--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -1548,10 +1548,14 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 			return -EFAULT;
 		}
 
-        addr = (unsigned long)ptr[0];
-        ioaddr = my_xlate_dev_mem_ptr(addr);
-        
-        switch(ptr[1])
+		addr = (unsigned long)ptr[0];
+		ioaddr = my_xlate_dev_mem_ptr(addr);
+		if (!ioaddr) {
+			printk(KERN_ALERT "[chipsec] ERROR: failed to xlate 0x%lx\n", addr);
+			return -EIO;
+		}
+
+		switch(ptr[1])
 		{
 			case 1:
 				ptr[0] = ioread8(ioaddr);
@@ -1591,11 +1595,15 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 			return -EFAULT;
 		}
 
-        addr = (unsigned long)ptr[0];
-        value = (unsigned long)ptr[2];
-        ioaddr = my_xlate_dev_mem_ptr(addr);
-        
-        switch(ptr[1])
+		addr = (unsigned long)ptr[0];
+		value = (unsigned long)ptr[2];
+		ioaddr = my_xlate_dev_mem_ptr(addr);
+		if (!ioaddr) {
+			printk(KERN_ALERT "[chipsec] ERROR: failed to xlate 0x%lx\n", addr);
+			return -EIO;
+		}
+
+		switch(ptr[1])
 		{
 			case 1:
 				iowrite8(value, ioaddr);

--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -19,6 +19,11 @@ Contact information:
 chipsec@intel.com
 */
 
+/* grsecurity compatibility: prevent sprint_symbol() from becoming a no-op */
+#if defined(CONFIG_KALLSYMS) && defined(CONFIG_GRKERNSEC_HIDESYM)
+#define __INCLUDED_BY_HIDESYM 1
+#endif
+
 #include <linux/module.h>
 #include <linux/highmem.h>
 #include <linux/kallsyms.h>

--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -73,19 +73,20 @@ DEFINE_STATIC_CALL(chipsec_page_is_ram_sc, chipsec_page_is_ram_scinit);
 static int (*guess_page_is_ram)(unsigned long pagenr);
 static int chipsec_page_is_ram(unsigned long pagenr);
 // same with phys_mem_accesss_prot
+static
 pgprot_t (*guess_phys_mem_access_prot)(struct file *file, unsigned long pfn,
 				       unsigned long size, pgprot_t vma_prot);
 
-unsigned long a1=0;
-unsigned long a2=0;
+static unsigned long a1;
+static unsigned long a2;
 module_param(a1,ulong,0); //a1 is addr of page_is_ram function
 module_param(a2,ulong,0); //a2 is addr of phys_mem_access_prot function
 
 /// Char we show before each debug print
-const char program_name[] = "chipsec";
+static const char program_name[] = "chipsec";
 
 // list of allocated memory
-struct allocated_mem_list allocated_mem_list;
+static struct allocated_mem_list allocated_mem_list;
 
 typedef struct tagCONTEXT {
    unsigned long a;   // rax - 0x00; eax - 0x0
@@ -1945,7 +1946,7 @@ static int chipsec_page_is_ram(unsigned long pagenr)
 
 #endif
 
-int find_symbols(void)
+static int find_symbols(void)
 {
 	//Older kernels don't have kallsyms_lookup_name. Use FMEM method (pass from run.sh)
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,33)

--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -93,13 +93,13 @@ typedef CONTEXT CPUID_CTX, *PCPUID_CTX;
   void __cpuid__(CPUID_CTX * ctx);
 
 typedef struct tagSMI_CONTEXT {
-   unsigned long c;     // rcx - 0x00;
-   unsigned long d;     // rdx - 0x08;
-   unsigned long r8;     // r8 - 0x10;
-   unsigned long r9;     // r9 - 0x18;
-   unsigned long r10;   // r10 - 0x20;
-   unsigned long r11;   // r11 - 0x28;
-   unsigned long r12;   // r12 - 0x30;
+   unsigned long smi_code_data; // smi_code_data - 0x00;
+   unsigned long rax;           // rax - 0x08; eax - 0x04
+   unsigned long rbx;           // rbx - 0x10; ebx - 0x08
+   unsigned long rcx;           // rcx - 0x18; ecx - 0x0c
+   unsigned long rdx;           // rdx - 0x20; edx - 0x10
+   unsigned long rsi;           // rsi - 0x28; edi - 0x14
+   unsigned long rdi;           // rdi - 0x30; esi - 0x18
 } SMI_CONTEXT, *SMI_PCONTEXT;
 
 typedef SMI_CONTEXT SMI_CTX, *PSMI_CTX; 


### PR DESCRIPTION
Various Linux driver fixes and cleanups:

- fixes (commits 0cfd44ff474e3ef28f9b2f09a1d4774eac46aaee, 61e7c9ca246ff8d4bc2624f5c895f609a252bd2b and e66c99ad1a3ba850f5b42613c5b7f4899b145b3d)
- better grsecurity compatibility (commit 20b1bd5b8801e109a6500279a71593ee4041b72b),
- changes easing driver development (commits 58a0b57c00eb8e6454c65415537e3b2373e780af and 11832f8a1e13a0a511d1b82ee1bec6505fa80288),
- followup cleanups to https://github.com/chipsec/chipsec/pull/1326 around SWSMI (commits 37b8cf802d4d100747fb297f60b89a7899e06377 and a576baf6c50030c936320723767055bf206bb065),
- pure cleanups (commit c32b1042bc807282e7591fe6b8a67f2cbbbd8631)