### PR TITLE
Configure GitHub Actions to stay on Windows Server 2019 for now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,7 +129,7 @@ jobs:
 
   windows-driver:
     name: Windows driver
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     strategy:
       matrix:


### PR DESCRIPTION
GitHub recently upgraded their `windows-latest` environment to Windows Server 2022:
https://github.blog/changelog/2022-01-11-github-actions-jobs-running-on-windows-latest-are-now-running-on-windows-server-2022/

This environment includes Visual Studio 2022 (cf. https://github.com/actions/virtual-environments/blob/7f1bc9ed1e3cff016136346e8f12eec301c6c11f/images/win/Windows2022-Readme.md#visual-studio-enterprise-2022 ), which is currently not supported by the WDK (Windows Driver Kit): https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk#download-and-install-the-windows-11-wdk

Because of this incompatibility, force the workflows to stay on Windows Server 2019 environments for now.