### PR TITLE
Add "chipsec_util txt" command to show information about Intel TXT

### DIFF
--- a/chipsec/cfg/8086/txt.xml
+++ b/chipsec/cfg/8086/txt.xml
@@ -91,6 +91,10 @@ only the public space registers were described here.
       <field name="RID" bit="32" size="16" desc="Revision ID"/>
     </register>
 
+    <register name="INSMM" type="memory" access="mmio" address="0xFED30000" offset="0x880" size="4" desc="InSMM.STS">
+      <field name="STS" bit="0" size="1" desc="BIOS Write Enable when enabled by SPI.BC.EISS=1"/>
+    </register>
+
     <!-- TXT_CMD_SECRETS at offset 0x8E0 -->
     <!-- TXT_CMD_NO_SECRETS at offset 0x8E8 -->
 

--- a/chipsec/cfg/8086/txt.xml
+++ b/chipsec/cfg/8086/txt.xml
@@ -42,7 +42,7 @@ only the public space registers were described here.
       <field name="TYPE1_MINOR_ERROR_CODE" bit="16" size="12" desc="Minor Error Code"/>
       <field name="TYPE1_RESERVED" bit="28" size="2" desc="Failure Condition Details"/>
       <field name="SOFTWARE" bit="30" size="1" desc="Error reported by Software (0 for Processor)"/>
-      <field name="VALID" bit="30" size="1" desc="Valid Register Content"/>
+      <field name="VALID" bit="31" size="1" desc="Valid Register Content"/>
     </register>
 
     <!-- TXT_CMD_RESET at offset 0x38 -->

--- a/chipsec/cfg/8086/txt.xml
+++ b/chipsec/cfg/8086/txt.xml
@@ -26,13 +26,21 @@ only the public space registers were described here.
     <register name="TXT_STS" type="memory" access="mmio" address="0xFED30000" offset="0x000" size="8" desc="TXT Status">
       <field name="SENTER_DONE_STS" bit="0" size="1" desc="SENTER Done"/>
       <field name="SEXIT_DONE_STS" bit="1" size="1" desc="SEXIT Done"/>
+      <field name="MEM_UNLOCK_STS" bit="4" size="1" desc="Memory Unlocked"/>
       <field name="MEM_CONFIG_LOCK_STS" bit="6" size="1" desc="Memory Configuration Locked"/>
       <field name="PRIVATE_OPEN_STS" bit="7" size="1" desc="Open-Private Command Performed"/>
+      <field name="NTP_ENABLE_STS" bit="10" size="1" desc="NTP Enabled"/>
+      <field name="MEM_CONFIG_OK_STS" bit="11" size="1" desc="Mem CFG OK"/>
+      <field name="PMRC_LOCK_STS" bit="12" size="1" desc="PMRC Locked"/>
+      <field name="SMM_OPEN_STS" bit="13" size="1" desc="SMM Opened"/>
+      <field name="TXT_LOCALITY3_OPEN_STS" bit="14" size="1" desc="Locality 3 Opened"/>
       <field name="TXT_LOCALITY1_OPEN_STS" bit="15" size="1" desc="Locality 1 Opened"/>
       <field name="TXT_LOCALITY2_OPEN_STS" bit="16" size="1" desc="Locality 2 Opened"/>
     </register>
     <register name="TXT_ESTS" type="memory" access="mmio" address="0xFED30000" offset="0x008" size="8" desc="TXT Error Status">
       <field name="TXT_RESET_STS" bit="0" size="1" desc="TXT Reset"/>
+      <field name="ROGUE_STS" bit="1" size="1" desc="Rogue Status"/>
+      <field name="WAKE_ERROR_STS" bit="6" size="1" desc="Wake Error"/>
     </register>
     <register name="TXT_ERRORCODE" type="memory" access="mmio" address="0xFED30000" offset="0x030" size="8" desc="TXT Error Code (0xC0000001 when successful SINIT)">
       <field name="TYPE2_MODULE_TYPE" bit="0" size="4" desc="Module Type (0 for BIOS ACM, 1 for SINIT)"/>
@@ -48,8 +56,23 @@ only the public space registers were described here.
     <!-- TXT_CMD_RESET at offset 0x38 -->
     <!-- TXT_CMD_CLOSE_PRIVATE at offset 0x48 -->
 
+    <register name="TXT_SPAD" type="memory" access="mmio" address="0xFED30000" offset="0x0A0" size="8" desc="Boot Status">
+      <field name="ACM_INTERNAL" bit="0" size="30" desc="ACM Internal Use"/>
+      <field name="TXT_STARTUP_SUCCESS" bit="30" size="1" desc="TXT Startup Success"/>
+      <field name="BOOT_STATUS" bit="31" size="16" desc="General Startup ACM to BIOS status communication"/>
+      <field name="MEM_POWER_DOWN_EXECUTED" bit="47" size="1" desc="Memory content was cleared via power down"/>
+      <field name="BOOT_STATUS_DETAILS_48" bit="48" size="5" desc="Startup ACM to BIOS communication in MP platforms"/>
+      <field name="TXT_POLICY_ENABLE" bit="53" size="1" desc="Startup ACM indication of run-time enabled status of TXT"/>
+      <field name="BOOT_STATUS_DETAILS_54" bit="54" size="5" desc="Startup ACM to BIOS communication in MP platforms"/>
+      <field name="BIOS_TRUSTED" bit="59" size="1" desc="BIOS is trusted"/>
+      <field name="TXT_POLICY_DISABLE" bit="60" size="1" desc="TXT has been disabled by runtime FIT type 0xA record policy setting"/>
+      <field name="BOOT_STATUS_DETAILS_61" bit="61" size="1" desc="Startup ACM to BIOS communication in MP platforms"/>
+      <field name="CPU_ERROR" bit="62" size="1" desc="ACM authentication error"/>
+      <field name="S_ACM_SUCCESS" bit="63" size="1" desc="S-ACM successfully enforced its logic for all provisioned technologies"/>
+    </register>
+
     <register name="TXT_VER_FSBIF" type="memory" access="mmio" address="0xFED30000" offset="0x100" size="4" desc="TXT Front Side Bus Interface">
-      <field name="DEBUG_FUSE" bit="31" size="1" desc="Chipsec is Production Fused (0 for Debug)"/>
+      <field name="DEBUG_FUSE" bit="31" size="1" desc="Chipset is Production Fused (0 for Debug)"/>
     </register>
     <register name="TXT_DIDVID" type="memory" access="mmio" address="0xFED30000" offset="0x110" size="8" desc="TXT Device ID">
       <field name="VID" bit="0" size="16" desc="Vendor ID"/>
@@ -58,8 +81,15 @@ only the public space registers were described here.
       <field name="EXTID" bit="48" size="16" desc="Extended ID"/>
     </register>
 
+    <!--
+      TXT.VER.QPIIF was renamed TXT.VER.EMIF "for EMC Version Number Register"
+      in Intel® Trusted Execution Technology (Intel® TXT) Software Development Guide
+      (document number 315168-017 from January 2021)
+    -->
     <register name="TXT_VER_QPIIF" type="memory" access="mmio" address="0xFED30000" offset="0x200" size="4" desc="TXT Intel QuickPath Interconnect Interface">
-      <field name="DEBUG_FUSE" bit="31" size="1" desc="Chipsec is Production Fused (0 for Debug)"/>
+      <field name="PMRC_CAPABLE" bit="19" size="1" desc="PMRC Capable"/>
+      <field name="DPR_CAPABLE" bit="26" size="1" desc="DPR Capable"/>
+      <field name="DEBUG_FUSE" bit="31" size="1" desc="Chipset is Production Fused (0 for Debug)"/>
     </register>
 
     <!-- TXT_CMD_UNLOCK_MEM_CONFIG at offset 0x218 -->
@@ -69,10 +99,39 @@ only the public space registers were described here.
     <register name="TXT_MLE_JOIN" type="memory" access="mmio" address="0xFED30000" offset="0x290" size="4" desc="MLE Join Base Address"/>
     <register name="TXT_HEAP_BASE" type="memory" access="mmio" address="0xFED30000" offset="0x300" size="4" desc="TXT Heap Base Address"/>
     <register name="TXT_HEAP_SIZE" type="memory" access="mmio" address="0xFED30000" offset="0x308" size="4" desc="TXT Heap Size"/>
-    <register name="TXT_DPR" type="memory" access="mmio" address="0xFED30000" offset="0x330" size="4" desc="TXT DMA Protected Range">
+    <register name="TXT_MSEG_BASE" type="memory" access="mmio" address="0xFED30000" offset="0x310" size="4" desc="TXT MSEG Base Address"/>
+    <register name="TXT_MSEG_SIZE" type="memory" access="mmio" address="0xFED30000" offset="0x318" size="4" desc="TXT MSEG Size"/>
+    <register name="TXT_ACM_STATUS" type="memory" access="mmio" address="0xFED30000" offset="0x328" size="4" desc="TXT ACM Status">
+       <field name="MODULE_TYPE" bit="0" size="4" desc="Module Type"/>
+       <field name="CLASS_CODE" bit="4" size="6" desc="Class Code"/>
+       <field name="MAJOR_ERROR_CODE" bit="10" size="5" desc="Major Error Code"/>
+       <field name="ACM_STARTED" bit="15" size="1" desc="ACM Started"/>
+       <field name="MINOR_ERROR_CODE" bit="16" size="12" desc="Minor Error Code"/>
+       <field name="VALID" bit="31" size="1" desc="Valid"/>
+    </register>
+    <register name="TXT_DPR" type="memory" access="mmio" address="0xFED30000" offset="0x330" size="4" desc="TXT DMA Protected Range (deprecated, replaced by PCI0.0.0_DPR)">
       <field name="LOCK" bit="0" size="1" desc="Lock Bits 19:0"/>
       <field name="SIZE" bit="4" size="8" desc="Protected Memory Size (in MB)"/>
       <field name="TOP" bit="20" size="12" desc="Top Address+1 of DPR (base of TSEG)"/>
+    </register>
+    <register name="TXT_FIT" type="memory" access="mmio" address="0xFED30000" offset="0x340" size="4" desc="FIT (Firmware Interface Table)">
+      <field name="FIT_FAILED" bit="0" size="1" desc="FIT Failed"/>
+      <field name="S_ACM_FAILED" bit="1" size="1" desc="S-ACM Failed"/>
+      <field name="FIT_MEASURED" bit="2" size="1" desc="FIT Measured"/>
+      <field name="FIT_FALLBACK" bit="3" size="1" desc="FIT Fallback"/>
+    </register>
+
+    <register name="TXT_SCRATCHPAD" type="memory" access="mmio" address="0xFED30000" offset="0x378" size="8" desc="ACM Policy Status">
+      <field name="TPM_TYPE" bit="13" size="2" desc="TPM type detected by Startup ACM (0 for no TPM, 1 for dTPM1.2, 2 for dTPM2.0, 3 for PTT)"/>
+      <field name="TPM_SUCCESS" bit="15" size="1" desc="TPM Success"/>
+      <field name="BOOT_POLICIES_2" bit="17" size="1" desc="Boot Policies"/>
+      <field name="BACKUP_ACTION" bit="18" size="2" desc="Backup Action"/>
+      <field name="TXT_PROFILE" bit="20" size="5" desc="TXT Profile"/>
+      <field name="MEMORY_SCRUB_POLICY" bit="25" size="2" desc="Memory Scrub Policy"/>
+      <field name="IBB_DMA_PROTECTION" bit="29" size="1" desc="IBB (Initial Boot Block) DMA Protection"/>
+      <field name="S_CRTM_STATUS" bit="32" size="3" desc="Startup ACM S-CRTM establishment"/>
+      <field name="CPU_COSIGNING_ENABLE" bit="35" size="1" desc="CPU co-signing enabled"/>
+      <field name="TPM_STARTUP_LOCALITY" bit="36" size="1" desc="Locality at which TPM2_Startup command was executed (0 for locality 3, 1 for locality 0)"/>
     </register>
 
     <!-- TXT_CMD_OPEN_LOCALITY1 at offset 0x380 -->

--- a/chipsec/utilcmd/txt_cmd.py
+++ b/chipsec/utilcmd/txt_cmd.py
@@ -1,0 +1,170 @@
+# CHIPSEC: Platform Security Assessment Framework
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program; if not, write to the Free Software
+#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#Contact information:
+#chipsec@intel.com
+#
+
+"""
+Command-line utility providing access to Intel TXT (Trusted Execution Technology) registers
+
+Usage:
+    >>> chipsec_util txt dump
+    >>> chipsec_util txt state
+"""
+
+from argparse        import ArgumentParser
+import binascii
+from chipsec.command import BaseCommand
+from chipsec.exceptions import HWAccessViolationError
+import struct
+
+
+class TXTCommand(BaseCommand):
+
+    def requires_driver(self):
+        parser = ArgumentParser(usage=__doc__)
+        subparsers = parser.add_subparsers()
+        parser_state = subparsers.add_parser('dump')
+        parser_state.set_defaults(func=self.txt_dump)
+        parser_state = subparsers.add_parser('state')
+        parser_state.set_defaults(func=self.txt_state)
+        parser.parse_args(self.argv[2:], namespace=self)
+        return True
+
+    def txt_dump(self):
+        # Read TXT Public area as hexdump, with absolute address and skipping zeros
+        txt_public = self.cs.mem.read_physical_mem(0xfed30000, 0x1000)
+        has_skipped_line = False
+        for offset in range(0, len(txt_public), 16):
+            line_bytes = txt_public[offset:offset + 16]
+            if all(b == 0 for b in line_bytes):
+                has_skipped_line = True
+                continue
+            if has_skipped_line:
+                self.logger.log("[CHIPSEC] *")
+                has_skipped_line = False
+            line_hex = " ".join("{:02X}".format(b) for b in line_bytes)
+            self.logger.log("[CHIPSEC] {:08X}: {}".format(0xfed30000 + offset, line_hex))
+
+    def _log_register(self, reg_name):
+        """Log the content of a register with lines starting with [CHIPSEC]"""
+        reg_def = self.cs.get_register_def(reg_name)
+        value = self.cs.read_register(reg_name)
+        desc = reg_def["desc"]
+        if reg_def["type"] == "memory":
+            addr = int(reg_def["address"], 16) + int(reg_def["offset"], 16)
+            desc += ", at {:08X}".format(addr)
+        self.logger.log("[CHIPSEC] {} = 0x{:0{width}X} ({})".format(
+            reg_name, value, desc, width=int(reg_def['size'], 16) * 2))
+
+        if 'FIELDS' in reg_def:
+            sorted_fields = sorted(reg_def['FIELDS'].items(), key=lambda field: int(field[1]['bit']))
+            for field_name, field_attrs in sorted_fields:
+                field_bit = int(field_attrs['bit'])
+                field_size = int(field_attrs['size'])
+                field_mask = (1 << field_size) - 1
+                field_value = (value >> field_bit) & field_mask
+                self.logger.log("[CHIPSEC]     [{:02d}] {:23} = {:X} << {}".format(
+                    field_bit, field_name, field_value, field_attrs['desc']))
+
+    def txt_state(self):
+        """Dump Intel TXT state
+
+        This is similar to command "txt-stat" from Trusted Boot project
+        https://sourceforge.net/p/tboot/code/ci/v2.0.0/tree/utils/txt-stat.c
+        which was documented on
+        https://www.intel.com/content/dam/www/public/us/en/documents/guides/dell-one-stop-txt-activation-guide.pdf
+        and it is also similar to command "sl-stat" from TrenchBoot project
+        https://github.com/TrenchBoot/sltools/blob/842cfd041b7454727b363b72b6d4dcca9c00daca/sl-stat/sl-stat.c
+        """
+        # Read bits in CPUID
+        (eax, ebx, ecx, edx) = self.cs.cpu.cpuid(0x01, 0x00)
+        self.logger.log("[CHIPSEC] CPUID.01H.ECX[Bit 6] = {} << Safer Mode Extensions (SMX)".format((ecx >> 6) & 1))
+        self.logger.log("[CHIPSEC] CPUID.01H.ECX[Bit 5] = {} << Virtual Machine Extensions (VMX)".format((ecx >> 5) & 1))
+
+        # Read bits in CR4
+        cr4 = self.cs.cpu.read_cr(0, 4)
+        self.logger.log("[CHIPSEC] CR4.SMXE[Bit 14] = {} << Safer Mode Extensions Enable".format((cr4 >> 14) & 1))
+        self.logger.log("[CHIPSEC] CR4.VMXE[Bit 13] = {} << Virtual Machine Extensions Enable".format((cr4 >> 13) & 1))
+
+        # Read bits in MSR IA32_FEATURE_CONTROL
+        self._log_register("IA32_FEATURE_CONTROL")
+        self.logger.log("[CHIPSEC]")
+
+        # Read TXT Device ID
+        self._log_register("TXT_DIDVID")
+        self.logger.log("[CHIPSEC]")
+
+        # Read hashes of public keys
+        txt_pubkey = struct.pack("<QQQQ",
+            self.cs.read_register("TXT_PUBLIC_KEY_0"),
+            self.cs.read_register("TXT_PUBLIC_KEY_1"),
+            self.cs.read_register("TXT_PUBLIC_KEY_2"),
+            self.cs.read_register("TXT_PUBLIC_KEY_3"),
+        )
+        self.logger.log("[CHIPSEC] TXT Public Key Hash: {}".format(
+            binascii.hexlify(txt_pubkey).decode("ascii")))
+
+        try:
+            eax, edx = self.cs.msr.read_msr(0, 0x20)
+            pubkey_in_msr = struct.pack("<II", eax, edx)
+            eax, edx = self.cs.msr.read_msr(0, 0x21)
+            pubkey_in_msr += struct.pack("<II", eax, edx)
+            eax, edx = self.cs.msr.read_msr(0, 0x22)
+            pubkey_in_msr += struct.pack("<II", eax, edx)
+            eax, edx = self.cs.msr.read_msr(0, 0x23)
+            pubkey_in_msr += struct.pack("<II", eax, edx)
+            self.logger.log("[CHIPSEC] Public Key Hash in MSR[0x20...0x23]: {}".format(
+                binascii.hexlify(pubkey_in_msr).decode("ascii")))
+        except HWAccessViolationError as exc:
+            # Report the exception and continue
+            self.logger.log("[CHIPSEC] Unable to read Public Key Hash in MSR[0x20...0x23]: {}".format(exc))
+        self.logger.log("[CHIPSEC]")
+
+        # Read TXT status
+        self._log_register("TXT_STS")
+        self._log_register("TXT_ESTS")
+        self._log_register("TXT_E2STS")
+        self._log_register("TXT_ERRORCODE")
+        self.logger.log("[CHIPSEC]")
+        self._log_register("TXT_SPAD")
+        self._log_register("TXT_ACM_STATUS")
+        self._log_register("TXT_FIT")
+        self._log_register("TXT_SCRATCHPAD")
+        self.logger.log("[CHIPSEC]")
+
+        # Read memory area for TXT components
+        self._log_register("TXT_SINIT_BASE")
+        self._log_register("TXT_SINIT_SIZE")
+        self._log_register("TXT_MLE_JOIN")
+        self._log_register("TXT_HEAP_BASE")
+        self._log_register("TXT_HEAP_SIZE")
+        self._log_register("TXT_MSEG_BASE")
+        self._log_register("TXT_MSEG_SIZE")
+        self.logger.log("[CHIPSEC]")
+
+        # Read other registers in the TXT memory area
+        self._log_register("TXT_DPR")
+        self._log_register("TXT_VER_FSBIF")
+        self._log_register("TXT_VER_QPIIF")
+        self._log_register("TXT_PCH_DIDVID")
+        self._log_register("INSMM")
+
+    def run(self):
+        self.func()
+
+
+commands = {'txt': TXTCommand}


### PR DESCRIPTION
Hello,
Following https://github.com/chipsec/chipsec/pull/1334 (which added a basic set of registers in Intel TXT public space at `0xFED30000`), I have been working on a command which shows the status of these registers. While testing this command, I encountered new registers, for which I added their definitions to `chipsec/cfg/8086/txt.xml`.

This Pull Request introduces a new command with two subcommands:

- `chipsec_util txt state` shows the current content of the registers. It also shows the state of SMX and VMX features in CPUID and CR4, as these feature are closely related to Intel TXT. It has been inspired by command `txt-stat` from Trusted Boot project.
- `chipsec_util txt dump` performs a hex dump of the first 4096 bytes of `0xFED30000`, skipping empty lines (in a way similar to what `xxd -a` and `hexdump -C` do).