### PR TITLE
drivers/linux: reinstantiate DMA32 allocations

### DIFF
--- a/drivers/linux/include/chipsec.h
+++ b/drivers/linux/include/chipsec.h
@@ -105,9 +105,3 @@ typedef struct _DESCRIPTOR_TABLE_RECORD {
   physaddr_t base;
 } DESCRIPTOR_TABLE_RECORD, *PDESCRIPTOR_TABLE_RECORD;
 #pragma pack()
-
-struct allocated_mem_list {
-  physaddr_t pa;
-  void *va;
-  struct list_head list;
-};


### PR DESCRIPTION
Complement the workaround of PR #1544 by switching to the page allocator for allocating memory which allows us to use DMA32 requests again. The page allocator will, in contrast to kmalloc(), respect that flag and allocate memory below 4GB only.