### PR TITLE
Fix TPM 1.2 commands logging

### DIFF
--- a/chipsec/hal/tpm.py
+++ b/chipsec/hal/tpm.py
@@ -30,7 +30,7 @@ import struct
 import sys
 from collections import namedtuple
 
-from chipsec.logger import print_buffer
+from chipsec.logger import print_buffer_bytes
 from chipsec.hal import hal_base
 import chipsec.hal.tpm12_commands
 
@@ -227,7 +227,7 @@ class TPM(hal_base.HALBase):
 
         ( header, data, header_blob, data_blob ) = self._read_response( Locality )
         self.logger.log( header )
-        print_buffer( str(data_blob) )
+        print_buffer_bytes( data_blob )
         self.logger.log( '\n' )
 
         #


### PR DESCRIPTION
When running `chipset_util.py tpm pcrread 0 8` to read a PCR (for example) on a system using a TPM 1.2, the following result is displayed:

    [CHIPSEC] Executing command 'tpm' with args ['command', 'pcrread', '0', '8']

    ----------------------------------------------------------------
                         TPM response header
    ----------------------------------------------------------------
       Response TAG: 0xc4
       Data Size   : 0x1e
       Return Code : 0x0
            Success

    62 79 74 65 61 72 72 61 79 28 62 27 5C 78 30 30 | bytearray(b'\x00
    5C 78 30 30 5C 78 30 30 5C 78 30 30 5C 78 30 30 | \x00\x00\x00\x00
    5C 78 30 30 5C 78 30 30 5C 78 30 30 5C 78 30 30 | \x00\x00\x00\x00
    5C 78 30 30 5C 78 30 30 5C 78 30 30 5C 78 30 30 | \x00\x00\x00\x00
    5C 78 30 30 5C 78 30 30 5C 78 30 30 5C 78 30 30 | \x00\x00\x00\x00
    5C 78 30 30 5C 78 30 30 5C 78 30 30 27 29       | \x00\x00\x00')

Instead of displaying a hexdump of a Python representation of a bytearray, display the hexdump of the bytes.