### PR TITLE
Update the versions used in Github Actions CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,36 +8,42 @@ jobs:
     strategy:
       matrix:
         distro:
-          - {name: "alpine", tag: "3.13", variant: "-lts"}
-          - {name: "alpine", tag: "3.12", variant: "-lts"}
-          - {name: "alpine", tag: "3.11", variant: "-lts"}
-          - {name: "alpine", tag: "3.10", variant: "-vanilla"}
-          - {name: "alpine", tag: "3.9", variant: "-vanilla"}
-          - {name: "alpine", tag: "3.8", variant: "-vanilla"}
-          - {name: "alpine", tag: "3.7", variant: "-vanilla"}
-          - {name: "alpine", tag: "3.7", variant: "-hardened"}
-          - {name: "alpine", tag: "3.6", variant: "-vanilla"}
-          - {name: "alpine", tag: "3.6", variant: "-hardened"}
-          - {name: "alpine", tag: "3.5", variant: "-vanilla"}
-          - {name: "alpine", tag: "3.5", variant: "-grsec"}
-          - {name: "alpine", tag: "3.4", variant: "-vanilla"}
-          - {name: "alpine", tag: "3.4", variant: "-grsec"}
-          - {name: "alpine", tag: "3.3", variant: "-vanilla"}
-          - {name: "alpine", tag: "3.3", variant: "-grsec"}
-          - {name: "archlinux", tag: "latest"}
-          - {name: "archlinux", tag: "latest", variant: "-lts"}
-          - {name: "archlinux", tag: "latest", variant: "-zen"}
-          - {name: "centos", tag: "7"}
-          #- {name: "centos", tag: "8"} # FIXME: yum could not find nasm?
-          - {name: "debian", tag: "10"}
-          - {name: "debian", tag: "9"}
-          - {name: "debian", tag: "8"}
-          - {name: "ubuntu", tag: "20.04"}
-          - {name: "ubuntu", tag: "18.04"}
-          - {name: "ubuntu", tag: "16.04"}
-    runs-on: ubuntu-20.04
+          - {name: "alpine", tag: "3.16", variant: "-lts", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.15", variant: "-lts", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.14", variant: "-lts", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.13", variant: "-lts", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.12", variant: "-lts", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.11", variant: "-lts", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.10", variant: "-vanilla", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.9", variant: "-vanilla", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.8", variant: "-vanilla", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.7", variant: "-vanilla", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.7", variant: "-hardened", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.6", variant: "-vanilla", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.6", variant: "-hardened", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.5", variant: "-vanilla", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.5", variant: "-grsec", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.4", variant: "-vanilla", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.4", variant: "-grsec", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.3", variant: "-vanilla", image_prefix: "docker.io/library/"}
+          - {name: "alpine", tag: "3.3", variant: "-grsec", image_prefix: "docker.io/library/"}
+          - {name: "archlinux", tag: "latest", image_prefix: "docker.io/library/"}
+          - {name: "archlinux", tag: "latest", variant: "-lts", image_prefix: "docker.io/library/"}
+          - {name: "archlinux", tag: "latest", variant: "-zen", image_prefix: "docker.io/library/"}
+          - {name: "centos", tag: "stream9", image_prefix: "quay.io/centos/"}
+          - {name: "centos", tag: "stream8", image_prefix: "quay.io/centos/"}
+          - {name: "centos", tag: "7", image_prefix: "quay.io/centos/"}
+          - {name: "debian", tag: "11", image_prefix: "docker.io/library/"}
+          - {name: "debian", tag: "10", image_prefix: "docker.io/library/"}
+          - {name: "debian", tag: "9", image_prefix: "docker.io/library/"}
+          - {name: "debian", tag: "8", image_prefix: "docker.io/library/"}
+          - {name: "ubuntu", tag: "22.04", image_prefix: "docker.io/library/"}
+          - {name: "ubuntu", tag: "20.04", image_prefix: "docker.io/library/"}
+          - {name: "ubuntu", tag: "18.04", image_prefix: "docker.io/library/"}
+          - {name: "ubuntu", tag: "16.04", image_prefix: "docker.io/library/"}
+    runs-on: ubuntu-22.04
     container:
-      image: docker://docker.io/library/${{ matrix.distro.name }}:${{ matrix.distro.tag }}
+      image: docker://${{ matrix.distro.image_prefix }}${{ matrix.distro.name }}:${{ matrix.distro.tag }}
 
     steps:
     - uses: actions/checkout@v2
@@ -49,7 +55,7 @@ jobs:
 
         # DKMS is not yet packaged in Alpine
         apk --no-cache --update add bash gcc git make
-        git clone --depth=1 --branch=v2.8.4 https://github.com/dell/dkms /opt/dkms
+        git clone --depth=1 --branch=v3.0.5 https://github.com/dell/dkms /opt/dkms
         make -C /opt/dkms install
 
     - name: Install Arch Linux dependencies
@@ -60,8 +66,22 @@ jobs:
     - name: Install CentOS dependencies
       if: matrix.distro.name == 'centos'
       run: |
-        yum install -y --enablerepo=extras epel-release
-        yum install -y dkms kernel kernel-devel nasm
+        if [ "${{ matrix.distro.tag }}" = 7 ] ; then
+            yum install -y kernel kernel-devel nasm
+            yum install -y elfutils-libelf-devel gcc git make
+        elif [ "${{ matrix.distro.tag }}" = stream8 ] ; then
+            dnf install -y --enablerepo=powertools kernel kernel-devel nasm
+            dnf install -y elfutils-libelf-devel gcc git make
+        elif [ "${{ matrix.distro.tag }}" = stream9 ] ; then
+            dnf install -y --enablerepo=crb kernel kernel-devel nasm
+            dnf install -y elfutils-libelf-devel gcc git make
+        fi
+
+        # DKMS is not longer packaged in CentOS Stream
+        if ! command -v dkms > /dev/null 2>&1 ; then
+            git clone --depth=1 --branch=v3.0.5 https://github.com/dell/dkms /opt/dkms
+            make -C /opt/dkms install
+        fi
 
     - name: Install Debian dependencies
       if: matrix.distro.name == 'debian'
@@ -80,15 +100,20 @@ jobs:
       run: |
         KERNEL_VER=''
         if [ "${{ matrix.distro.name }}" = alpine ] ; then
+            # Parse "lib/modules/5.15.53-0-lts/build"
             KERNEL_VER="$(apk info --contents "linux${{ matrix.distro.variant }}-dev" | sed -n 's:^lib/modules/\([^/][^/]*\)/.*:\1:p' | head -n 1)"
         elif [ "${{ matrix.distro.name }}" = archlinux ] ; then
+            # Parse "/usr/lib/modules/5.18.0-arch1-1/build/"
             KERNEL_VER="$(pacman -Qql "linux${{ matrix.distro.variant }}-headers" | sed -n 's:^/usr/lib/modules/\([^/]\+\)/.*:\1:p' | head -n 1)"
         elif [ "${{ matrix.distro.name }}" = centos ] ; then
+            # Parse "Source RPM  : kernel-3.10.0-1160.71.1.el7.src.rpm"
             KERNEL_VER="$(LANG=C rpm -qi kernel-devel | sed -n 's/^Source RPM *: kernel-\(.*\).src.rpm$/\1.x86_64/p' | tail -n 1)"
         elif [ "${{ matrix.distro.name }}" = debian ] ; then
-            KERNEL_VER="$(LANG=C dpkg --status linux-headers-amd64 | sed -n 's/^Depends: linux-headers-\(.*\)/\1/p' | head -n 1)"
+            # Parse "Depends: linux-headers-5.10.0-15-amd64 (= 5.10.120-1)"
+            KERNEL_VER="$(LANG=C dpkg --status linux-headers-amd64 | sed -n 's/^Depends: linux-headers-\(\S*\)\( .*\)\?$/\1/p' | head -n 1)"
         elif [ "${{ matrix.distro.name }}" = ubuntu ] ; then
-            KERNEL_VER="$(LANG=C dpkg --status linux-headers-generic | sed -n 's/^Depends: linux-headers-\(.*\)/\1/p' | head -n 1)"
+            # Parse "Depends: linux-headers-5.15.0-40-generic"
+            KERNEL_VER="$(LANG=C dpkg --status linux-headers-generic | sed -n 's/^Depends: linux-headers-\(\S*\)\( .*\)\?$/\1/p' | head -n 1)"
         fi
         if [ -z "${KERNEL_VER}" ] ; then
             echo >&2 "Error: no kernel package found"
@@ -134,9 +159,10 @@ jobs:
     strategy:
       matrix:
         python:
-          - 3.9
-          - 3.8
-          - 3.7
+          - "3.10"
+          - "3.9"
+          - "3.8"
+          - "3.7"
 
     steps:
     - uses: actions/checkout@v2
@@ -170,11 +196,17 @@ jobs:
     strategy:
       matrix:
         versions:
-          - {ubuntu: 20.04, python: 3.9}
-          - {ubuntu: 20.04, python: 3.8}
-          - {ubuntu: 20.04, python: 3.7}
+          - {ubuntu: "22.04", python: "3.10"}
+          - {ubuntu: "22.04", python: "3.9"}
+          - {ubuntu: "22.04", python: "3.8"}
+          - {ubuntu: "22.04", python: "3.7"}
 
-          - {ubuntu: 18.04, python: 3.7}
+          - {ubuntu: "20.04", python: "3.10"}
+          - {ubuntu: "20.04", python: "3.9"}
+          - {ubuntu: "20.04", python: "3.8"}
+          - {ubuntu: "20.04", python: "3.7"}
+
+          - {ubuntu: "18.04", python: "3.7"}
     runs-on: ubuntu-${{ matrix.versions.ubuntu }}
 
     steps:


### PR DESCRIPTION
Hello,

This Pull Request updates the versions of the Linux distributions and the version of Python used in Github Actions Continuous Integration system:

- Add Alpine 3.14, 3.15 and 3.16 to test building with more Linux kernel versions
- Add CentOS Stream 8 and 9, using images from quay.io, as they are not on Docker Hub (this introduces a new variable `distro.image_prefix`)
- Add Debian 11 and adjust kernel version detection, as `dpkg --status linux-headers-amd64` now returns something in parentheses, `Depends: linux-headers-5.10.0-15-amd64 (= 5.10.120-1)`
- Add Ubuntu 22.04 and use it as the base environment for tests using Docker
- Add Python 3.10 (this requires quoting the version, otherwise GitHub parses the version as "3.1" instead)
- Update fallback DKMS version to the latest release, v3.0.5