### PR TITLE
Use CPUID to identify processors instead of PCI Dev ID 

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -335,7 +335,7 @@ class Chipset:
         return self.pch_longname
 
     def print_chipset(self):
-        logger().log("[*] Platform: {}\n          VID: {:04X}\n          DID: {:04X}\n          RID: {:02X}".format(self.longname, self.vid, self.did, self.rid))
+        logger().log("[*] Platform: {}\n          CPUID: {}\n           VID: {:04X}\n          DID: {:04X}\n          RID: {:02X}".format(self.longname, self.get_cpuid(), self.vid, self.did, self.rid))
 
     def print_pch(self):
         logger().log("[*] PCH     : {}\n          VID: {:04X}\n          DID: {:04X}\n          RID: {:02X}".format(self.pch_longname, self.pch_vid, self.pch_did, self.pch_rid))

--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -446,7 +446,7 @@ class ChipsecMain:
         ret["OS"] = "{} {} {} {}".format(self._cs.helper.os_system, self._cs.helper.os_release,
                                          self._cs.helper.os_version, self._cs.helper.os_machine)
         ret["Python"] = "Python {}".format(platform.python_version())
-        ret["Platform"] = "{}, VID: {:04X}, DID: {:04X}, RID: {:02X}".format(self._cs.longname, self._cs.vid,
+        ret["Platform"] = "{}, CPUID: {}, VID: {:04X}, DID: {:04X}, RID: {:02X}".format(self._cs.longname, self._cs.get_cpuid(), self._cs.vid,
                                                                              self._cs.did, self._cs.rid)
         if not self._cs.is_atom():
             ret["PCH"] = "{}, VID: {:04X}, DID: {:04X} RID: {:02X}".format(self._cs.pch_longname, self._cs.pch_vid,
@@ -461,10 +461,12 @@ class ChipsecMain:
         logger().log("[CHIPSEC] Python  : {} ({})".format(platform.python_version(),
                                                           "64-bit" if self.PYTHON_64_BITS else "32-bit"))
         logger().log("[CHIPSEC] Helper  : {} ({})".format(*self._cs.helper.helper.get_info()))
-        chip_info = "[CHIPSEC] {:8}: {}\n[CHIPSEC]      VID: {:04X}\n" \
+        chip_info = "[CHIPSEC] {:8}: {}\n[CHIPSEC]      CPUID: {}\n[CHIPSEC]      VID: {:04X}\n" \
             "[CHIPSEC]      DID: {:04X}\n[CHIPSEC]      RID: {:02X}"
-        logger().log(chip_info.format("Platform", self._cs.longname, self._cs.vid, self._cs.did, self._cs.rid))
+        logger().log(chip_info.format("Platform", self._cs.longname, self._cs.get_cpuid(), self._cs.vid, self._cs.did, self._cs.rid))
         if not self._cs.is_atom():
+            chip_info = "[CHIPSEC] {:8}: {}\n[CHIPSEC]      VID: {:04X}\n" \
+            "[CHIPSEC]      DID: {:04X}\n[CHIPSEC]      RID: {:02X}"
             logger().log(chip_info.format("PCH", self._cs.pch_longname, self._cs.pch_vid,
                                           self._cs.pch_did, self._cs.pch_rid))
 

--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -461,7 +461,7 @@ class ChipsecMain:
         logger().log("[CHIPSEC] Python  : {} ({})".format(platform.python_version(),
                                                           "64-bit" if self.PYTHON_64_BITS else "32-bit"))
         logger().log("[CHIPSEC] Helper  : {} ({})".format(*self._cs.helper.helper.get_info()))
-        chip_info = "[CHIPSEC] {:8}: {}\n[CHIPSEC]      CPUID: {}\n[CHIPSEC]      VID: {:04X}\n" \
+        chip_info = "[CHIPSEC] {:8}: {}\n[CHIPSEC]    CPUID: {}\n[CHIPSEC]      VID: {:04X}\n" \
             "[CHIPSEC]      DID: {:04X}\n[CHIPSEC]      RID: {:02X}"
         logger().log(chip_info.format("Platform", self._cs.longname, self._cs.get_cpuid(), self._cs.vid, self._cs.did, self._cs.rid))
         if not self._cs.is_atom():

--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -195,7 +195,7 @@ class ChipsecUtil:
         if self._show_banner:
             logger().log("[CHIPSEC] Helper  : {} ({})".format(*self._cs.helper.helper.get_info()))
 
-            chip_info = "[CHIPSEC] {:8}: {}\n[CHIPSEC]      CPUID: {}\n[CHIPSEC]      VID: {:04X}\n" \
+            chip_info = "[CHIPSEC] {:8}: {}\n[CHIPSEC]    CPUID: {}\n[CHIPSEC]      VID: {:04X}\n" \
                 "[CHIPSEC]      DID: {:04X}\n[CHIPSEC]      RID: {:02X}"
             logger().log(chip_info.format("Platform", self._cs.longname, self._cs.get_cpuid(), self._cs.vid, self._cs.did, self._cs.rid))
             if not self._cs.is_atom():

--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -194,10 +194,13 @@ class ChipsecUtil:
 
         if self._show_banner:
             logger().log("[CHIPSEC] Helper  : {} ({})".format(*self._cs.helper.helper.get_info()))
-            chip_info = "[CHIPSEC] {:8}: {}\n[CHIPSEC]      VID: {:04X}\n" \
+
+            chip_info = "[CHIPSEC] {:8}: {}\n[CHIPSEC]      CPUID: {}\n[CHIPSEC]      VID: {:04X}\n" \
                 "[CHIPSEC]      DID: {:04X}\n[CHIPSEC]      RID: {:02X}"
-            logger().log(chip_info.format("Platform", self._cs.longname, self._cs.vid, self._cs.did, self._cs.rid))
+            logger().log(chip_info.format("Platform", self._cs.longname, self._cs.get_cpuid(), self._cs.vid, self._cs.did, self._cs.rid))
             if not self._cs.is_atom():
+                chip_info = "[CHIPSEC] {:8}: {}\n[CHIPSEC]      VID: {:04X}\n" \
+                    "[CHIPSEC]      DID: {:04X}\n[CHIPSEC]      RID: {:02X}"
                 logger().log(chip_info.format("PCH", self._cs.pch_longname, self._cs.pch_vid,
                                               self._cs.pch_did, self._cs.pch_rid))
 


### PR DESCRIPTION
Add cpuid printing

Signed-off-by: Zhou Jun,  jun2.zhou@intel.com