### PR TITLE
Fixed pylint issue R1719, R1703 and E0602

### DIFF
--- a/chipsec/hal/uefi_platform.py
+++ b/chipsec/hal/uefi_platform.py
@@ -31,7 +31,7 @@ from chipsec.logger import logger
 from chipsec.hal.uefi_common import bit_set, VARIABLE_SIGNATURE_VSS, S3BootScriptOpcode_MDE, op_io_pci_mem, S3BootScriptOpcode_EdkCompat, EFI_GUID_STR, EFI_GUID_SIZE
 from chipsec.hal.uefi_common import op_stall, op_dispatch, op_terminate, op_mem_poll, op_unknown, get_3b_size, get_nvar_name, op_smbus_execute, script_width_formats
 from chipsec.hal.uefi_common import S3BOOTSCRIPT_ENTRY, MAX_S3_BOOTSCRIPT_ENTRY_LENGTH, VARIABLE_STORE_FV_GUID, IS_VARIABLE_ATTRIBUTE, VARIABLE_DATA
-from chipsec.hal.uefi_common import EFI_VARIABLE_BOOTSERVICE_ACCESS, EFI_VARIABLE_NON_VOLATILE, EFI_VARIABLE_RUNTIME_ACCESS
+from chipsec.hal.uefi_common import EFI_VARIABLE_BOOTSERVICE_ACCESS, EFI_VARIABLE_NON_VOLATILE, EFI_VARIABLE_RUNTIME_ACCESS, script_opcodes
 from chipsec.hal.uefi_common import EFI_VARIABLE_HARDWARE_ERROR_RECORD, EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS, EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS
 from chipsec.hal.uefi_fv import NextFwVolume, NextFwFile, EFI_FVB2_ERASE_POLARITY, EFI_FV_FILETYPE_RAW
 

--- a/chipsec/hal/virtmem.py
+++ b/chipsec/hal/virtmem.py
@@ -118,4 +118,4 @@ class VirtMemory(hal_base.HALBase):
         pa = self.va2pa(virt_address)
         ret = self.helper.free_physical_mem(pa)
         if logger().HAL: logger().log( '[mem] Deallocated : VA = 0x{:016X}'.format(virt_address) )
-        return True if ret == 1 else False
+        return ret == 1

--- a/chipsec/utilcmd/ec_cmd.py
+++ b/chipsec/utilcmd/ec_cmd.py
@@ -76,10 +76,7 @@ class ECCommand(BaseCommand):
         parser_index.set_defaults(func=self.index)
 
         parser.parse_args(self.argv[2:], namespace=self)
-        if hasattr(self, 'func'):
-            return True
-        else:
-            return False
+        return bool(hasattr(self, 'func'))
 
     def dump(self):
         self.logger.log("[CHIPSEC] EC dump")

--- a/chipsec/utilcmd/ec_cmd.py
+++ b/chipsec/utilcmd/ec_cmd.py
@@ -76,7 +76,7 @@ class ECCommand(BaseCommand):
         parser_index.set_defaults(func=self.index)
 
         parser.parse_args(self.argv[2:], namespace=self)
-        return bool(hasattr(self, 'func'))
+        return hasattr(self, 'func')
 
     def dump(self):
         self.logger.log("[CHIPSEC] EC dump")


### PR DESCRIPTION
Hi, in this PR i fix pylint issues about missing imports(undefined variable) and simplifiable-if-statement:
# Simplifiable-if-statement
- chipsec/hal/virtmem.py:121:15: R1719: (simplifiable-if-expression) [Description](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/simplifiable-if-expression.html)
- chipsec/utilcmd/ec_cmd.py:79:8: R1703: (simplifiable-if-expression) [Description](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/simplifiable-if-statement.html)
# Missing imports
- chipsec/hal/uefi_platform.py:964:39: E0602: Undefined variable 'script_opcodes' (undefined-variable) [Description](https://pylint.pycqa.org/en/latest/user_guide/messages/error/undefined-variable.html)
- chipsec/hal/uefi_platform.py:1089:39: E0602: Undefined variable 'script_opcodes' (undefined-variable) [Description](https://pylint.pycqa.org/en/latest/user_guide/messages/error/undefined-variable.html)
