### PR TITLE
va2pa fixes

### DIFF
--- a/chipsec/hal/physmem.py
+++ b/chipsec/hal/physmem.py
@@ -105,10 +105,10 @@ class Memory(HALBase):
 
     def va2pa(self, va):
         (pa, error_code) = self.helper.va2pa(va)
-        if self.logger.HAL: self.logger.log('[mem] VA (0x{:016X}) -> PA (0x{:016X})'.format(va, pa))
         if error_code:
             if self.logger.HAL: self.logger.log('[mem] Looks like VA (0x{:016X}) not mapped'.format(va))
             return
+        if self.logger.HAL: self.logger.log('[mem] VA (0x{:016X}) -> PA (0x{:016X})'.format(va, pa))
         return pa
 
     # Map physical address to virtual

--- a/chipsec/hal/virtmem.py
+++ b/chipsec/hal/virtmem.py
@@ -108,10 +108,10 @@ class VirtMemory(hal_base.HALBase):
 
     def va2pa( self, va ):
         (pa, error_code) = self.helper.va2pa( va )
-        if logger().HAL: logger().log( '[mem] VA (0x{:016X}) -> PA (0x{:016X})'.format(va, pa) )
         if error_code:
             if logger().HAL: logger().log( '[mem] Looks like VA (0x{:016X}) not mapped'.format(va) )
             return
+        if logger().HAL: logger().log( '[mem] VA (0x{:016X}) -> PA (0x{:016X})'.format(va, pa) )
         return pa
 
     def free_virtual_mem(self, virt_address):

--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -403,9 +403,14 @@ class LinuxHelper(Helper):
     def va2pa( self, va ):
         error_code = 0
 
-        in_buf = struct.pack( self._pack, va )
-        out_buf = self.ioctl(IOCTL_VA2PA, in_buf)
-        pa = struct.unpack( self._pack, out_buf )[0]
+        in_buf = struct.pack(self._pack, va)
+        try:
+            out_buf = self.ioctl(IOCTL_VA2PA, in_buf)
+            pa = struct.unpack(self._pack, out_buf)[0]
+        except IOError as err:
+            if logger().DEBUG:
+                logger().error("[helper] Error in va2pa: getting PA for VA 0x{:016X} failed with IOError: {}".format(va, err.strerror))
+            return (None, err.errno)
 
         #Check if PA > max physical address
         max_pa = self.cpuid( 0x80000008, 0x0 )[0] & 0xFF

--- a/drivers/linux/chipsec_km.c
+++ b/drivers/linux/chipsec_km.c
@@ -1639,13 +1639,19 @@ static long d_ioctl(struct file *file, unsigned int ioctl_num, unsigned long ioc
 		//IN  params: va
 		//OUT params: pa
 #ifdef CONFIG_X86
-		PHYSICAL_ADDRESS pa;
+		phys_addr_t pa;
+		void *va;
+
 		numargs = 1;
 		if(copy_from_user((void*)ptrbuf, (void*)ioctl_param, (sizeof(long) * numargs)) > 0)
 			return -EFAULT;
 
-		pa.quadpart = virt_to_phys((void*)ptr[0]);
-                ptr[0] = pa.quadpart;
+		va = (void*)ptr[0];
+		if (!virt_addr_valid(va))
+			return -EINVAL;
+
+		pa = virt_to_phys(va);
+		ptr[0] = pa;
 
 		if(copy_to_user((void*)ioctl_param, (void*)ptrbuf, (sizeof(long) * numargs)) > 0)
 			return -EFAULT;


### PR DESCRIPTION
This branch fixes va2pa related errors that will lead to `BUG()`s on Linux kernels with enabled `CONFIG_DEBUG_VIRTUAL` (commits 272bffc95f7298bb92956834ffb9727758e0e68f, 59dc3e137ba772342da161d410cf4007d74fb180 and 350f0346640ea54c052d336c0aba3598fc4e48b9).

It also fixes a physical memory allocation error, where `ioctl(IOCTL_ALLOC_PHYSMEM)` would return an allocation that doesn't fit the maximum address requirement, leading to the `tools.smm.smm_ptr` module using a truncated pointer for the actual SWSMI call, leading to possibly corrupting unrelated memory (commit 02c20f93cf8714bd9a740b5543e6e3ef5f07d18d).

The fix for that requires using a bounce buffer for `write_mem()` as well to not run into USERCOPY violations (commit 537b1ba31e7648736531c5f888c2f02b47b89e6f). As `read_mem()` and `write_mem()` are now nearly identical, I merged them into a common helper (commit c5f1d60d8d068cf2b3615620c721bc88d3ce2ab9).