### PR TITLE
Update to use GitHub Teams to define codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Intel Employees / Code Owners
-*       @frinzell @npmitche @Sae86 @dscott90 @kevinsun49
+*       @chipsec/intel-codeowner
 
 # AMD Support
-1022/*  @kerneis-anssi
+1022/*  @chipsec/amd-codeowner


### PR DESCRIPTION
Signed-off-by: Nathaniel Mitchell <nathaniel.p.mitchell@intel.com>