### PR TITLE
Better docstring formatting in smm_dma.py

### DIFF
--- a/chipsec/modules/common/smm_dma.py
+++ b/chipsec/modules/common/smm_dma.py
@@ -24,17 +24,17 @@ SMM TSEG Range Configuration Checks
 This module examines the configuration and locking of SMRAM range configuration protecting from DMA attacks.
 If it fails, then DMA protection may not be securely configured to protect SMRAM.
 
-Reference:
-    Just like SMRAM needs to be protected from software executing on the CPU,
-    it also needs to be protected from devices that have direct access to DRAM (DMA).
-    Protection from DMA is configured through proper programming of SMRAM memory range.
-    If BIOS does not correctly configure and lock the configuration,
-    then malware could reprogram configuration and open SMRAM area to DMA access,
-    allowing manipulation of memory that should have been protected.
+Just like SMRAM needs to be protected from software executing on the CPU,
+it also needs to be protected from devices that have direct access to DRAM (DMA).
+Protection from DMA is configured through proper programming of SMRAM memory range.
+If BIOS does not correctly configure and lock the configuration,
+then malware could reprogram configuration and open SMRAM area to DMA access,
+allowing manipulation of memory that should have been protected.
 
-    DMA attacks were discussed in `Programmed I/O accesses: a threat to Virtual Machine Monitors? <http://www.ssi.gouv.fr/archive/fr/sciences/fichiers/lti/pacsec2007-duflot-papier.pdf>`_
-    and `System Management Mode Design and Security Issues <http://www.ssi.gouv.fr/uploads/IMG/pdf/IT_Defense_2010_final.pdf>`_
-    and `Summary of Attack against BIOS and Secure Boot` https://www.defcon.org/images/defcon-22/dc-22-presentations/Bulygin-Bazhaniul-Furtak-Loucaides/DEFCON-22-Bulygin-Bazhaniul-Furtak-Loucaides-Summary-of-attacks-against-BIOS-UPDATED.pdf
+References:
+    - `System Management Mode Design and Security Issues <http://www.ssi.gouv.fr/uploads/IMG/pdf/IT_Defense_2010_final.pdf>`_
+    - `Summary of Attack against BIOS and Secure Boot <https://www.defcon.org/images/defcon-22/dc-22-presentations/Bulygin-Bazhaniul-Furtak-Loucaides/DEFCON-22-Bulygin-Bazhaniul-Furtak-Loucaides-Summary-of-attacks-against-BIOS-UPDATED.pdf>`_
+    - `Programmed I/O accesses: a threat to Virtual Machine Monitors? <http://www.ssi.gouv.fr/archive/fr/sciences/fichiers/lti/pacsec2007-duflot-papier.pdf>`_ (broken?)
 
 Usage:
     ``chipsec_main -m smm_dma``
@@ -126,10 +126,6 @@ class smm_dma(BaseModule):
 
         return res
 
-    # --------------------------------------------------------------------------
-    # run( module_argv )
-    # Required function: run here all tests from this module
-    # --------------------------------------------------------------------------
     def run(self, module_argv):
         self.logger.start_test("SMM TSEG Range Configuration Check")
         self.res = self.check_tseg_config()

--- a/chipsec/modules/common/smm_dma.py
+++ b/chipsec/modules/common/smm_dma.py
@@ -34,7 +34,6 @@ allowing manipulation of memory that should have been protected.
 References:
     - `System Management Mode Design and Security Issues <http://www.ssi.gouv.fr/uploads/IMG/pdf/IT_Defense_2010_final.pdf>`_
     - `Summary of Attack against BIOS and Secure Boot <https://www.defcon.org/images/defcon-22/dc-22-presentations/Bulygin-Bazhaniul-Furtak-Loucaides/DEFCON-22-Bulygin-Bazhaniul-Furtak-Loucaides-Summary-of-attacks-against-BIOS-UPDATED.pdf>`_
-    - `Programmed I/O accesses: a threat to Virtual Machine Monitors? <http://www.ssi.gouv.fr/archive/fr/sciences/fichiers/lti/pacsec2007-duflot-papier.pdf>`_ (broken?)
 
 Usage:
     ``chipsec_main -m smm_dma``


### PR DESCRIPTION
- Should address formatting quirk in chipsec-manual.pdf
- Possible dead link (keep as an archive?)

Signed-off-by: Frinzell, Aaron <aaron.frinzell@intel.com>