### PR TITLE
Update logger.error() in utilcmd files

### DIFF
--- a/chipsec/utilcmd/acpi_cmd.py
+++ b/chipsec/utilcmd/acpi_cmd.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -70,10 +70,10 @@ class ACPICommand(BaseCommand):
     def acpi_table(self):
         name = self._name[0]
         if not self._file and not self._acpi.is_ACPI_table_present( name ):
-            self.logger.error( "Please specify table name from {}".format(self._acpi.tableList.keys()) )
+            self.logger.log_error("Please specify table name from {}".format(self._acpi.tableList.keys()))
             return
         elif self._file and not path_exists( name ):
-            self.logger.error( "[CHIPSEC] Unable to find file '{}'".format(name) )
+            self.logger.log_error("[CHIPSEC] Unable to find file '{}'".format(name))
             return
         self.logger.log( "[CHIPSEC] reading ACPI table {} '{}'".format('from file' if self._file else '', name) )
         self._acpi.dump_ACPI_table( name, self._file )

--- a/chipsec/utilcmd/chipset_cmd.py
+++ b/chipsec/utilcmd/chipset_cmd.py
@@ -1,23 +1,22 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
-
 
 
 """
@@ -48,6 +47,6 @@ class PlatformCommand(BaseCommand):
             self.cs.print_chipset()
             self.cs.print_pch()
         except UnknownChipsetError as msg:
-            self.logger.error( msg )
+            self.logger.log_error(msg)
 
 commands = { 'platform': PlatformCommand }

--- a/chipsec/utilcmd/deltas_cmd.py
+++ b/chipsec/utilcmd/deltas_cmd.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2018-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2018-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -53,7 +53,7 @@ class DeltasCommand(BaseCommand):
         previous = chipsec.result_deltas.get_json_results(self._prev_log)
         current = chipsec.result_deltas.get_json_results(self._cur_log)
         if previous is None or current is None:
-            self.logger.error('Unable to process JSON log files.')
+            self.logger.log_error('Unable to process JSON log files.')
             return
         deltas = chipsec.result_deltas.compute_result_deltas(previous, current)
 
@@ -64,7 +64,7 @@ class DeltasCommand(BaseCommand):
             elif self._out_format.upper() == 'XML':
                 chipsec.result_deltas.log_deltas_xml(deltas, self._out_name)
             else:
-                self.logger.error('Output log format not supported: {}'.format(self._out_format))
+                self.logger.log_error('Output log format not supported: {}'.format(self._out_format))
 
         # Display the results
         chipsec.result_deltas.display_deltas(deltas, True, start_time)

--- a/chipsec/utilcmd/desc_cmd.py
+++ b/chipsec/utilcmd/desc_cmd.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -120,6 +120,6 @@ class LDTCommand(BaseCommand):
         return True
 
     def run(self):
-        self.logger.error( "[CHIPSEC] ldt not implemented" )
+        self.logger.log_error("[CHIPSEC] ldt not implemented")
 
 commands = { 'idt': IDTCommand, 'gdt': GDTCommand }

--- a/chipsec/utilcmd/igd_cmd.py
+++ b/chipsec/utilcmd/igd_cmd.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -81,8 +81,8 @@ class IgdCommand(BaseCommand):
             try:
                 buffer = bytearray.fromhex( buffer_value )
             except ValueError as e:
-                self.logger.error( "Incorrect <value> specified: '{}'".format(self.file_value) )
-                self.logger.error( str(e) )
+                self.logger.log_error("Incorrect <value> specified: '{}'".format(self.file_value))
+                self.logger.log_error(str(e))
                 return
             self.logger.log( "[CHIPSEC] Read 0x{:X} hex bytes from command-line: {}'".format(len(buffer), buffer_value) )
         else:
@@ -90,7 +90,7 @@ class IgdCommand(BaseCommand):
             self.logger.log( "[CHIPSEC] Read 0x{:X} bytes from file '{}'".format(len(buffer), self.file_value) )
 
         if len(buffer) < self.size:
-            self.logger.error( "Number of bytes read (0x{:X}) is less than the specified <length> (0x{:X})".format(len(buffer), self.size) )
+            self.logger.log_error("Number of bytes read (0x{:X}) is less than the specified <length> (0x{:X})".format(len(buffer), self.size))
             return
 
         self.logger.log( '[CHIPSEC] Writing buffer to memory: PA = 0x{:016X}, len = 0x{:X}..'.format(self.address, self.size) )

--- a/chipsec/utilcmd/iommu_cmd.py
+++ b/chipsec/utilcmd/iommu_cmd.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -92,7 +92,7 @@ class IOMMUCommand(BaseCommand):
             if self.engine in iommu.IOMMU_ENGINES.keys():
                 _iommu_engines = [ self.engine ]
             else:
-                self.logger.error( "IOMMU name {} not recognized. Run 'iommu list' command for supported IOMMU names".format(self.engine) )
+                self.logger.log_error("IOMMU name {} not recognized. Run 'iommu list' command for supported IOMMU names".format(self.engine))
                 return
         else:
             _iommu_engines = iommu.IOMMU_ENGINES.keys()

--- a/chipsec/utilcmd/mem_cmd.py
+++ b/chipsec/utilcmd/mem_cmd.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -153,11 +153,11 @@ class MemCommand(BaseCommand):
             try:
                 width = get_option_width(self.length) if is_option_valid_width(self.length) else int(self.length, 16)
             except ValueError:
-                self.logger.error("[CHIPSEC] Bad length given '{}'".format(self.length))
+                self.logger.log_error("[CHIPSEC] Bad length given '{}'".format(self.length))
                 return
 
         if width not in (0x1,0x2,0x4):
-            self.logger.error( "Must specify <length> argument in 'mem readval' as one of {}".format(CMD_OPTS_WIDTH) )
+            self.logger.log_error("Must specify <length> argument in 'mem readval' as one of {}".format(CMD_OPTS_WIDTH))
             return
         self.logger.log( '[CHIPSEC] Reading {:X}-byte value from PA 0x{:016X}..'.format(width, self.phys_address) )
         if   0x1 == width: value = self.cs.mem.read_physical_mem_byte ( self.phys_address )
@@ -170,7 +170,7 @@ class MemCommand(BaseCommand):
             try:
                 buffer = bytearray.fromhex(self.buffer_data)
             except ValueError:
-                self.logger.error( "Incorrect <value> specified: '{}'".format(self.buffer_data) )
+                self.logger.log_error("Incorrect <value> specified: '{}'".format(self.buffer_data))
                 return
             self.logger.log( "[CHIPSEC] Read 0x{:X} hex bytes from command-line: '{}'".format(len(buffer), self.buffer_data) )
         else:
@@ -178,7 +178,7 @@ class MemCommand(BaseCommand):
             self.logger.log( "[CHIPSEC] Read 0x{:X} bytes from file '{}'".format(len(buffer), self.buffer_data) )
 
         if len(buffer) < self.buffer_length:
-            self.logger.error( "Number of bytes read (0x{:X}) is less than the specified <length> (0x{:X})".format(len(buffer), self.buffer_length) )
+            self.logger.log_error("Number of bytes read (0x{:X}) is less than the specified <length> (0x{:X})".format(len(buffer), self.buffer_length))
             return
 
         self.logger.log( '[CHIPSEC] writing buffer to memory: PA = 0x{:016X}, len = 0x{:X}..'.format(self.phys_address, self.buffer_length) )
@@ -188,11 +188,11 @@ class MemCommand(BaseCommand):
             try:
                 width = get_option_width(self.length) if is_option_valid_width(self.length) else int(self.length, 16)
             except ValueError:
-                self.logger.error( "Must specify <length> argument in 'mem writeval' as one of {}".format(CMD_OPTS_WIDTH) )
+                self.logger.log_error("Must specify <length> argument in 'mem writeval' as one of {}".format(CMD_OPTS_WIDTH))
                 return
 
             if width not in (0x1,0x2,0x4):
-                self.logger.error( "Must specify <length> argument in 'mem writeval' as one of {}".format(CMD_OPTS_WIDTH) )
+                self.logger.log_error("Must specify <length> argument in 'mem writeval' as one of {}".format(CMD_OPTS_WIDTH))
                 return
             self.logger.log( '[CHIPSEC] Writing {:X}-byte value 0x{:X} to PA 0x{:016X}..'.format(width, self.write_data, self.phys_address) )
             if   0x1 == width: self.cs.mem.write_physical_mem_byte ( self.phys_address, self.write_data )

--- a/chipsec/utilcmd/mmcfg_cmd.py
+++ b/chipsec/utilcmd/mmcfg_cmd.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -69,7 +69,7 @@ class MMCfgCommand(BaseCommand):
             else:
                 _width = int(self.width)
         except ValueError:
-            self.logger.error( "ValueError: Invalid inputs." )
+            self.logger.log_error("ValueError: Invalid inputs.")
             return
 
         if self.value is not None:

--- a/chipsec/utilcmd/pci_cmd.py
+++ b/chipsec/utilcmd/pci_cmd.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -154,7 +154,7 @@ class PCICommand(BaseCommand):
             elif 2 == width: pci_value = self.cs.pci.read_word (self.bus, self.device, self.function, self.offset)
             elif 4 == width: pci_value = self.cs.pci.read_dword(self.bus, self.device, self.function, self.offset)
             else:
-                self.logger.error( "Width should be one of {}".format(CMD_OPTS_WIDTH) )
+                self.logger.log_error("Width should be one of {}".format(CMD_OPTS_WIDTH))
                 return
             self.logger.log( "[CHIPSEC] PCI {:02X}:{:02X}.{:02X} + 0x{:02X}: 0x{:X}".format(self.bus, self.device, self.function, self.offset, pci_value) )
 
@@ -165,7 +165,7 @@ class PCICommand(BaseCommand):
             elif 2 == width: self.cs.pci.write_word ( self.bus, self.device, self.function, self.offset, self.value )
             elif 4 == width: self.cs.pci.write_dword( self.bus, self.device, self.function, self.offset, self.value )
             else:
-                self.logger.error( "Width should be one of {}".format(CMD_OPTS_WIDTH) )
+                self.logger.log_error("Width should be one of {}".format(CMD_OPTS_WIDTH))
                 return
             self.logger.log( "[CHIPSEC] Write 0x{:X} to PCI {:02X}:{:02X}.{:02X} + 0x{:02X}".format(self.value, self.bus, self.device, self.function, self.offset) )
 

--- a/chipsec/utilcmd/reg_cmd.py
+++ b/chipsec/utilcmd/reg_cmd.py
@@ -1,19 +1,19 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2017, Google
-#Copyright (c) 2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2017, Google
+# Copyright (c) 2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
 """
@@ -94,7 +94,7 @@ class RegisterCommand(BaseCommand):
             value = self.cs.read_register_field(self.reg_name, self.field_name)
             self.logger.log("[CHIPSEC] {}.{}=0x{:X}".format(self.reg_name, self.field_name, value))
         else:
-            self.logger.error("[CHIPSEC] Register '{}' doesn't have field '{}' defined".format(self.reg_name, self.field_name))
+            self.logger.log_error("[CHIPSEC] Register '{}' doesn't have field '{}' defined".format(self.reg_name, self.field_name))
 
 
     def reg_write(self):
@@ -107,7 +107,7 @@ class RegisterCommand(BaseCommand):
             self.logger.log("[CHIPSEC] Writing {}.{} < 0x{:X}".format(self.reg_name, self.field_name, self.value))
             self.cs.write_register_field(self.reg_name, self.field_name, self.value)
         else:
-            self.logger.error("[CHIPSEC] Register '{}' doesn't have field '{}' defined".format(self.reg_name, self.field_name))
+            self.logger.log_error("[CHIPSEC] Register '{}' doesn't have field '{}' defined".format(self.reg_name, self.field_name))
 
 
     def reg_get_control(self):
@@ -115,7 +115,7 @@ class RegisterCommand(BaseCommand):
             value = self.cs.get_control(self.control_name)
             self.logger.log("[CHIPSEC] {} = 0x{:X}".format(self.control_name, value))
         else:
-            self.logger.error("[CHIPSEC] Control '{}' isn't defined".format(self.control_name))
+            self.logger.log_error("[CHIPSEC] Control '{}' isn't defined".format(self.control_name))
 
 
     def reg_set_control(self):
@@ -123,7 +123,7 @@ class RegisterCommand(BaseCommand):
             self.cs.set_control(self.control_name, self.value)
             self.logger.log("[CHIPSEC] Setting control {} < 0x{:X}".format(self.control_name, self.value))
         else:
-            self.logger.error("[CHIPSEC] Control '{}' isn't defined".format(self.control_name))
+            self.logger.log_error("[CHIPSEC] Control '{}' isn't defined".format(self.control_name))
 
 
     def run(self):

--- a/chipsec/utilcmd/smbus_cmd.py
+++ b/chipsec/utilcmd/smbus_cmd.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -72,7 +72,7 @@ class SMBusCommand(BaseCommand):
         try:
             self._smbus = SMBus( self.cs )
         except BaseException as msg:
-            self.logger.error(msg)
+            self.logger.log_error(msg)
             return
 
         t = time.time()

--- a/chipsec/utilcmd/spd_cmd.py
+++ b/chipsec/utilcmd/spd_cmd.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -119,7 +119,7 @@ class SPDCommand(BaseCommand):
             _smbus    = smbus.SMBus( self.cs )
             self._spd = spd.SPD( _smbus )
         except BaseException as msg:
-            self.logger.error(msg)
+            self.logger.log_error(msg)
             return
 
         t = time.time()

--- a/chipsec/utilcmd/uefi_cmd.py
+++ b/chipsec/utilcmd/uefi_cmd.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -196,14 +196,14 @@ class UEFICommand(BaseCommand):
         if status == 0:
             self.logger.log( "[CHIPSEC] writing EFI variable was successful" )
         else:
-            self.logger.error( "writing EFI variable failed" )
+            self.logger.log_error("writing EFI variable failed")
 
     def var_delete(self):
         self.logger.log( "[CHIPSEC] Deleting EFI variable Name='{}' GUID={{{}}} via Variable API..".format(self.name, self.guid) )
         status = self._uefi.delete_EFI_variable( self.name, self.guid )
         self.logger.log("Returned {}".format(EFI_STATUS_DICT[status]))
         if status == 0: self.logger.log( "[CHIPSEC] deleting EFI variable was successful" )
-        else: self.logger.error( "deleting EFI variable failed" )
+        else: self.logger.log_error("deleting EFI variable failed")
 
     def var_list(self):
         self.logger.log( "[CHIPSEC] Enumerating all EFI variables via OS specific EFI Variable API.." )
@@ -259,10 +259,10 @@ class UEFICommand(BaseCommand):
         if self.fwtype is None:
             self.fwtype = identify_EFI_NVRAM( rom )
             if self.fwtype is None:
-                self.logger.error( "Could not automatically identify EFI NVRAM type" )
+                self.logger.log_error("Could not automatically identify EFI NVRAM type")
                 return
         elif self.fwtype not in fw_types:
-            self.logger.error( "Unrecognized EFI NVRAM type '{}'".format(self.fwtype) )
+            self.logger.log_error("Unrecognized EFI NVRAM type '{}'".format(self.fwtype))
             return
 
         _orig_logname = self.logger.LOG_FILE_NAME
@@ -276,10 +276,10 @@ class UEFICommand(BaseCommand):
         if self.fwtype is None:
             self.fwtype = identify_EFI_NVRAM( rom )
             if self.fwtype is None:
-                self.logger.error( "Could not automatically identify EFI NVRAM type" )
+                self.logger.log_error("Could not automatically identify EFI NVRAM type")
                 return
         elif self.fwtype not in fw_types:
-            self.logger.error( "Unrecognized EFI NVRAM type '{}'".format(self.fwtype) )
+            self.logger.log_error("Unrecognized EFI NVRAM type '{}'".format(self.fwtype))
             return
 
         _orig_logname = self.logger.LOG_FILE_NAME
@@ -289,7 +289,7 @@ class UEFICommand(BaseCommand):
 
     def decode(self):
         if not os.path.exists( self.filename ):
-            self.logger.error( "Could not find file '{}'".format(self.filename) )
+            self.logger.log_error("Could not find file '{}'".format(self.filename))
             return
 
         self.logger.log( "[CHIPSEC] Parsing EFI volumes from '{}'..".format(self.filename) )
@@ -309,7 +309,7 @@ class UEFICommand(BaseCommand):
 
     def keys(self):
         if not os.path.exists( self.filename ):
-            self.logger.error( "Could not find file '{}'".format(self.filename) )
+            self.logger.log_error("Could not find file '{}'".format(self.filename))
             return
         self.logger.log( "<keyvar_file> should contain one of the following EFI variables\n[ %s ]" % (" | ".join( ["%s" % var for var in SECURE_BOOT_KEY_VARIABLES]))  )
         self.logger.log( "[CHIPSEC] Parsing EFI variable from '{}'..".format(self.filename) )

--- a/chipsec/utilcmd/vmem_cmd.py
+++ b/chipsec/utilcmd/vmem_cmd.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -106,7 +106,7 @@ class VMemCommand(BaseCommand):
         try:
             buffer = self._vmem.read_virtual_mem( self.virt_address, self.size )
         except (TypeError, OSError):
-            self.logger.error( 'Error mapping VA to PA.' )
+            self.logger.log_error('Error mapping VA to PA.')
             return
 
         if self.buf_file:
@@ -134,10 +134,10 @@ class VMemCommand(BaseCommand):
             elif 0x2 == width: value = self._vmem.read_virtual_mem_word ( self.virt_address )
             elif 0x4 == width: value = self._vmem.read_virtual_mem_dword( self.virt_address )
             else:
-                self.logger.error( "Must specify <length> argument in 'mem readval' as one of {}".format(chipsec_util.CMD_OPTS_WIDTH) )
+                self.logger.log_error("Must specify <length> argument in 'mem readval' as one of {}".format(chipsec_util.CMD_OPTS_WIDTH))
                 return
         except (TypeError, OSError):
-            self.logger.error( 'Error mapping VA to PA.' )
+            self.logger.log_error('Error mapping VA to PA.')
             return
         self.logger.log( '[CHIPSEC] value = 0x{:X}'.format(value) )
 
@@ -147,8 +147,8 @@ class VMemCommand(BaseCommand):
             try:
                 buffer = bytearray.fromhex(self.buf_file)
             except ValueError as e:
-                self.logger.error( "Incorrect <value> specified: '{}'".format(self.buf_file) )
-                self.logger.error( str(e) )
+                self.logger.log_error("Incorrect <value> specified: '{}'".format(self.buf_file))
+                self.logger.log_error(str(e))
                 return
             self.logger.log( "[CHIPSEC] Read 0x{:X} hex bytes from command-line: {}'".format(len(buffer), self.buf_file) )
         else:
@@ -156,7 +156,7 @@ class VMemCommand(BaseCommand):
             self.logger.log( "[CHIPSEC] Read 0x{:X} bytes from file '{}'".format(len(buffer), self.buf_file) )
 
         if len(buffer) < self.size:
-            self.logger.error( "Number of bytes read (0x{:X}) is less than the specified <length> (0x{:X})".format(len(buffer), self.size) )
+            self.logger.log_error("Number of bytes read (0x{:X}) is less than the specified <length> (0x{:X})".format(len(buffer), self.size))
             return
 
         self.logger.log( '[CHIPSEC] Writing buffer to memory: VA = 0x{:016X}, len = 0x{:X}.'.format(self.virt_address, self.size) )
@@ -178,16 +178,16 @@ class VMemCommand(BaseCommand):
             elif 0x2 == width: self._vmem.write_virtual_mem_word ( self.virt_address, self.value )
             elif 0x4 == width: self._vmem.write_virtual_mem_dword( self.virt_address, self.value )
             else:
-                self.logger.error( "Must specify <length> argument in 'mem writeval' as one of {}".format(chipsec_util.CMD_OPTS_WIDTH) )
+                self.logger.log_error("Must specify <length> argument in 'mem writeval' as one of {}".format(chipsec_util.CMD_OPTS_WIDTH))
         except (TypeError, OSError):
-            self.logger.error( 'Error mapping VA to PA.' )
+            self.logger.log_error('Error mapping VA to PA.')
 
 
     def vmem_search(self):
         try:
             buffer = self._vmem.read_virtual_mem( self.virt_address, self.size )
         except (TypeError, OSError):
-            self.logger.error( 'Error mapping VA to PA.' )
+            self.logger.log_error('Error mapping VA to PA.')
             return
 
         buffer = bytestostring(buffer)
@@ -205,7 +205,7 @@ class VMemCommand(BaseCommand):
         try:
             (va, pa) = self._vmem.alloc_virtual_mem( self.size )
         except (TypeError, OSError):
-            self.logger.error( 'Error mapping VA to PA.' )
+            self.logger.log_error('Error mapping VA to PA.')
             return
         self.logger.log( '[CHIPSEC] Allocated {:X} bytes of virtual memory:'.format(self.size) )
         self.logger.log( '          VA = 0x{:016X}'.format(va) )
@@ -216,7 +216,7 @@ class VMemCommand(BaseCommand):
         try:
             pa = self._vmem.va2pa( self.virt_address )
         except (TypeError, OSError):
-            self.logger.error( 'Error mapping VA to PA.' )
+            self.logger.log_error('Error mapping VA to PA.')
             return
         if pa is not None:
             self.logger.log( '[CHIPSEC] Virtual memory:' )

--- a/chipsec/utilcmd/vmm_cmd.py
+++ b/chipsec/utilcmd/vmm_cmd.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 """
@@ -89,7 +89,7 @@ class VMMCommand(BaseCommand):
                 dev  = (_bus, _dev, _fun, vid, did)
                 virt_dev = [dev]
             else:
-                self.logger.error("Invalid B:D.F ({})".format(self.bdf))
+                self.logger.log_error("Invalid B:D.F ({})".format(self.bdf))
                 self.logger.log(VMMCommand.__doc__)
                 return
         else:
@@ -132,7 +132,7 @@ class VMMCommand(BaseCommand):
             self.vmm.dump_EPT_page_tables( self.eptp, pt_fname )
         else:
             self.logger.log( "[CHIPSEC] Finding EPT hierarchy in memory is not implemented yet" )
-            self.logger.error(VMMCommand.__doc__)
+            self.logger.log_error(VMMCommand.__doc__)
             return
 
 
@@ -142,7 +142,7 @@ class VMMCommand(BaseCommand):
         try:
             self.vmm = VMM( self.cs )
         except VMMRuntimeError as msg:
-            self.logger.error( msg )
+            self.logger.log_error(msg)
             return
 
         self.vmm.init()


### PR DESCRIPTION
Replace deprecated `error()` with `log_error()`

Signed-off-by: Frinzell, Aaron <aaron.frinzell@intel.com>