### PR TITLE
Update logger.error() in helper files

### DIFF
--- a/chipsec/helper/dal/dalhelper.py
+++ b/chipsec/helper/dal/dalhelper.py
@@ -282,7 +282,7 @@ class DALHelper(Helper):
         return True
 
     def load_ucode_update( self, core_id, ucode_update_buf ):
-        if logger().DEBUG: logger().error( "[DAL] API load_ucode_update() is not supported yet" )
+        if logger().DEBUG: logger().log_error("[DAL] API load_ucode_update() is not supported yet")
         return False
 
     def get_threads_count( self ):
@@ -300,7 +300,7 @@ class DALHelper(Helper):
         return (reax, rebx, recx, redx)
 
     def get_descriptor_table( self, cpu_thread_id, desc_table_code ):
-        if logger().DEBUG: logger().error( '[DAL] API get_descriptor_table() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API get_descriptor_table() is not supported')
         return None
 
     #
@@ -313,31 +313,31 @@ class DALHelper(Helper):
     # Placeholders for EFI Variable API
 
     def delete_EFI_variable(self, name, guid):
-        if logger().DEBUG: logger().error( '[DAL] API delete_EFI_variable() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API delete_EFI_variable() is not supported')
         return None
     def native_delete_EFI_variable(self, name, guid):
-        if logger().DEBUG: logger().error( '[DAL] API native_delete_EFI_variable() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API native_delete_EFI_variable() is not supported')
         return None
 
     def list_EFI_variables(self):
-        if logger().DEBUG: logger().error( '[DAL] API list_EFI_variables() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API list_EFI_variables() is not supported')
         return None
     def native_list_EFI_variables(self):
-        if logger().DEBUG: logger().error( '[DAL] API native_list_EFI_variables() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API native_list_EFI_variables() is not supported')
         return None
 
     def get_EFI_variable(self, name, guid, attrs=None):
-        if logger().DEBUG: logger().error( '[DAL] API get_EFI_variable() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API get_EFI_variable() is not supported')
         return None
     def native_get_EFI_variable(self, name, guid, attrs=None):
-        if logger().DEBUG: logger().error( '[DAL] API native_get_EFI_variable() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API native_get_EFI_variable() is not supported')
         return None
 
     def set_EFI_variable(self, name, guid, data, datasize, attrs=None):
-        if logger().DEBUG: logger().error( '[DAL] API set_EFI_variable() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API set_EFI_variable() is not supported')
         return None
     def native_set_EFI_variable(self, name, guid, data, datasize, attrs=None):
-        if logger().DEBUG: logger().error( '[DAL] API native_set_EFI_variable() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API native_set_EFI_variable() is not supported')
         return None
 
     #
@@ -376,52 +376,52 @@ class DALHelper(Helper):
     # Interrupts
     #
     def send_sw_smi( self, cpu_thread_id, SMI_code_data, _rax, _rbx, _rcx, _rdx, _rsi, _rdi ):
-        if logger().DEBUG: logger().error( '[DAL] API send_sw_smi() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API send_sw_smi() is not supported')
         return None
 
     def set_affinity( self, value ):
-        if logger().DEBUG: logger().error( '[DAL] API set_affinity() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API set_affinity() is not supported')
         return 0
 
     def get_affinity( self ):
-        if logger().DEBUG: logger().error( '[DAL] API get_affinity() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API get_affinity() is not supported')
         return 0
 
     #
     # ACPI tables access
     #
     def get_ACPI_SDT( self ):
-        if logger().DEBUG: logger().error( '[DAL] API get_ACPI_SDT() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API get_ACPI_SDT() is not supported')
         return None, None
 
     def native_get_ACPI_table( self, table_name ):
-        if logger().DEBUG: logger().error( '[DAL] API native_get_ACPI_table() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API native_get_ACPI_table() is not supported')
         return None
 
     def get_ACPI_table( self, table_name ):
-        if logger().DEBUG: logger().error( '[DAL] API get_ACPI_table() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API get_ACPI_table() is not supported')
         return None
 
     #
     # IOSF Message Bus access
     #
     def msgbus_send_read_message( self, mcr, mcrx ):
-        if logger().DEBUG: logger().error( '[DAL] API msgbus_send_read_message() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API msgbus_send_read_message() is not supported')
         return None
 
     def msgbus_send_write_message( self, mcr, mcrx, mdr ):
-        if logger().DEBUG: logger().error( '[DAL] API msgbus_send_write_message() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API msgbus_send_write_message() is not supported')
         return None
 
     def msgbus_send_message( self, mcr, mcrx, mdr=None ):
-        if logger().DEBUG: logger().error( '[DAL] API msgbus_send_message() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API msgbus_send_message() is not supported')
         return None
 
     #
     # File system
     #
     def get_tool_info( self, tool_type ):
-        if logger().DEBUG: logger().error( '[DAL] API get_tool_info() is not supported' )
+        if logger().DEBUG: logger().log_error('[DAL] API get_tool_info() is not supported')
         return None, None
 
 def get_helper():
@@ -433,4 +433,4 @@ if __name__ == '__main__':
 
     except DALHelperError as msg:
         if logger().DEBUG:
-            logger().error(msg)
+            logger().log_error(msg)

--- a/chipsec/helper/file/filehelper.py
+++ b/chipsec/helper/file/filehelper.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2018-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2018-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -65,12 +65,12 @@ class FileCmds:
     def Load(self):
         file_data = chipsec.file.read_file(self.filename)
         if file_data == 0:
-            logger().error("Unable to open JSON file: {}".format(self.filename))
+            logger().log_error("Unable to open JSON file: {}".format(self.filename))
             raise OsHelperError("Unable to open JSON file: {}".format(self.filename), 1)
         try:
             self.data = json.loads(file_data)
         except:
-            logger().error("Unable to load JSON file: {}".format(self.filename))
+            logger().log_error("Unable to load JSON file: {}".format(self.filename))
             raise OsHelperError("Unable to open JSON file: {}".format(self.filename), 1)
 
     def getElement(self, cmd, args):
@@ -82,7 +82,7 @@ class FileCmds:
         if str(cmd) in self.data:
             if margs in self.data[str(cmd)]:
                 return self.data[cmd][margs].pop()
-        logger().error("Missing entry for {} {}".format(str(cmd), margs))
+        logger().log_error("Missing entry for {} {}".format(str(cmd), margs))
 
 
 class FileHelper(Helper):

--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -189,7 +189,7 @@ class LinuxHelper(Helper):
             if logger().DEBUG:
                 logger().log("Module {} loaded successfully".format(self.DEVICE_NAME))
         else:
-            logger().error( "Fail to load module: {}".format(driver_path) )
+            logger().log_error("Fail to load module: {}".format(driver_path))
         self.driverpath = driver_path
 
     def unload_chipsec_module(self):
@@ -387,7 +387,7 @@ class LinuxHelper(Helper):
             os.lseek(self.dev_mem, addr, os.SEEK_SET)
             written = os.write(self.dev_mem, newval)
             if written != length:
-                if logger().DEBUG: logger().error("Cannot write {} to memory {:016X} (wrote {:d} of {:d})".format(newval, addr, written, length))
+                if logger().DEBUG: logger().log_error("Cannot write {} to memory {:016X} (wrote {:d} of {:d})".format(newval, addr, written, length))
 
     def read_phys_mem(self, phys_address_hi, phys_address_lo, length):
         addr = (phys_address_hi << 32) | phys_address_lo
@@ -409,13 +409,13 @@ class LinuxHelper(Helper):
             pa = struct.unpack(self._pack, out_buf)[0]
         except IOError as err:
             if logger().DEBUG:
-                logger().error("[helper] Error in va2pa: getting PA for VA 0x{:016X} failed with IOError: {}".format(va, err.strerror))
+                logger().log_error("[helper] Error in va2pa: getting PA for VA 0x{:016X} failed with IOError: {}".format(va, err.strerror))
             return (None, err.errno)
 
         #Check if PA > max physical address
         max_pa = self.cpuid( 0x80000008, 0x0 )[0] & 0xFF
         if pa > 1<<max_pa:
-            if logger().DEBUG: logger().error("[helper] Error in va2pa: PA higher that max physical address: VA (0x{:016X}) -> PA (0x{:016X})".format(va, pa))
+            if logger().DEBUG: logger().log_error("[helper] Error in va2pa: PA higher that max physical address: VA (0x{:016X}) -> PA (0x{:016X})".format(va, pa))
             error_code = 1
         return (pa, error_code)
 
@@ -426,7 +426,7 @@ class LinuxHelper(Helper):
         try:
             ret = self.ioctl(IOCTL_RDPCI, d)
         except IOError:
-            if logger().DEBUG: logger().error("IOError\n")
+            if logger().DEBUG: logger().log_error("IOError\n")
             return None
         x = struct.unpack("5" +self._pack, ret)
         return x[4]
@@ -460,7 +460,7 @@ class LinuxHelper(Helper):
         try:
             ret = self.ioctl(IOCTL_WRPCI, d)
         except IOError:
-            if logger().DEBUG: logger().error("IOError\n")
+            if logger().DEBUG: logger().log_error("IOError\n")
             return None
         x = struct.unpack("5" +self._pack, ret)
         return x[4]
@@ -493,7 +493,7 @@ class LinuxHelper(Helper):
         try:
             out_buf = self.ioctl(IOCTL_LOAD_UCODE_PATCH, in_buf_final)
         except IOError:
-            if logger().DEBUG: logger().error("IOError IOCTL Load Patch\n")
+            if logger().DEBUG: logger().log_error("IOError IOCTL Load Patch\n")
             return None
 
         return True
@@ -511,7 +511,7 @@ class LinuxHelper(Helper):
             else:
                 value = struct.unpack("3" +self._pack, out_buf)[2] & 0xffffffff
         except:
-            if logger().DEBUG: logger().error( "DeviceIoControl did not return value of proper size {:x} (value = '{}')".format(size, out_buf) )
+            if logger().DEBUG: logger().log_error( "DeviceIoControl did not return value of proper size {:x} (value = '{}')".format(size, out_buf) )
 
         return value
 
@@ -540,7 +540,7 @@ class LinuxHelper(Helper):
             elif 4 == size: fmt = 'I'
             written = os.write(self.dev_port, struct.pack(fmt, newval))
             if written != size:
-                if logger().DEBUG: logger().error("Cannot write {} to port {:x} (wrote {:d} of {:d})".format(newval, io_port, written, size))
+                if logger().DEBUG: logger().log_error("Cannot write {} to port {:x} (wrote {:d} of {:d})".format(newval, io_port, written, size))
 
     def read_cr(self, cpu_thread_id, cr_number):
         self.set_affinity(cpu_thread_id)
@@ -581,7 +581,7 @@ class LinuxHelper(Helper):
             buf = struct.pack( "2I", eax, edx)
             written = os.write(self.dev_msr[thread_id], buf)
             if written != 8:
-                if logger().DEBUG: logger().error("Cannot write {:8X} to MSR {:x}".format(buf, msr_addr))
+                if logger().DEBUG: logger().log_error("Cannot write {:8X} to MSR {:x}".format(buf, msr_addr))
 
     def get_descriptor_table(self, cpu_thread_id, desc_table_code  ):
         self.set_affinity(cpu_thread_id)
@@ -627,7 +627,7 @@ class LinuxHelper(Helper):
             if not region:
                 self.native_map_io_space(bar_base, bar_size, 0)
                 region = self.memory_mapping(bar_base, bar_size)
-                if not region: logger().error("Unable to map region {:08x}".format(bar_base))
+                if not region: logger().log_error("Unable to map region {:08x}".format(bar_base))
 
             # Create memoryview into mmap'ed region in dword granularity
             region_mv = memoryview(region)
@@ -649,7 +649,7 @@ class LinuxHelper(Helper):
             if not region:
                 self.native_map_io_space(bar_base, bar_size, 0)
                 region = self.memory_mapping(bar_base, bar_size)
-                if not region: logger().error("Unable to map region {:08x}".format(bar_base))
+                if not region: logger().log_error("Unable to map region {:08x}".format(bar_base))
 
             # Create memoryview into mmap'ed region in dword granularity
             region_mv = memoryview(region)
@@ -785,17 +785,17 @@ class LinuxHelper(Helper):
             try:
                 stat = self.ioctl(IOCTL_GET_EFIVAR, buffer)
             except IOError:
-                if logger().DEBUG: logger().error("IOError IOCTL GetUEFIvar\n")
+                if logger().DEBUG: logger().log_error("IOError IOCTL GetUEFIvar\n")
                 return (off, buf, hdr, None, guid, attr)
             new_size, status = struct.unpack( "2I", buffer[:8])
 
         if (new_size > data_size):
-            if logger().DEBUG: logger().error( "Incorrect size returned from driver" )
+            if logger().DEBUG: logger().log_error("Incorrect size returned from driver")
             return (off, buf, hdr, None, guid, attr)
 
         if (status > 0):
             if logger().DEBUG:
-                logger().error( "Reading variable (GET_EFIVAR) did not succeed: {} ({:d})".format(status_dict.get(status, 'UNKNOWN'), status))
+                logger().log_error("Reading variable (GET_EFIVAR) did not succeed: {} ({:d})".format(status_dict.get(status, 'UNKNOWN'), status))
             data = ""
             guid = 0
             attr = 0
@@ -822,7 +822,7 @@ class LinuxHelper(Helper):
             else:
                 return None
         except Exception:
-            if logger().DEBUG: logger().error('Failed to read /sys/firmware/efi/[vars|efivars]. Folder does not exist')
+            if logger().DEBUG: logger().log_error('Failed to read /sys/firmware/efi/[vars|efivars]. Folder does not exist')
             return None
         variables = dict()
         for v in varlist:
@@ -864,7 +864,7 @@ class LinuxHelper(Helper):
 
         if (status != 0):
             if logger().DEBUG:
-                logger().error("Setting EFI (SET_EFIVAR) variable did not succeed: '{}' ({:d})".format(status_dict.get(status, 'UNKNOWN'), status))
+                logger().log_error("Setting EFI (SET_EFIVAR) variable did not succeed: '{}' ({:d})".format(status_dict.get(status, 'UNKNOWN'), status))
         else:
             os.system('umount /sys/firmware/efi/efivars; mount -t efivarfs efivarfs /sys/firmware/efi/efivars')
         return status
@@ -907,7 +907,7 @@ class LinuxHelper(Helper):
             f.close()
 
         except Exception as err:
-            if logger().DEBUG: logger().error('Failed to read files under /sys/firmware/efi/vars/' +filename)
+            if logger().DEBUG: logger().log_error('Failed to read files under /sys/firmware/efi/vars/' + filename)
             data = ""
             guid = 0
             attr = 0
@@ -920,7 +920,7 @@ class LinuxHelper(Helper):
         try:
             varlist = os.listdir('/sys/firmware/efi/vars')
         except Exception:
-            if logger().DEBUG: logger().error('Failed to read /sys/firmware/efi/vars. Folder does not exist')
+            if logger().DEBUG: logger().log_error('Failed to read /sys/firmware/efi/vars. Folder does not exist')
         variables = dict()
         for v in varlist:
             name = v[:-37]
@@ -954,7 +954,7 @@ class LinuxHelper(Helper):
                     f.write(value)
                     ret = 0 # EFI_SUCCESS
                 except Exception as err:
-                    if logger().DEBUG: logger().error('Failed to write EFI variable. {}'.format(err))
+                    if logger().DEBUG: logger().log_error('Failed to write EFI variable. {}'.format(err))
         return ret
 
 
@@ -976,7 +976,7 @@ class LinuxHelper(Helper):
             f.close()
 
         except Exception as err:
-            if logger().DEBUG: logger().error('Failed to read /sys/firmware/efi/efivars/' +filename)
+            if logger().DEBUG: logger().log_error('Failed to read /sys/firmware/efi/efivars/' +filename)
             data = ""
             guid = 0
             attr = 0
@@ -990,7 +990,7 @@ class LinuxHelper(Helper):
         try:
             varlist = os.listdir('/sys/firmware/efi/efivars')
         except Exception:
-            if logger().DEBUG: logger().error('Failed to read /sys/firmware/efi/efivars. Folder does not exist')
+            if logger().DEBUG: logger().log_error('Failed to read /sys/firmware/efi/efivars. Folder does not exist')
             return None
         variables = dict()
         for v in varlist:
@@ -1014,7 +1014,7 @@ class LinuxHelper(Helper):
             f.close()
 
         except Exception as err:
-            if logger().DEBUG: logger().error('Failed to read /sys/firmware/efi/efivars/' +filename)
+            if logger().DEBUG: logger().log_error('Failed to read /sys/firmware/efi/efivars/' +filename)
             data = ""
 
         finally:
@@ -1043,13 +1043,13 @@ class LinuxHelper(Helper):
                 f.close()
                 ret = 0 # EFI_SUCCESS
             except Exception as err:
-                if logger().DEBUG: logger().error('Failed to write EFI variable. {}'.format(err))
+                if logger().DEBUG: logger().log_error('Failed to write EFI variable. {}'.format(err))
         else:
             try:
                 os.remove(path)
                 ret = 0 # EFI_SUCCESS
             except Exception as err:
-                if logger().DEBUG: logger().error('Failed to delete EFI variable. {}'.format(err))
+                if logger().DEBUG: logger().log_error('Failed to delete EFI variable. {}'.format(err))
 
         return ret
 
@@ -1143,7 +1143,7 @@ class LinuxHelper(Helper):
         encode_str += FileName
         data = subprocess.check_output(encode_str, shell=True)
         if not data == 0 and logger().VERBOSE:
-            logger().error("Cannot compress file({})".format(FileName))
+            logger().log_error("Cannot compress file({})".format(FileName))
             return False
         return True
 
@@ -1174,7 +1174,7 @@ class LinuxHelper(Helper):
         decode_str += CompressedFileName
         data = subprocess.call(decode_str, shell=True)
         if not data == 0 and logger().VERBOSE:
-            logger().error("Cannot decompress file({})".format(CompressedFileName))
+            logger().log_error("Cannot decompress file({})".format(CompressedFileName))
             return False
         return True
 

--- a/chipsec/helper/oshelper.py
+++ b/chipsec/helper/oshelper.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -555,7 +555,7 @@ def helper():
             _helper  = OsHelper()
         except BaseException as msg:
             if logger().DEBUG:
-                logger().error( str(msg) )
+                logger().log_error(str(msg))
                 logger().log_bad(traceback.format_exc())
             raise
     return _helper

--- a/chipsec/helper/osx/osxhelper.py
+++ b/chipsec/helper/osx/osxhelper.py
@@ -105,7 +105,7 @@ class OSXHelper(Helper):
             if logger().DEBUG:
                 logger().log("Module {} loaded successfully".format(self.DRIVER_NAME))
         else:
-            logger().error("Failed to load the module {}".format(self.DRIVER_NAME))
+            logger().log_error("Failed to load the module {}".format(self.DRIVER_NAME))
         self.driverpath = driver_path
 
     def create(self, start_driver):
@@ -183,7 +183,7 @@ class OSXHelper(Helper):
         try:
             ret = self.ioctl(IOCTL_RDPCI, data)
         except IOError:
-            if logger().DEBUG: logger().error("IOError")
+            if logger().DEBUG: logger().log_error("IOError")
             return None
         x = struct.unpack(_pci_msg_t_fmt, ret)
         return x[5]
@@ -194,7 +194,7 @@ class OSXHelper(Helper):
         try:
             ret = self.ioctl(IOCTL_WRPCI, data)
         except IOError:
-            if logger().DEBUG: logger().error("IOError")
+            if logger().DEBUG: logger().log_error("IOError")
 
     def read_mmio_reg(self, phys_address, size):
         data = struct.pack(_mmio_msg_t_fmt, phys_address, 0, size)
@@ -255,7 +255,7 @@ class OSXHelper(Helper):
         encode_str += FileName
         data = subprocess.call(encode_str, shell=True)
         if not data == 0 and logger().VERBOSE:
-            logger().error("Cannot decompress file({})".format(FileName))
+            logger().log_error("Cannot decompress file({})".format(FileName))
             return False
         return True
 
@@ -286,7 +286,7 @@ class OSXHelper(Helper):
         decode_str += CompressedFileName
         data = subprocess.call(decode_str, shell=True)
         if not data == 0 and logger().VERBOSE:
-            logger().error("Cannot decompress file({})".format(CompressedFileName))
+            logger().log_error("Cannot decompress file({})".format(CompressedFileName))
             return False
         return True
 
@@ -347,7 +347,7 @@ class OSXHelper(Helper):
             else:
                 value = struct.unpack(_io_msg_t_fmt, out_buf)[2] & 0xffffffff
         except:
-            if logger().DEBUG: logger().error("DeviceIoControl did not return value of proper size {:x} (value = '{}')".format(size, out_buf))
+            if logger().DEBUG: logger().log_error("DeviceIoControl did not return value of proper size {:x} (value = '{}')".format(size, out_buf))
         return value
 
     def write_io_port(self, io_port, value, size):

--- a/chipsec/helper/win/win32helper.py
+++ b/chipsec/helper/win/win32helper.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -231,7 +231,7 @@ def getEFIvariables_NtEnumerateSystemEnvironmentValuesEx2( nvram_buf ):
 def _handle_winerror(fn, msg, hr):
     _handle_error( ("{} failed: {} ({:d})".format(fn, msg, hr)), hr )
 def _handle_error( err, hr=0 ):
-    if logger().DEBUG: logger().error( err )
+    if logger().DEBUG: logger().log_error(err)
     raise OsHelperError( err, hr )
 
 class Win32Helper(Helper):
@@ -453,7 +453,7 @@ class Win32Helper(Helper):
             self.driver_handle = None
             win32serviceutil.StopService( SERVICE_NAME )
         except pywintypes.error as err:
-            if logger().DEBUG: logger().error( "StopService failed: {} ({:d})".format(err.args[2], err.args[0]) )
+            if logger().DEBUG: logger().log_error("StopService failed: {} ({:d})".format(err.args[2], err.args[0]))
             return False
         finally:
             self.driver_loaded = False
@@ -521,7 +521,7 @@ class Win32Helper(Helper):
             err_status = _err.args[0] + 0x100000000
             if STATUS_PRIVILEGED_INSTRUCTION == err_status:
                 err_msg = "HW Access Violation: DeviceIoControl returned STATUS_PRIVILEGED_INSTRUCTION (0x{:X})".format(err_status)
-                if logger().DEBUG: logger().error( err_msg )
+                if logger().DEBUG: logger().log_error(err_msg)
                 raise HWAccessViolationError( err_msg, err_status )
             else:
                 _handle_error( "HW Access Error: DeviceIoControl returned status 0x{:X} ({})".format(err_status, _err.args[2]), err_status )
@@ -737,7 +737,7 @@ class Win32Helper(Helper):
                 length = self.GetFirmwareEnvironmentVariableEx( name, "{{{}}}".format(guid), efi_var, EFI_VAR_MAX_BUFFER_SIZE, pattrs )
         if (0 == length) or (efi_var is None):
             status = kernel32.GetLastError()
-            if logger().DEBUG: logger().error( 'GetFirmwareEnvironmentVariable[Ex] returned error: {}'.format(WinError()) )
+            if logger().DEBUG: logger().log_error('GetFirmwareEnvironmentVariable[Ex] returned error: {}'.format(WinError()))
             efi_var_data = None
             #raise WinError(errno.EIO,"Unable to get EFI variable")
         else:
@@ -768,7 +768,7 @@ class Win32Helper(Helper):
             status = 0 # EFI_SUCCESS
         else:
             status = kernel32.GetLastError()
-            if logger().DEBUG: logger().error( 'SetFirmwareEnvironmentVariable[Ex] returned error: {}'.format(WinError()) )
+            if logger().DEBUG: logger().log_error('SetFirmwareEnvironmentVariable[Ex] returned error: {}'.format(WinError()))
             #raise WinError(errno.EIO, "Unable to set EFI variable")
         return status
 
@@ -797,8 +797,8 @@ class Win32Helper(Helper):
                 return None
             else:
                 if logger().DEBUG:
-                    logger().error( 'NtEnumerateSystemEnvironmentValuesEx failed (GetLastError = 0x{:X})'.format(lasterror) )
-                    logger().error( '*** NTSTATUS: {:08X}'.format(status) )
+                    logger().log_error('NtEnumerateSystemEnvironmentValuesEx failed (GetLastError = 0x{:X})'.format(lasterror))
+                    logger().log_error('*** NTSTATUS: {:08X}'.format(status))
                 raise WinError()
         if logger().DEBUG: logger().log( '[helper] len(efi_vars) = 0x{:X} (should be 0x20000)'.format(len(efi_vars)) )
         return getEFIvariables_NtEnumerateSystemEnvironmentValuesEx2( efi_vars )
@@ -876,7 +876,7 @@ class Win32Helper(Helper):
         retVal = self.GetSystemFirmwareTbl( FirmwareTableProviderSignature_ACPI, tbl, tBuffer, table_size )
         if retVal == 0:
             if logger().DEBUG:
-                logger().error( 'GetSystemFirmwareTable({}) returned error: {}'.format(table_name, WinError()) )
+                logger().log_error('GetSystemFirmwareTable({}) returned error: {}'.format(table_name, WinError()))
             return None
         if retVal > table_size:
             table_size = retVal
@@ -895,15 +895,15 @@ class Win32Helper(Helper):
     #
 
     def msgbus_send_read_message( self, mcr, mcrx ):
-        if logger().DEBUG: logger().error( "[helper] Message Bus is not supported yet" )
+        if logger().DEBUG: logger().log_error("[helper] Message Bus is not supported yet")
         return None
 
     def msgbus_send_write_message( self, mcr, mcrx, mdr ):
-        if logger().DEBUG: logger().error( "[helper] Message Bus is not supported yet" )
+        if logger().DEBUG: logger().log_error("[helper] Message Bus is not supported yet")
         return None
 
     def msgbus_send_message( self, mcr, mcrx, mdr=None ):
-        if logger().DEBUG: logger().error( "[helper] Message Bus is not supported yet" )
+        if logger().DEBUG: logger().log_error("[helper] Message Bus is not supported yet")
         return None
 
     def rotate_list(self, list, n):
@@ -952,7 +952,7 @@ class Win32Helper(Helper):
         encode_str += FileName
         data = subprocess.call(encode_str, stdout=open(os.devnull, 'wb'), shell=True)
         if not data == 0 and logger().DEBUG:
-            logger().error("Cannot compress file({})".format(FileName))
+            logger().log_error("Cannot compress file({})".format(FileName))
             return False
         return True
 
@@ -984,7 +984,7 @@ class Win32Helper(Helper):
         data = subprocess.call(decode_str, stdout=open(os.devnull, 'wb'), shell=True)
         if not data == 0:
             if logger().DEBUG:
-                logger().error("Cannot decompress file({})".format(CompressedFileName))
+                logger().log_error("Cannot decompress file({})".format(CompressedFileName))
             return False
         return True
 


### PR DESCRIPTION
Replace deprecated `error()` with `log_error()`

Signed-off-by: Frinzell, Aaron <aaron.frinzell@intel.com>