### PR TITLE
Update logger.error() in common files

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -162,9 +162,9 @@ class Chipset:
             did = (vid_did >> 16) & 0xFFFF
             rid = self.pci.read_byte(0, 0, 0, PCI_HDR_RID_OFF)
         except:
-            if logger().DEBUG: logger().error("pci.read_dword couldn't read platform VID/DID")
+            if logger().DEBUG: logger().log_error("pci.read_dword couldn't read platform VID/DID")
         if not vid in PCH_ADDRESS:
-            if logger().DEBUG: logger().error("PCH address unknown for VID 0x{:04X}.".format(vid))
+            if logger().DEBUG: logger().log_error("PCH address unknown for VID 0x{:04X}.".format(vid))
         else:
             try:
                  (bus,dev,fun) = PCH_ADDRESS[vid]
@@ -173,7 +173,7 @@ class Chipset:
                  pch_did = (vid_did >> 16) & 0xFFFF
                  pch_rid = self.pci.read_byte(0, 31, 0, PCI_HDR_RID_OFF)
             except:
-                 if logger().DEBUG: logger().error("pci.read_dword couldn't read PCH VID/DID")
+                 if logger().DEBUG: logger().log_error("pci.read_dword couldn't read PCH VID/DID")
         return (vid, did, rid, pch_vid, pch_did, pch_rid)
 
     def get_cpuid(self):
@@ -771,7 +771,7 @@ class Chipset:
                     reg_def['address'] = dev['address']
                     reg_def['access'] = dev['access']
                 else:
-                    logger().error("Memory device {} not found".format(dev_name))
+                    logger().log_error("Memory device {} not found".format(dev_name))
             elif reg_def["type"] == "indirect":
                 if dev_name in self.Cfg.IMA_REGISTERS:
                     dev = self.Cfg.IMA_REGISTERS[dev_name]
@@ -782,13 +782,13 @@ class Chipset:
                     if (dev['index'] in self.Cfg.REGISTERS):
                         reg_def['index'] = dev['index']
                     else:
-                        logger().error("Index register {} not found".format(dev['index']))
+                        logger().log_error("Index register {} not found".format(dev['index']))
                     if (dev['data'] in self.Cfg.REGISTERS):
                         reg_def['data'] = dev['data']
                     else:
-                        logger().error("Data register {} not found".format(dev['data']))
+                        logger().log_error("Data register {} not found".format(dev['data']))
                 else:
-                    logger().error("Indirect access device {} not found".format(dev_name))
+                    logger().log_error("Indirect access device {} not found".format(dev_name))
         return reg_def
 
     def get_register_bus(self, reg_name):

--- a/chipsec/file.py
+++ b/chipsec/file.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -32,8 +32,8 @@
 Reading from/writing to files
 
 usage:
-    >>> read_file( filename )
-    >>> write_file( filename, buffer )
+    >>> read_file(filename)
+    >>> write_file(filename, buffer)
 """
 
 import struct
@@ -52,7 +52,7 @@ def read_file( filename, size=0 ):
     try:
         f = open(filename, 'rb')
     except:
-        logger().error( "Unable to open file '{:.256}' for read access".format(filename) )
+        logger().log_error("Unable to open file '{:.256}' for read access".format(filename))
         return 0
 
     if size:
@@ -74,7 +74,7 @@ def write_file( filename, buffer, append=False ):
     try:
         f = open(filename, perm)
     except:
-        logger().error( "Unable to open file '{:.256}' for write access".format(filename) )
+        logger().log_error("Unable to open file '{:.256}' for write access".format(filename))
         return 0
     f.write( buffer )
     f.close()

--- a/chipsec/module.py
+++ b/chipsec/module.py
@@ -59,7 +59,7 @@ class Module():
     def do_import(self):
         loaded = False
         if not MODPATH_RE.match(self.get_name()):
-            self.logger.error( "Invalid module path: {}".format(self.name) )
+            self.logger.log_error("Invalid module path: {}".format(self.name))
         else:
             try:
                 if _importlib:
@@ -67,7 +67,7 @@ class Module():
                 loaded = True
                 if self.logger.DEBUG: self.logger.log_good( "imported: {}".format(self.name) )
             except BaseException as msg:
-                self.logger.error( "Exception occurred during import of {}: '{}'".format(self.name, str(msg)) )
+                self.logger.log_error("Exception occurred during import of {}: '{}'".format(self.name, str(msg)))
                 if self.logger.DEBUG: self.logger.log_bad(traceback.format_exc())
                 raise msg
         return loaded

--- a/chipsec/result_deltas.py
+++ b/chipsec/result_deltas.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2018-2019, Intel Corporation
-#
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
-#
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
-#
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-#
-#Contact information:
-#chipsec@intel.com
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2018-2019, Intel Corporation
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# 
+# Contact information:
+# chipsec@intel.com
 #
 
 import json
@@ -33,7 +33,7 @@ def get_json_results(json_file):
     try:
         json_data = json.loads(bytestostring(file_data))
     except:
-        logger().error("Unable to load JSON file: {}".format(json_file))
+        logger().log_error("Unable to load JSON file: {}".format(json_file))
         return None
     return json_data
 


### PR DESCRIPTION
Replace deprecated `error()` with `log_error()`

Signed-off-by: Frinzell, Aaron <aaron.frinzell@intel.com>