### PR TITLE
hal/iommu: do not raise exception when an IOMMU BAR is not configured

### DIFF
--- a/chipsec/hal/iommu.py
+++ b/chipsec/hal/iommu.py
@@ -75,6 +75,8 @@ class IOMMU(hal_base.HALBase):
         self.logger.log( "Base register (BAR)       : {}".format(vtd) )
         reg = self.cs.read_register( vtd )
         self.logger.log( "BAR register value        : 0x{:X}".format(reg) )
+        if reg == 0:
+            return
         base    = self.get_IOMMU_Base_Address( iommu_engine )
         self.logger.log( "MMIO base                 : 0x{:016X}".format(base) )
         self.logger.log( "------------------------------------------------------------------" )
@@ -114,6 +116,9 @@ class IOMMU(hal_base.HALBase):
 
     def dump_IOMMU_page_tables( self, iommu_engine ):
         vtd = IOMMU_ENGINES[ iommu_engine ]
+        if self.cs.read_register( vtd ) == 0:
+            self.logger.log( "[iommu] {} value is zero".format(vtd) )
+            return
         te  = self.is_IOMMU_Translation_Enabled( iommu_engine )
         self.logger.log( "[iommu] Translation enabled    : {:d}".format(te) )
         rtaddr_reg = self.cs.read_register( vtd + '_RTADDR' )
@@ -148,6 +153,9 @@ class IOMMU(hal_base.HALBase):
         self.logger.log( "==================================================================" )
         self.logger.log( "[iommu] {} IOMMU Engine Status:".format(iommu_engine) )
         self.logger.log( "==================================================================" )
+        if self.cs.read_register( vtd ) == 0:
+            self.logger.log( "[iommu] {} value is zero".format(vtd) )
+            return
         gsts_reg = self.cs.read_register( vtd + '_GSTS' )
         self.cs.print_register( vtd + '_GSTS', gsts_reg )
         fsts_reg = self.cs.read_register( vtd + '_FSTS' )


### PR DESCRIPTION
On some testing systems, `chipsec_util.py iommu config` fails with:

    [CHIPSEC] Executing command 'iommu' with args ['config']

    [CHIPSEC] Couldn't find DMAR ACPI table

    ==================================================================
    [iommu] GFXVTD IOMMU Engine Configuration
    ==================================================================
    Base register (BAR)       : GFXVTBAR
    BAR register value        : 0x0
    Traceback (most recent call last):
      File "./chipsec_util.py", line 236, in <module>
        sys.exit(main())
      File "./chipsec_util.py", line 232, in main
        return chipsecUtil.main()
      File "./chipsec_util.py", line 204, in main
        comm.run()
      File "/root/chipsec/chipsec/utilcmd/iommu_cmd.py", line 139, in run
        self.func()
      File "/root/chipsec/chipsec/utilcmd/iommu_cmd.py", line 122, in iommu_config
        self.iommu_engine('config')
      File "/root/chipsec/chipsec/utilcmd/iommu_cmd.py", line 114, in iommu_engine
        if   (cmd == 'config' ): _iommu.dump_IOMMU_configuration( e )
      File "/root/chipsec/chipsec/hal/iommu.py", line 78, in dump_IOMMU_configuration
        base    = self.get_IOMMU_Base_Address( iommu_engine )
      File "/root/chipsec/chipsec/hal/iommu.py", line 52, in get_IOMMU_Base_Address
        (base, size) = self.mmio.get_MMIO_BAR_base_address(vtd_base_name)
      File "/root/chipsec/chipsec/hal/mmio.py", line 249, in get_MMIO_BAR_base_address
        raise CSReadError('[mmio] Base address was determined to be 0')
    chipsec.exceptions.CSReadError: [mmio] Base address was determined to be 0

Indeed, the OS did not configure any IOMMU and `GFXVTBAR` was zero. It is nonetheless annoying that the execution of this utility stops without describing the other IOMMU ("VTBAR").

Fix this issue by returning early from the dump functions if the BAR contains zero. With this change:

    $ ./chipsec_util.py iommu config
    ...
    ==================================================================
    [iommu] GFXVTD IOMMU Engine Configuration
    ==================================================================
    Base register (BAR)       : GFXVTBAR
    BAR register value        : 0x0
    ==================================================================
    [iommu] VTD IOMMU Engine Configuration
    ==================================================================
    Base register (BAR)       : VTBAR
    BAR register value        : 0x0

    $ ./chipsec_util.py iommu status
    ...
    ==================================================================
    [iommu] GFXVTD IOMMU Engine Status:
    ==================================================================
    [iommu] GFXVTBAR value is zero
    ==================================================================
    [iommu] VTD IOMMU Engine Status:
    ==================================================================
    [iommu] VTBAR value is zero

    $ ./chipsec_util.py iommu pt
    ...
    [iommu] GFXVTBAR value is zero
    [iommu] VTBAR value is zero

System information:
```text
[CHIPSEC] Version : 1.8.3
[CHIPSEC] OS      : Linux 5.13.0-39-generic #44~20.04.1-Ubuntu SMP Thu Mar 24 16:43:35 UTC 2022 x86_64
[CHIPSEC] Python  : 3.8.10 (64-bit)

****** Chipsec Linux Kernel module is licensed under GPL 2.0
[CHIPSEC] API mode: using CHIPSEC kernel module API
[CHIPSEC] Helper  : LinuxHelper (None)
[CHIPSEC] Platform: Mobile 8th Generation Core Processor (Whiskey Lake U 4 Cores)
[CHIPSEC]      VID: 8086
[CHIPSEC]      DID: 3E34
[CHIPSEC]      RID: 0C
[CHIPSEC] PCH     : Intel 300 series On-Package PCH
[CHIPSEC]      VID: 8086
[CHIPSEC]      DID: 9D84
[CHIPSEC]      RID: 30
```