### PR TITLE
Add FORCE in Linux driver Makefile

### DIFF
--- a/drivers/linux/Makefile
+++ b/drivers/linux/Makefile
@@ -32,8 +32,8 @@ chipsec: check_kernel_dir clean
 clean: check_kernel_dir
 	make -C $(KSRC) M=$(CURDIR) clean
 
-$(obj)/i386/cpu.o: $(src)/i386/cpu.asm
+$(obj)/i386/cpu.o: $(src)/i386/cpu.asm FORCE
 	$(call if_changed,nasm32)
 
-$(obj)/amd64/cpu.o: $(src)/amd64/cpu.asm
+$(obj)/amd64/cpu.o: $(src)/amd64/cpu.asm FORCE
 	$(call if_changed,nasm64)


### PR DESCRIPTION
Since Linux 5.15 (commit https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e1f86d7b4b2a5213b012c2b4fe3e5b6ad537686e ), `make` now warns about missing `FORCE` prerequisite:

    /var/lib/dkms/chipsec/1.8.1/build/Makefile:39: FORCE prerequisite is missing

Fix this issue by adding the required prerequisite.