### PR TITLE
Add a script which starts a QEMU virtual machine with a UEFI shell

### DIFF
--- a/scripts/qemu_efi.py
+++ b/scripts/qemu_efi.py
@@ -88,7 +88,7 @@ def create_efi_disk(filename, startup_nsh=None):
                 f.write(startup_nsh)
 
         # Convert to QCow image
-        print("Converting to QCow2 format to {} ...".format(filename))
+        print("Converting to QCow2 format in {} ...".format(filename))
         subprocess.run(
             ("qemu-img", "convert", "-c", "-f", "vvfat", "-O", "qcow2", "fat:" + tmpdir, filename),
             check=True

--- a/scripts/qemu_efi.py
+++ b/scripts/qemu_efi.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# CHIPSEC: Platform Security Assessment Framework
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Contact information:
+# chipsec@intel.com
+#
+"""Launch a QEMU virtual machine with a UEFI Shell and chipsec
+
+This scripts uses the UEFI Shell provided by OVMF firmware. Therefore it
+requires both QEMU (for x86_64 system emulation) and OVMF to be installed.
+It also requires qemu-img, to create a temporary boot disk.
+
+On Debian and Ubuntu, installing these requirements can be done with:
+
+    sudo apt install ovmf qemu-system-x86 qemu-utils
+
+Usage examples:
+
+    # Run chipsec_main.py in the default QEMU virtual machine
+    qemu_efi.py -m
+
+    # Enumerate PCI devices of the virtual machine (like command "pci" of UEFI shell)
+    qemu_efi.py -u pci enumerate
+
+    # Launch a Python interpreter where it is possible to import chipsec and edk2
+    qemu_efi.py -p
+"""
+import argparse
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+
+CHIPSEC_BASE = Path(__file__).parent / ".."
+PYTHON_INSTALL_ZIP = CHIPSEC_BASE / "__install__" / "UEFI" / "chipsec_py368_uefi_x64.zip"
+PYTHON_EFI_COMMAND = "python368.efi"
+
+OVMF_CODE_LOCATIONS = (
+    # Arch Linux https://archlinux.org/packages/extra/any/edk2-ovmf/
+    "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd",
+    # Debian https://packages.debian.org/fr/sid/all/ovmf/filelist
+    "/usr/share/OVMF/OVMF_CODE.fd",
+    # Fedora https://fedora.pkgs.org/35/fedora-updates-x86_64/edk2-ovmf-20211126gitbb1bba3d7767-1.fc35.noarch.rpm.html
+    "/usr/share/edk2/ovmf/OVMF_CODE.fd",
+)
+
+
+def create_efi_disk(filename, startup_nsh=None):
+    """Create a disk bootable through UEFI with chipsec
+
+    This function copies all needed files to a temporary directory and uses
+    qemu-img to convert this directory into a FAT partition.
+    """
+    with tempfile.TemporaryDirectory(prefix="efidisk_") as tmpdir:
+        # Unzip Python into the temporary directory
+        print("Extracting {} to {} ...".format(PYTHON_INSTALL_ZIP.name, tmpdir))
+        with zipfile.ZipFile(PYTHON_INSTALL_ZIP) as python_zip:
+            python_zip.extractall(tmpdir)
+
+        # Copy Chipsec
+        print("Copying chipsec to {} ...".format(tmpdir))
+        for extension in (".py", ".xml", ".xsd"):
+            for filepath in CHIPSEC_BASE.glob("**/*" + extension):
+                destination = Path(tmpdir) / "chipsec" / filepath.relative_to(CHIPSEC_BASE)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy(filepath, destination)
+
+        # Create startup.nsh
+        if startup_nsh:
+            with (Path(tmpdir) / "startup.nsh").open("w") as f:
+                f.write(startup_nsh)
+
+        # Convert to QCow image
+        print("Converting to QCow2 format to {} ...".format(filename))
+        subprocess.run(
+            ("qemu-img", "convert", "-c", "-f", "vvfat", "-O", "qcow2", "fat:" + tmpdir, filename),
+            check=True
+        )
+
+
+def unescape_arguments(args):
+    """Replace " -" with "-" in the arguments"""
+    return [arg[1:] if arg.startswith(" -") else arg for arg in args]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Launch a QEMU virtual machine with a UEFI Shell and chipsec")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-m", "--main", nargs="*", type=str,
+                       help="start chipsec_main.py, optionally with some arguments")
+    group.add_argument("-p", "--python", nargs="*", type=str,
+                       help="start a Python-UEFI shell, optionally with some arguments")
+    group.add_argument("-u", "--util", nargs="+", type=str,
+                       help="start chipsec_util.py, with some arguments (use ' -' to escape the dash prefix)")
+    parser.add_argument("--ovmf", type=str,
+                        help="path to the OVMF firmware code")
+    parser.add_argument("--memory", type=str, default="512M",
+                        help="set the RAM size of the virtual machine (QEMU option -m)")
+    parser.add_argument("-g", "--gui", action="store_true",
+                        help="use QEMU graphics window")
+    parser.add_argument("-H", "--host-cpu", action="store_true",
+                        help="use host CPU")
+    parser.add_argument("-M", "--machine", type=str,
+                        help="specify QEMU machine ('pc', 'q35,smm=on'...)")
+    parser.add_argument("-Q", "--qemu-arg", nargs="+", type=str,
+                        help="specify additional QEMU arguments (use ' -' to escape the dash prefix)")
+    args = parser.parse_args()
+
+    ovmf_path = args.ovmf
+    if not ovmf_path:
+        for test_ovmf_path in OVMF_CODE_LOCATIONS:
+            if Path(test_ovmf_path).exists():
+                ovmf_path = test_ovmf_path
+                break
+        if not ovmf_path:
+            print("No OVMF file found. You can specify one using option --ovmf.", file=sys.stderr)
+            sys.exit(1)
+
+    # Create startup.nsh
+    start_cmd = None
+    if args.main is not None:
+        start_cmd = [PYTHON_EFI_COMMAND, "chipsec_main.py"] + unescape_arguments(args.main)
+    elif args.python is not None:
+        start_cmd = [PYTHON_EFI_COMMAND] + unescape_arguments(args.python)
+    elif args.util is not None:
+        start_cmd = [PYTHON_EFI_COMMAND, "chipsec_util.py"] + unescape_arguments(args.util)
+
+    if start_cmd:
+        startup_nsh = "fs0:\ncd chipsec\n" + " ".join(shlex.quote(arg) for arg in start_cmd) + "\nreset\n"
+    else:
+        startup_nsh = "@echo Type 'reset' to exit"
+
+    qemu_cmd = [
+        "qemu-system-x86_64",
+        # Make OVMF boot directly in UEFI shell instead of trying network boot (PXE)
+        "-nic", "none",
+        # Enable exiting by entering "reset" in UEFI shell
+        "-no-reboot",
+        # Start OVMF
+        "-drive", "if=pflash,format=raw,readonly=on,file=" + ovmf_path,
+    ]
+    if not args.gui:
+        qemu_cmd += ["-nographic"]
+
+    if args.memory:
+        qemu_cmd += ["-m", args.memory]
+
+    if args.host_cpu:
+        qemu_cmd += ["-cpu", "host", "-enable-kvm"]
+
+    if args.machine:
+        qemu_cmd += ["-machine", args.machine]
+
+    with tempfile.NamedTemporaryFile(prefix="efidisk_") as tmpdisk:
+        create_efi_disk(tmpdisk.name, startup_nsh)
+        qemu_cmd += ["-drive", "format=qcow2,file=" + tmpdisk.name]
+
+        if args.qemu_arg:
+            qemu_cmd += [arg[1:] if arg.startswith(" ") else arg for arg in args.qemu_arg]
+
+        print("Launching {}".format(" ".join(qemu_cmd)))
+        subprocess.run(qemu_cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
To easily test using chipsec in a UEFI environment, it is useful to be able to run it in a virtual machine. On most Linux distributions, QEMU can be used to start a UEFI shell in a virtual machine. By providing a `startup.nsh` file, some commands can even be automatically entered!

Moreover:

- OVMF embeds the UEFI shell. There is no need to download a `Shell.efi` file. But by default QEMU tries to boot with PXE (network boot). I have not found a nice way to prevent this, so instead I removed the NIC of the machine with `-nic none` option.

- `qemu-img convert` can create a FAT partition from a directory, thanks to QEMU's Virtual VFAT storage engine. This enables creating an ESP (EFI System Partition) without needing to mount a temporary filesystem and without using GNU mtools commands (`mmd` and `mcopy`).

Provide a shell script which prepares an ESP with chipsec and the Python module, and launches a QEMU virtual machine from it. It works on Ubuntu 20.04 and 22.04:

    sudo apt install ovmf qemu-system-x86 qemu-utils
    ./scripts/qemu_efi.py

Then in the UEFI shell:

    Shell> fs0:
    FS0:\> cd chipsec
    FS0:\chipsec\> python368.efi chipsec_util.py -i cpu cpuid 0

    ################################################################
    ##                                                            ##
    ##  CHIPSEC: Platform Hardware Security Assessment Framework  ##
    ##                                                            ##
    ################################################################
    [CHIPSEC] Version :
    [CHIPSEC] OS      : uefi
    [CHIPSEC] Python  : 3.6.8 (64-bit)

    [CHIPSEC] API mode: using CHIPSEC kernel module API
    [-] ERROR: Unknown Platform: VID = 0x8086, DID = 0x1237, RID = 0x02
    [!] WARNING: *******************************************************************
    [!] WARNING: * Unknown platform!
    [!] WARNING: * Platform dependent functionality will likely be incorrect
    [!] WARNING: * Error Message: "Unknown Platform: VID = 0x8086, DID = 0x1237, RID = 0x02"
    [!] WARNING: *******************************************************************
    [CHIPSEC] Helper  : EfiHelper (None)
    [CHIPSEC] Platform: UnknownPlatform
    [CHIPSEC]      VID: FFFF
    [CHIPSEC]      DID: FFFF
    [CHIPSEC]      RID: FF
    [CHIPSEC] PCH     : Default PCH
    [CHIPSEC]      VID: FFFF
    [CHIPSEC]      DID: FFFF
    [CHIPSEC]      RID: FF
    [CHIPSEC] Executing command 'cpu' with args ['cpuid', '0']

    [CHIPSEC] CPUID < EAX: 0x00000000
    [CHIPSEC]         ECX: 0x00000000
    [CHIPSEC] CPUID > EAX: 0x0000000D
    [CHIPSEC]         EBX: 0x68747541
    [CHIPSEC]         ECX: 0x444D4163
    [CHIPSEC]         EDX: 0x69746E65
    [CHIPSEC] (cpu) time elapsed 0.000

As typing a command in the virtual UEFI Shell can be quite cumbersome, it is possible to directly provide it to the script. For example:

    $ ./scripts/qemu_efi.py -u ' -i' cpu cpuid 0

N.B. the options of chipsec commands are escaped with a space (`' -i'`) to work around limitations of Python's `argparse` module. Moreover, `-i` is required in this example because chipsec does not support the default platform emulated by QEMU yet (I opened another Pull Request to fix this, https://github.com/chipsec/chipsec/pull/1570).