### PR TITLE
Don't check for PCH on SoC

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -265,8 +265,6 @@ class Chipset:
                 msg += ', CPUID = 0x{}'.format(cpuid)
             logger().log("[CHIPSEC] {}".format(msg))
 
-        pch_vid_found = pch_vid in self.pch_dictionary.keys()
-        pch_did_found = pch_did in self.pch_dictionary[pch_vid].keys()
         if req_pch_code is not None:
             # Check if pch code passed in is valid
             if req_pch_code in self.pch_codes:
@@ -278,7 +276,7 @@ class Chipset:
                 _unknown_pch = False
                 msg = 'PCH     : Actual values: VID = 0x{:04X}, DID = 0x{:04X}, RID = 0x{:02X}'.format(pch_vid, pch_did, pch_rid)
                 logger().log("[CHIPSEC] {}".format(msg))
-        elif pch_vid_found and pch_did_found:
+        elif (pch_vid in self.pch_dictionary.keys()) and (pch_did in self.pch_dictionary[pch_vid].keys()):
             #Check if pch did for device is in configuration
             self.pch_vid = pch_vid
             self.pch_did = pch_did

--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -530,7 +530,7 @@ class Chipset:
         if not os.path.exists(fxml):
             return
         if logger().DEBUG:
-            logger().log( "[*] looking for platform config in '{}'..".format(fxml) )
+            logger().log("[*] looking for platform config in '{}'..".format(fxml))
         tree = ET.parse(fxml)
         root = tree.getroot()
         for _cfg in root.iter('configuration'):

--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -193,8 +193,7 @@ class Chipset:
 
     def init(self, platform_code, req_pch_code, start_driver, driver_exists=None, to_file=None, from_file=None):
         _unknown_platform = False
-        self.reqs_pch = False
-        self.is_soc = False
+        self.reqs_pch = None
         self.helper.start(start_driver, driver_exists, to_file, from_file)
         logger().log( '[CHIPSEC] API mode: {}'.format('using OS native API (not using CHIPSEC kernel module)' if self.use_native_api() else 'using CHIPSEC kernel module API') )
 
@@ -295,19 +294,19 @@ class Chipset:
         if _unknown_platform:
             msg = 'Unknown Platform: VID = 0x{:04X}, DID = 0x{:04X}, RID = 0x{:02X}'.format(vid, did, rid)
             if start_driver:
-                logger().error(msg)
+                logger().log_error(msg)
                 raise UnknownChipsetError(msg)
             else:
                 logger().log("[!]       {}; Using Default.".format(msg))
         if not _unknown_platform: # Don't initialize config if platform is unknown
             self.init_cfg()
-        if self.is_soc:
+        if self.reqs_pch == False:
             self.pch_longname = self.longname
             _unknown_pch = False
         if _unknown_pch:
             msg = 'Unknown PCH: VID = 0x{:04X}, DID = 0x{:04X}, RID = 0x{:02X}'.format(pch_vid, pch_did, pch_rid)
             if self.reqs_pch and start_driver:
-                logger().error("Chipset requires a supported PCH to be loaded. {}".format(msg))
+                logger().log_error("Chipset requires a supported PCH to be loaded. {}".format(msg))
                 raise UnknownChipsetError(msg)
             else:
                 logger().log("[!]       {}; Using Default.".format(msg))
@@ -542,9 +541,8 @@ class Chipset:
                 if 'req_pch' in _cfg.attrib:
                     if 'true' == _cfg.attrib['req_pch'].lower():
                         self.reqs_pch = True
-                if 'is_soc' in _cfg.attrib:
-                    if 'true' == _cfg.attrib['is_soc'].lower():
-                        self.is_soc = True
+                    if 'false' == _cfg.attrib['req_pch'].lower():
+                        self.reqs_pch = False
             elif pch_code == _cfg.attrib['platform'].lower():
                 if logger().DEBUG: logger().log("[*] loading '{}' PCH config from '{}'..".format(pch_code, fxml))
             else: continue


### PR DESCRIPTION
- if `is_soc="True"` defined in config, don't look for PCH definition
- Minor code cleanup

Example configuration XML:
`<configuration platform="BYT" is_soc="True">`

Signed-off-by: Frinzell, Aaron <aaron.frinzell@intel.com>