### PR TITLE
Update logger.error() in hal modules

### DIFF
--- a/chipsec/hal/acpi.py
+++ b/chipsec/hal/acpi.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -436,9 +436,9 @@ class ACPI(hal_base.HALBase):
         if dsdt_address_to_use is None:
             dsdt_address = parsed_fadt_content.dsdt
             x_dsdt_address = parsed_fadt_content.x_dsdt
-            if logger().HAL: logger().error( 'Unable to determine the correct DSDT address' )
-            if logger().HAL: logger().error( '  DSDT   address = 0x{:08X}'.format(dsdt_address) )
-            if logger().HAL: logger().error( '  X_DSDT address = 0x{}'.format("{:16X}".format(x_dsdt_address)) if x_dsdt_address is not None else 'Not found')
+            if logger().HAL: logger().log_error('Unable to determine the correct DSDT address')
+            if logger().HAL: logger().log_error('  DSDT   address = 0x{:08X}'.format(dsdt_address))
+            if logger().HAL: logger().log_error('  X_DSDT address = 0x{}'.format("{:16X}".format(x_dsdt_address)) if x_dsdt_address is not None else 'Not found')
             return
 
         self.tableList[ ACPI_TABLE_SIG_DSDT ].append(dsdt_address_to_use)
@@ -454,7 +454,7 @@ class ACPI(hal_base.HALBase):
     #
     def print_ACPI_table_list(self):
         if len( self.tableList ) == 0:
-            logger().error("Couldn't get a list of ACPI tables")
+            logger().log_error("Couldn't get a list of ACPI tables")
         else:
             if logger().HAL: logger().log( "[acpi] Found the following ACPI tables:" )
             for tableName in sorted(self.tableList.keys()):

--- a/chipsec/hal/cpu.py
+++ b/chipsec/hal/cpu.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -220,7 +220,7 @@ class CPU(hal_base.HALBase):
         logger().set_log_file( pt_fname )
         hpt.read_pt_and_show_status( pt_fname, 'PT', cr3 )
         logger().set_log_file( _orig_logname )
-        if hpt.failure: logger().error( 'could not dump page tables' )
+        if hpt.failure: logger().log_error('could not dump page tables')
 
     def dump_page_tables_all( self ):
         for tid in range(self.cs.msr.get_cpu_thread_count()):

--- a/chipsec/hal/interrupts.py
+++ b/chipsec/hal/interrupts.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -109,7 +109,7 @@ class Interrupts(hal_base.HALBase):
                 #check for return status
                 ret_buf = self.cs.helper.read_io_port(buf_addr, 8)
             else:
-                logger().error("Functionality is currently not implemented")
+                logger().log_error("Functionality is currently not implemented")
                 ret_buf = None
             return ret_buf
 
@@ -174,14 +174,14 @@ MdeModulePkg/Core/PiSmmCore/PiSmmCorePrivateData.h
         self.cs.mem.write_physical_mem(smmc + CommBuffer_offset, 8, struct.pack("Q", payload_loc))
         self.cs.mem.write_physical_mem(smmc + BufferSize_offset, 8, struct.pack("Q", len(data_hdr)))
         self.cs.mem.write_physical_mem(payload_loc, len(data_hdr), data_hdr)
-        
+
         if self.logger.VERBOSE:
             self.logger.log("[*] Communication buffer on input")
             print_buffer_bytes(self.cs.mem.read_physical_mem(payload_loc, len(data_hdr)))
             self.logger.log("")
 
         self.send_SMI_APMC(CommandPort, DataPort)
-        
+
         if self.logger.VERBOSE:
             self.logger.log("[*] Communication buffer on output")
             print_buffer_bytes(self.cs.mem.read_physical_mem(payload_loc, len(data_hdr)))

--- a/chipsec/hal/iobar.py
+++ b/chipsec/hal/iobar.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -49,7 +49,7 @@ class IOBAR(hal_base.HALBase):
         try:
             return (self.cs.Cfg.IO_BARS[ bar_name ] is not None)
         except KeyError:
-            if logger().HAL: logger().error( "'%s' I/O BAR definition not found in XML config" % bar_name)
+            if logger().HAL: logger().log_error("'{}' I/O BAR definition not found in XML config".format(bar_name))
             #raise IOBARNotFoundError, ('IOBARNotFound: %s' % bar_name)
             return False
 

--- a/chipsec/hal/iommu.py
+++ b/chipsec/hal/iommu.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -141,11 +141,10 @@ class IOMMU(hal_base.HALBase):
                 self.logger.log( '[iommu] total VTd domains: {:d}'.format(len(paging_vtd.domains)))
                 for domain in paging_vtd.domains:
                     paging_vtd.read_pt_and_show_status('vtd_{:08X}'.format(domain), 'VTd', domain)
-                    #if paging_vtd.failure: self.logger.error( "couldn't dump VT-d page tables" )
             else:
                 self.logger.log( "[iommu] translation via VT-d engine '{}' is not enabled".format(iommu_engine) )
         else:
-            self.logger.error( "cannot access VT-d registers" )
+            self.logger.log_error("Cannot access VT-d registers")
 
 
     def dump_IOMMU_status( self, iommu_engine ):

--- a/chipsec/hal/paging.py
+++ b/chipsec/hal/paging.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -254,7 +254,7 @@ class c_paging(c_paging_with_2nd_level_translation, c_translation):
             self.translation                    = {}
             self.pt                             = {}
             self.failure = True
-            if logger().HAL: logger().error( '    ERROR: Invalid {} Page Tables!'.format(name) )
+            if logger().HAL: logger().log_error('    Invalid {} Page Tables!'.format(name))
         #finally:
         #    #txt.close()
         return

--- a/chipsec/hal/smbus.py
+++ b/chipsec/hal/smbus.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -86,7 +86,7 @@ class SMBus(hal_base.HALBase):
         if self.logger.HAL: self.logger.log( "[smbus] SMBus Controller (DID,VID) = (0x{:04X},0x{:04X})".format(did, vid) )
         if (0x8086 == vid): return True
         else:
-            self.logger.error( "Unknown SMBus Controller (DID,VID) = (0x{:04X},0x{:04X})".format(did, vid) )
+            self.logger.log_error("Unknown SMBus Controller (DID,VID) = (0x{:04X},0x{:04X})".format(did, vid))
             return False
 
     def is_SMBus_host_controller_enabled( self ):
@@ -140,16 +140,16 @@ class SMBus(hal_base.HALBase):
                 #kill = 0
                 #if chipsec.chipset.register_has_field( self.cs, self.smb_reg_control, 'KILL' ):
                 #    kill = chipsec.chipset.read_register_field( self.cs, self.smb_reg_control, 'KILL' )
-                if self.logger.HAL: self.logger.error( "SMBus transaction failed (FAILED/ERROR bit = 1)" )
+                if self.logger.HAL: self.logger.log_error("SMBus transaction failed (FAILED/ERROR bit = 1)")
                 return False
             else:
                 if self.cs.register_has_field( self.smb_reg_status, 'DEV_ERR' ):
                     if 1 == self.cs.get_register_field( self.smb_reg_status, sts, 'DEV_ERR' ):
-                        if self.logger.HAL: self.logger.error( "SMBus device error (invalid cmd, unclaimed cycle or time-out error)" )
+                        if self.logger.HAL: self.logger.log_error("SMBus device error (invalid cmd, unclaimed cycle or time-out error)")
                         return False
                 if self.cs.register_has_field( self.smb_reg_status, 'BUS_ERR' ):
                     if 1 == self.cs.get_register_field( self.smb_reg_status, sts, 'BUS_ERR' ):
-                        if self.logger.HAL: self.logger.error( "SMBus bus error" )
+                        if self.logger.HAL: self.logger.log_error("SMBus bus error")
                         return False
         return (0 == busy)
 

--- a/chipsec/hal/spi.py
+++ b/chipsec/hal/spi.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -448,7 +448,7 @@ class SPI(hal_base.HALBase):
             reg_value = self.cs.read_register('BC')
             self.cs.print_register('BC', reg_value )
         else:
-            if self.logger.HAL: self.logger.error( "Could not locate the definition of 'BIOS Control' register.." )
+            if self.logger.HAL: self.logger.log_error("Could not locate the definition of 'BIOS Control' register..")
 
 
     def disable_BIOS_write_protection( self ):
@@ -553,7 +553,7 @@ class SPI(hal_base.HALBase):
         # Test if the flash decriptor is valid (and hardware sequencing enabled)
         fdv = self.cs.read_register_field('HSFS', 'FDV')
         if fdv == 0:
-            self.logger.error("HSFS.FDV is 0, hardware sequencing is disabled")
+            self.logger.log_error("HSFS.FDV is 0, hardware sequencing is disabled")
             raise SpiRuntimeError("Chipset does not support hardware sequencing")
 
     #
@@ -591,14 +591,14 @@ class SPI(hal_base.HALBase):
 
         cycle_done = self._wait_SPI_flash_cycle_done()
         if not cycle_done:
-            self.logger.error( "SPI cycle not ready" )
+            self.logger.log_error("SPI cycle not ready")
             return None
 
         for i in range(n):
             if self.logger.HAL:
                 self.logger.log( "[spi] reading chunk {:d} of 0x{:x} bytes from 0x{:x}".format(i, dbc, spi_fla + i *dbc) )
             if not self._send_spi_cycle( HSFCTL_READ_CYCLE, dbc -1, spi_fla + i *dbc ):
-                self.logger.error( "SPI flash read failed" )
+                self.logger.log_error("SPI flash read failed")
             else:
                 for fdata_idx in range(0, dbc //4):
                     dword_value = self.spi_reg_read( self.fdata0_off + fdata_idx *4 )
@@ -610,7 +610,7 @@ class SPI(hal_base.HALBase):
             if self.logger.HAL:
                 self.logger.log( "[spi] reading remaining 0x{:x} bytes from 0x{:x}".format(r, spi_fla + n *dbc) )
             if not self._send_spi_cycle( HSFCTL_READ_CYCLE, r -1, spi_fla + n *dbc ):
-                self.logger.error( "SPI flash read failed" )
+                self.logger.log_error("SPI flash read failed")
             else:
                 t = 4
                 n_dwords = (r +3) //4
@@ -643,7 +643,7 @@ class SPI(hal_base.HALBase):
 
         cycle_done = self._wait_SPI_flash_cycle_done()
         if not cycle_done:
-            self.logger.error( "SPI cycle not ready" )
+            self.logger.log_error("SPI cycle not ready")
             return None
 
         for i in range(n):
@@ -655,7 +655,7 @@ class SPI(hal_base.HALBase):
             self.spi_reg_write( self.fdata0_off, dword_value )
             if not self._send_spi_cycle( HSFCTL_WRITE_CYCLE, dbc -1, spi_fla + i *dbc ):
                 write_ok = False
-                self.logger.error( "SPI flash write cycle failed" )
+                self.logger.log_error("SPI flash write cycle failed")
 
         if (0 != r):
             if self.logger.UTIL_TRACE or self.logger.HAL:
@@ -668,7 +668,7 @@ class SPI(hal_base.HALBase):
             self.spi_reg_write( self.fdata0_off, dword_value )
             if not self._send_spi_cycle( HSFCTL_WRITE_CYCLE, r -1, spi_fla + n *dbc ):
                 write_ok = False
-                self.logger.error( "SPI flash write cycle failed" )
+                self.logger.log_error("SPI flash write cycle failed")
 
         return write_ok
 
@@ -681,12 +681,12 @@ class SPI(hal_base.HALBase):
 
         cycle_done = self._wait_SPI_flash_cycle_done()
         if not cycle_done:
-            self.logger.error( "SPI cycle not ready" )
+            self.logger.log_error("SPI cycle not ready")
             return None
 
         erase_ok = self._send_spi_cycle( HSFCTL_ERASE_CYCLE, 0, spi_fla )
         if not erase_ok:
-            self.logger.error( "SPI Flash erase cycle failed" )
+            self.logger.log_error("SPI Flash erase cycle failed")
 
         return erase_ok
 
@@ -733,7 +733,7 @@ class SPI(hal_base.HALBase):
                 self.spi_reg_write( self.fdata14_off, 0x00000000 )
                 self.spi_reg_write( self.fdata15_off, 0x00000000 )
                 if not self._send_spi_cycle( HSFCTL_SFDP_CYCLE, 0x3F, 0 ):
-                    self.logger.error( 'SPI SFDP signature cycle failed' )
+                    self.logger.log_error('SPI SFDP signature cycle failed')
                     continue
                 pTable_offset_list = []
                 pTable_length = []
@@ -776,7 +776,7 @@ class SPI(hal_base.HALBase):
             self.check_hardware_sequencing()
 
             if not self._send_spi_cycle( HSFCTL_JEDEC_CYCLE, 4, 0 ):
-                self.logger.error( 'SPI JEDEC ID cycle failed' )
+                self.logger.log_error('SPI JEDEC ID cycle failed')
             id = self.spi_reg_read( self.fdata0_off )
         else:
             return False

--- a/chipsec/hal/spi_descriptor.py
+++ b/chipsec/hal/spi_descriptor.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -83,12 +83,12 @@ def get_spi_regions( fd ):
 
 def parse_spi_flash_descriptor( cs, rom ):
     if not (isinstance(rom, str) or isinstance(rom, bytes)):
-        logger().error('Invalid fd object type {}'.format(type(rom)))
+        logger().log_error('Invalid fd object type {}'.format(type(rom)))
         return
 
     pos = rom.find( SPI_FLASH_DESCRIPTOR_SIGNATURE )
     if (-1 == pos or pos < 0x10):
-        logger().error( 'Valid SPI flash descriptor is not found (should have signature {:08X})'.format(struct.unpack('=I', SPI_FLASH_DESCRIPTOR_SIGNATURE)[0]) )
+        logger().log_error('Valid SPI flash descriptor is not found (should have signature {:08X})'.format(struct.unpack('=I', SPI_FLASH_DESCRIPTOR_SIGNATURE)[0]))
         return None
 
     fd_off = pos - 0x10

--- a/chipsec/hal/spi_uefi.py
+++ b/chipsec/hal/spi_uefi.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -499,7 +499,7 @@ def decode_uefi_region(_uefi, pth, fname, fwtype, filetype=[]):
         fwtype = identify_EFI_NVRAM( region_data )
         if fwtype is None: return
     elif fwtype not in fw_types:
-        if logger().HAL: logger().error( "unrecognized NVRAM type {}".format(fwtype) )
+        if logger().HAL: logger().log_error("unrecognized NVRAM type {}".format(fwtype))
         return
     nvram_fname = os.path.join( bios_pth, ('nvram_{}'.format(fwtype)) )
     logger().set_log_file( (nvram_fname + '.nvram.lst') )

--- a/chipsec/hal/ucode.py
+++ b/chipsec/hal/ucode.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -103,7 +103,7 @@ class Ucode:
 
     def update_ucode_all_cpus(self, ucode_file ):
         if not ( os.path.exists(ucode_file) and os.path.isfile(ucode_file) ):
-            logger().error( "Ucode file not found: '{:.256}'".format(ucode_file) )
+            logger().log_error("Ucode file not found: '{:.256}'".format(ucode_file))
             return False
         ucode_buf = read_ucode_file( ucode_file )
         if (ucode_buf is not None) and (len(ucode_buf) > 0):
@@ -113,7 +113,7 @@ class Ucode:
 
     def update_ucode(self, cpu_thread_id, ucode_file ):
         if not ( os.path.exists(ucode_file) and os.path.isfile(ucode_file) ):
-            logger().error( "Ucode file not found: '{:.256}'".format(ucode_file) )
+            logger().log_error("Ucode file not found: '{:.256}'".format(ucode_file))
             return False
         _ucode_buf = read_ucode_file( ucode_file )
         return self.load_ucode_update( cpu_thread_id, _ucode_buf )

--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -302,7 +302,7 @@ class UEFI(hal_base.HALBase):
 
     def find_EFI_variable_store( self, rom_buffer ):
         if ( rom_buffer is None ):
-            logger().error( 'rom_buffer is None' )
+            logger().log_error('rom_buffer is None')
             return None
 
         rom = rom_buffer
@@ -313,7 +313,7 @@ class UEFI(hal_base.HALBase):
         if uefi_platform.EFI_VAR_DICT[ self._FWType ]['func_getnvstore']:
             (offset, size, nvram_header) = uefi_platform.EFI_VAR_DICT[ self._FWType ]['func_getnvstore']( rom )
             if (-1 == offset):
-                logger().error( "'func_getnvstore' is defined but could not find EFI NVRAM. Exiting.." )
+                logger().log_error("'func_getnvstore' is defined but could not find EFI NVRAM. Exiting..")
                 return None
         else:
             logger().log( "[uefi] 'func_getnvstore' is not defined in EFI_VAR_DICT. Assuming start offset 0.." )
@@ -334,7 +334,7 @@ NVRAM: EFI Variable Store
     # @TODO: Do not use, will be removed
     def read_EFI_variables( self, efi_var_store, authvars ):
         if ( efi_var_store is None ):
-            logger().error( 'efi_var_store is None' )
+            logger().log_error('efi_var_store is None')
             return None
         variables = uefi_platform.EFI_VAR_DICT[ self._FWType ]['func_getefivariables']( efi_var_store )
         if logger().UTIL_TRACE: print_sorted_EFI_variables( variables )
@@ -346,7 +346,7 @@ NVRAM: EFI Variable Store
             logger().log( "[uefi] Using FW type (NVRAM format): {}".format(_fw_type) )
             self.set_FWType( _fw_type )
         else:
-            logger().error( "Unrecognized FW type (NVRAM format) '{}'..".format(_fw_type) )
+            logger().log_error("Unrecognized FW type (NVRAM format) '{}'..".format(_fw_type))
             return False
 
         logger().log( "[uefi] Searching for NVRAM in the binary.." )
@@ -361,7 +361,7 @@ NVRAM: EFI Variable Store
             efi_vars = uefi_platform.EFI_VAR_DICT[ self._FWType ]['func_getefivariables']( efi_vars_store )
             decode_EFI_variables( efi_vars, nvram_pth )
         else:
-            logger().error( "Did not find NVRAM" )
+            logger().log_error("Did not find NVRAM")
             return False
 
         return True
@@ -375,7 +375,7 @@ NVRAM: EFI Variable Store
             else:
                 return None
         else:
-            logger().error( 'Unknown EFI compression type 0x{:X}'.format(compression_type) )
+            logger().log_error('Unknown EFI compression type 0x{:X}'.format(compression_type))
             return None
 
     def compress_EFI_binary( self, uncompressed_name, compressed_name, compression_type ):
@@ -386,7 +386,7 @@ NVRAM: EFI Variable Store
             else:
                 return None
         else:
-            logger().error( 'Unknown EFI compression type 0x{:X}'.format(compression_type) )
+            logger().log_error('Unknown EFI compression type 0x{:X}'.format(compression_type))
             return None
 
     ######################################################################
@@ -405,7 +405,7 @@ NVRAM: EFI Variable Store
 
         efivars = self.list_EFI_variables()
         if efivars is None:
-            logger().error( 'Could not enumerate UEFI variables at runtime' )
+            logger().log_error('Could not enumerate UEFI variables at runtime')
             return (found, BootScript_addresses)
         if logger().HAL: logger().log( "[uefi] searching for EFI variable(s): " + str(S3_BOOTSCRIPT_VARIABLES) )
 
@@ -421,11 +421,11 @@ NVRAM: EFI Variable Store
                 if   4 == varsz: AcpiGlobalAddr_fmt = '<L'
                 elif 8 == varsz: AcpiGlobalAddr_fmt = '<Q'
                 else:
-                    logger().error( "Unrecognized format of '{}' UEFI variable (data size = 0x{:X})".format(efivar_name, varsz) )
+                    logger().log_error("Unrecognized format of '{}' UEFI variable (data size = 0x{:X})".format(efivar_name, varsz))
                     break
                 AcpiGlobalAddr = struct.unpack_from( AcpiGlobalAddr_fmt, data )[0]
                 if 0 == AcpiGlobalAddr:
-                    logger().error( "Pointer to ACPI Global Data structure in {} variable is 0".format(efivar_name) )
+                    logger().log_error("Pointer to ACPI Global Data structure in {} variable is 0".format(efivar_name))
                     break
                 if logger().HAL: logger().log( "[uefi] Pointer to ACPI Global Data structure: 0x{:016X}".format( AcpiGlobalAddr ) )
                 if logger().HAL: logger().log( "[uefi] Decoding ACPI Global Data structure.." )
@@ -435,7 +435,7 @@ NVRAM: EFI Variable Store
                     print_buffer( bytestostring(AcpiVariableSet) )
                 AcpiVariableSet_fmt = '<6Q'
                 #if len(AcpiVariableSet) < struct.calcsize(AcpiVariableSet_fmt):
-                #    logger().error( 'Unrecognized format of AcpiVariableSet structure' )
+                #    logger().log_error( 'Unrecognized format of AcpiVariableSet structure' )
                 #    return (False,0)
                 AcpiReservedMemoryBase, AcpiReservedMemorySize, S3ReservedLowMemoryBase, AcpiBootScriptTable, RuntimeScriptTableBase, AcpiFacsTable = struct.unpack_from( AcpiVariableSet_fmt, AcpiVariableSet )
                 if logger().HAL: logger().log( '[uefi] ACPI Boot-Script table base = 0x{:016X}'.format(AcpiBootScriptTable) )
@@ -498,7 +498,7 @@ NVRAM: EFI Variable Store
 
     def set_EFI_variable_from_file( self, name, guid, filename, datasize=None, attrs=None ):
         if filename is None:
-            logger().error( 'File with EFI variable is not specified' )
+            logger().log_error('File with EFI variable is not specified')
             return False
         var = read_file( filename )
         return self.set_EFI_variable( name, guid, var, datasize, attrs )

--- a/chipsec/hal/uefi_common.py
+++ b/chipsec/hal/uefi_common.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -335,8 +335,8 @@ def parse_sb_db(db, decode_dir):
             err_str = "Wrong SignatureSize for {} type: 0x{:X}." .format(SignatureType, SignatureSize)
             if (sig_size > 0): err_str = err_str + " Must be 0x{:X}.".format(sig_size)
             else:              err_str = err_str + " Must be >= 0x10."
-            logger().error( err_str )
-            logger().error('Skipping signature decode for this list.')
+            logger().log_error(err_str)
+            logger().log_error('Skipping signature decode for this list.')
         dof = dof + SignatureListSize
 
     return entries
@@ -388,7 +388,7 @@ def parse_auth_var(db, decode_dir):
         return entries
     expected_size = struct.unpack(AUTH_CERT_DB_LIST_HEAD, db[dof:dof +AUTH_CERT_DB_LIST_HEAD_size])[0]
     if db_size != expected_size:
-        logger().error("Expected size of cert list did not match actual size.")
+        logger().log_error("Expected size of cert list did not match actual size.")
         return entries
     dof += AUTH_CERT_DB_LIST_HEAD_size
 

--- a/chipsec/hal/uefi_platform.py
+++ b/chipsec/hal/uefi_platform.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -1201,7 +1201,7 @@ def parse_s3bootscript_entry( s3bootscript_type, script, off, log_script=False )
         entry_data = script[ off: off + entry_length ]
 
         if entry_length > MAX_S3_BOOTSCRIPT_ENTRY_LENGTH:
-            logger().error( '[uefi] Unrecognized S3 boot script format (entry length = 0x{:X})'.format(entry_length) )
+            logger().log_error('[uefi] Unrecognized S3 boot script format (entry length = 0x{:X})'.format(entry_length))
             return (0, None)
 
         s3script_entry = S3BOOTSCRIPT_ENTRY( s3bootscript_type, entry_index, off, entry_length, entry_data )
@@ -1222,7 +1222,7 @@ def parse_s3bootscript_entry( s3bootscript_type, script, off, log_script=False )
         entry_data = script[ off + hdr_length: off + entry_length ]
 
         if entry_length > MAX_S3_BOOTSCRIPT_ENTRY_LENGTH:
-            logger().error( '[uefi] Unrecognized S3 boot script format (entry length = 0x{:X})'.format(entry_length) )
+            logger().log_error('[uefi] Unrecognized S3 boot script format (entry length = 0x{:X})'.format(entry_length))
             return (0, None)
 
         s3script_entry                = S3BOOTSCRIPT_ENTRY( s3bootscript_type, entry_index, off, entry_length, entry_data )

--- a/chipsec/hal/vmm.py
+++ b/chipsec/hal/vmm.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -93,7 +93,7 @@ class VMM:
         logger().set_log_file( pt_fname )
         paging_ept.read_pt_and_show_status( pt_fname, 'EPT', eptp )
         logger().set_log_file( _orig_logname )
-        if paging_ept.failure: logger().error( 'could not dump EPT page tables' )
+        if paging_ept.failure: logger().log_error('could not dump EPT page tables')
 
 
 ################################################################################


### PR DESCRIPTION
Replace deprecated `error()` with `log_error()`

Signed-off-by: Frinzell, Aaron <aaron.frinzell@intel.com>