### PR TITLE
Fix PMBASE definition in pch_c620

### DIFF
--- a/chipsec/cfg/8086/pch_c620.xml
+++ b/chipsec/cfg/8086/pch_c620.xml
@@ -62,7 +62,7 @@ XML configuration file for
   <!-- #################################### -->
   <io>
     <bar name="ABASE"      register="ABASE"    base_field="Base"  size="0x100" desc="ACPI Base Address"/>
-    <bar name="PMBASE"     register="ABASE"    base_field="BA"    size="0x100" desc="ACPI Base Address"/>
+    <bar name="PMBASE"     register="ABASE"    base_field="Base"  size="0x100" desc="ACPI Base Address"/>
     <bar name="TCOBASE"    register="TCOBASE"  base_field="TCOBA" size="0x20"  desc="TCO Base Address"/>
 
     <!-- old definition -->


### PR DESCRIPTION
This is a small fix, I noticed that PMBASE was pointing to an invalid field since here the right field is 'Base' instead of 'BA'.