### PR TITLE
Update tests.yml to include python 3.6 in validation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,6 +163,7 @@ jobs:
           - "3.9"
           - "3.8"
           - "3.7"
+          - "3.6"
 
     steps:
     - uses: actions/checkout@v2
@@ -205,8 +206,10 @@ jobs:
           - {ubuntu: "20.04", python: "3.9"}
           - {ubuntu: "20.04", python: "3.8"}
           - {ubuntu: "20.04", python: "3.7"}
+          - {ubuntu: "20.04", python: "3.6"}
 
           - {ubuntu: "18.04", python: "3.7"}
+          - {ubuntu: "18.04", python: "3.6"}
     runs-on: ubuntu-${{ matrix.versions.ubuntu }}
 
     steps:


### PR DESCRIPTION
Update tests.yml to include python 3.6 as that is the lowest version of python we support due to the UEFI Shell support.

Signed-off-by: Nathaniel Mitchell <nathaniel.p.mitchell@intel.com>