### PR TITLE
Add cpuid detection string to xml files

### DIFF
--- a/chipsec/cfg/8086/adl.xml
+++ b/chipsec/cfg/8086/adl.xml
@@ -35,7 +35,7 @@ https://cdrdv2.intel.com/v1/dl/getContent/655259
 <!-- Information                          -->
 <!--                                      -->
 <!-- #################################### -->
-<info family="core">
+<info family="core" detection_value="90670-90672, 90674-90675, 906a0-906a4">
     <sku did="0x4601" name="AlderLake" code="ADL" longname="ADL-P/U15 2+8"/>
     <sku did="0x4602" name="AlderLake" code="ADL" longname="ADL-U9 2+8"/>
     <sku did="0x4609" name="AlderLake" code="ADL" longname="ADL-U15 2+4"/>

--- a/chipsec/cfg/8086/apl.xml
+++ b/chipsec/cfg/8086/apl.xml
@@ -10,7 +10,7 @@ document id 334818/334819
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="atom">
+  <info family="atom" detection_value="506c8, 506c9, 506ca">
     <sku did="0x5AF0" name="Apollo Lake" code="APL" longname="Apollo Lake" />
   </info>
 

--- a/chipsec/cfg/8086/bdw.xml
+++ b/chipsec/cfg/8086/bdw.xml
@@ -9,7 +9,7 @@ XML configuration for Broadwell based platforms
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core">
+  <info family="core" detection_value="306dx, 4067x">
     <sku did="0x1600" name="Broadwell" code="BDW" longname="Desktop 5th Generation Core Processor (Broadwell CPU / Wildcat Point PCH)" />
     <sku did="0x1604" name="Broadwell" code="BDW" longname="Mobile 5th Generation Core Processor (Broadwell M/H / Wildcat Point PCH)" />
     <sku did="0x1610" name="Broadwell" code="BDW" longname="Desktop 5th Generation Core Processor (Broadwell H / Wildcat Point PCH)" />

--- a/chipsec/cfg/8086/bdx.xml
+++ b/chipsec/cfg/8086/bdx.xml
@@ -14,7 +14,7 @@ Intel (c) C610 Series Chipset and Intel (c) X99 Chipset Platform Controller Hub 
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="xeon">
+  <info family="xeon" detection_value="406f1">
     <sku did="0x6F00" name="Broadwell Server" code="BDX" longname="Intel Xeon Processor E5/E7 v4 (Broadwell Server CPU / Wellsburg PCH)" />
   </info>
 

--- a/chipsec/cfg/8086/byt.xml
+++ b/chipsec/cfg/8086/byt.xml
@@ -12,7 +12,7 @@ XML configuration for Bay Trail based platforms
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="atom">
+  <info family="atom" detection_value="30671-30673, 30679">
     <sku did="0x0F00" name="Baytrail" code="BYT" longname="Bay Trail SoC" />
   </info>
 

--- a/chipsec/cfg/8086/cfl.xml
+++ b/chipsec/cfg/8086/cfl.xml
@@ -12,7 +12,7 @@ XML configuration file for Coffee Lake
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core" detection_value="906EA, 906EB, 906EC">
+  <info family="core" detection_value="906EA-906ED, 806EA">
     <sku did="0x3E0F" name="CoffeeLake" code="CFL" longname="Desktop 8th Generation Core Processor (CoffeeLake S 2 Cores)" />
     <sku did="0x3E1F" name="CoffeeLake" code="CFL" longname="Desktop 8th Generation Core Processor (Coffeelake S 4 Cores)" />
     <sku did="0x3EC2" name="CoffeeLake" code="CFL" longname="Desktop 8th Generation Core Processor (Coffeelake S 6 Cores)" />

--- a/chipsec/cfg/8086/cht.xml
+++ b/chipsec/cfg/8086/cht.xml
@@ -15,7 +15,7 @@ XML configuration for Cherry Trail and Braswell SoCs
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="atom">
+  <info family="atom" detection_value="30651">
     <sku did="0x2280" name="Braswell/Cherry Trail" code="CHT" longname="Braswell/Cherry Trail SoC" />
   </info>
 

--- a/chipsec/cfg/8086/cml.xml
+++ b/chipsec/cfg/8086/cml.xml
@@ -7,7 +7,7 @@
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core" detection_value="A0652, A0653, A0655, A0660">
+  <info family="core" detection_value="A0652, A0653, A0655, A0660, A0661">
     <sku did="0x3E20" name="CometLake" code="CML" longname="CometLake H8 Core / XeonW" />
     <sku did="0x3E33" name="CometLake" code="CML" longname="CometLake v1 U6 Core" />
     <sku did="0x3E34" name="CometLake" code="CML" longname="CometLake v1 U4 Core" />

--- a/chipsec/cfg/8086/dnv.xml
+++ b/chipsec/cfg/8086/dnv.xml
@@ -9,7 +9,7 @@ XML configuration file for Denverton
 -->
 
   <!-- #################################### -->
-  <info family="atom">
+  <info family="atom" detection_value="506f0, 506f1">
     <sku did="0x1980" name="Denverton" code="DNV" longname="Intel Atom Processor C3000 Product Family" />
     <sku did="0x1993" name="Denverton" code="DNV" longname="Intel Atom Processor C3000 Product Family" />
     <sku did="0x1994" name="Denverton" code="DNV" longname="Intel Atom Processor C3000 Product Family" />

--- a/chipsec/cfg/8086/glk.xml
+++ b/chipsec/cfg/8086/glk.xml
@@ -9,7 +9,7 @@
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="atom">
+  <info family="atom" detection_value="7006a">
     <sku did="0x3180" name="Gemini Lake" code="GLK" longname="Gemini Lake" />
     <sku did="0x31F0" name="Gemini Lake" code="GLK" longname="Gemini Lake" />
   </info>

--- a/chipsec/cfg/8086/hsw.xml
+++ b/chipsec/cfg/8086/hsw.xml
@@ -8,7 +8,7 @@ XML configuration file for Haswell based platforms
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core">
+  <info family="core" detection_value="3069x,4066x">
     <sku did="0x0C00" name="Haswell" code="HSW" longname="Desktop 4th Generation Core Processor (Haswell CPU / Lynx Point PCH" />
     <sku did="0x0C04" name="Haswell" code="HSW" longname="Mobile 4th Generation Core Processor (Haswell M/H / Lynx Point PCH)" />
     <sku did="0x0C08" name="Haswell" code="HSW" longname="Intel Xeon Processor E3-1200 v3 (Haswell CPU, C220 Series PCH)" />

--- a/chipsec/cfg/8086/hsx.xml
+++ b/chipsec/cfg/8086/hsx.xml
@@ -14,7 +14,7 @@ Intel (c) C610 Series Chipset and Intel (c) X99 Chipset Platform Controller Hub 
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="xeon">
+  <info family="xeon" detection_value="3069x, 4066x">
     <sku did="0x2F00" name="Haswell Server" code="HSX" longname="Server 4th Generation Core Processor (Haswell Server CPU / Wellsburg PCH)" />
   </info>
 

--- a/chipsec/cfg/8086/icl.xml
+++ b/chipsec/cfg/8086/icl.xml
@@ -27,7 +27,7 @@ chipsec@intel.com
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core" detection_value="706E5">
+  <info family="core" detection_value="706e4, 706E5">
     <sku did="0x8A00" name="IceLake" code="ICL" longname="(IceLake Y 2 Cores)" />
     <sku did="0x8A02" name="IceLake" code="ICL" longname="(IceLake U 2 Cores)" />
     <sku did="0x8A10" name="IceLake" code="ICL" longname="(IceLake Y 4 Cores)" />

--- a/chipsec/cfg/8086/ivb.xml
+++ b/chipsec/cfg/8086/ivb.xml
@@ -9,7 +9,7 @@ XML configuration for IvyBridge based platforms
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core">
+  <info family="core" detection_value="306a8-306a9, 306e7, 306f2">
     <sku did="0x0150" name="Ivy Bridge" code="IVB" longname="Desktop 3rd Generation Core Processor (Ivy Bridge CPU / Panther Point PCH)" />
     <sku did="0x0154" name="Ivy Bridge" code="IVB" longname="Mobile 3rd Generation Core Processor (Ivy Bridge CPU / Panther Point PCH)" />
     <sku did="0x0158" name="Ivy Bridge" code="IVB" longname="Intel Xeon Processor E3-1200 v2 (Ivy Bridge CPU, C200/C216 Series PCH)" />

--- a/chipsec/cfg/8086/kbl.xml
+++ b/chipsec/cfg/8086/kbl.xml
@@ -15,7 +15,7 @@ http://www.intel.com/content/www/us/en/processors/core/core-technical-resources.
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core">
+  <info family="core" detection_value="8067x, 906e9">
     <sku did="0x5900" name="Kabylake" code="KBL" longname="Mobile 7th Generation Core Processor (Kabylake H)" />
     <sku did="0x5904" name="Kabylake" code="KBL" longname="Mobile 7th Generation Core Processor (Kabylake U)" />
     <sku did="0x590C" name="Kabylake" code="KBL" longname="Mobile 7th Generation Core Processor (Kabylake Y)" />

--- a/chipsec/cfg/8086/qrk.xml
+++ b/chipsec/cfg/8086/qrk.xml
@@ -9,7 +9,7 @@ XML configuration for Quark based platforms
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="quark">
+  <info family="quark" detection_value="590">
     <sku did="0x0958" name="Galileo " code="QRK" longname="Intel Quark SoC X1000" />
   </info>
 

--- a/chipsec/cfg/8086/skl.xml
+++ b/chipsec/cfg/8086/skl.xml
@@ -21,7 +21,7 @@ http://www.intel.com/content/www/us/en/processors/core/core-technical-resources.
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core">
+  <info family="core" detection_value="506ex">
     <sku did="0x1904" name="Skylake" code="SKL" longname="Mobile 6th Generation Core Processor (Skylake U)" />
     <sku did="0x190C" name="Skylake" code="SKL" longname="Mobile 6th Generation Core Processor (Skylake Y)" />
     <sku did="0x1900" name="Skylake" code="SKL" longname="Mobile 6th Generation Core Processor Dual Core (Skylake H)" />

--- a/chipsec/cfg/8086/skx.xml
+++ b/chipsec/cfg/8086/skx.xml
@@ -10,7 +10,7 @@ Intel (c) Xeon Processor Scalable Family datasheet Vol. 2
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="xeon" detection_value="50650-5065B">
+  <info family="xeon" detection_value="406ex, 506ex, 50650-5065B">
     <sku did="0x2020" name="Skylake" code="SKX" longname="Intel Xeon Processor E5/E7 v5 (Skylake)" />
   </info>
 

--- a/chipsec/cfg/8086/snb.xml
+++ b/chipsec/cfg/8086/snb.xml
@@ -9,7 +9,7 @@ XML configuration for Sandy Bridge based platforms
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core">
+  <info family="core" detection_value="306e0, 306e2-306e4,  206d6-206d7">
     <sku did="0x0100" name="Sandy Bridge" code="SNB" longname="Desktop 2nd Generation Core Processor (Sandy Bridge CPU / Cougar Point PCH)" />
     <sku did="0x0104" name="Sandy Bridge" code="SNB" longname="Mobile 2nd Generation Core Processor (Sandy Bridge CPU / Cougar Point PCH)" />
     <sku did="0x0108" name="Sandy Bridge" code="SNB" longname="Intel Xeon Processor E3-1200 (Sandy Bridge CPU, C200 Series PCH)" />

--- a/chipsec/cfg/8086/tglh.xml
+++ b/chipsec/cfg/8086/tglh.xml
@@ -36,7 +36,7 @@ http://www.intel.com/content/www/us/en/processors/core/core-technical-resources.
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core">
+  <info family="core" detection_value="806c1, 806c2, 806d1">
     <sku did="0x9A36" name="TigerLake" code="TGLH" longname="TGL-H (8 Cores)"/>
     <sku did="0x9A26" name="TigerLake" code="TGLH" longname="TGL-H (6 Cores)"/>
   </info>

--- a/chipsec/cfg/8086/tglu.xml
+++ b/chipsec/cfg/8086/tglu.xml
@@ -36,7 +36,7 @@ http://www.intel.com/content/www/us/en/processors/core/core-technical-resources.
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="core">
+  <info family="core" detection_value="806c1, 806c2, 806d1">
     <sku did="0x9A12" name="TigerLake" code="TGLU" longname="TGL UP4 4 Cores"/>
     <sku did="0x9A02" name="TigerLake" code="TGLU" longname="TGL UP4 2 Cores"/>
     <sku did="0x9A14" name="TigerLake" code="TGLU" longname="TGL UP3 4 Cores"/>

--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -226,12 +226,16 @@ class Chipset:
             # platform code was not passed in try to determine based upon cpu id
             vid_found = vid in self.chipset_dictionary
             did_found = did in self.chipset_dictionary[vid]
+            #check if multiple platform found by [vid][did]
             multiple_found = len(self.chipset_dictionary[vid][did]) > 1
+            logger().log_debug("read out cpuid:{}, platforms found per vid & did:{}, multiple:{}".format(cpuid, self.chipset_dictionary[vid][did], multiple_found))
+            for i in self.detection_dictionary.keys():
+                logger().log_debug("cpuid detection val:{}, plat:{}".format(i, self.detection_dictionary[i]))
             cpuid_found = cpuid in self.detection_dictionary.keys()
             if vid_found and did_found and multiple_found and cpuid_found:
                 for item in self.chipset_dictionary[vid][did]:
                     if self.detection_dictionary[cpuid] == item['code']:
-                        # matched processor with detection value
+                        # matched processor with detection value, cpuid used to decide the correct platform
                         _unknown_platform = False
                         data_dict = item
                         self.code = data_dict['code'].upper()

--- a/tests/software/mock_helper.py
+++ b/tests/software/mock_helper.py
@@ -326,6 +326,8 @@ class InvalidChipsetHelper(TestHelper):
         else:
             raise Exception("Unexpected PCI read")
 
+    def cpuid(self, eax, ecx):
+        return 0xfffff, 0, 0, 0
 
 class InvalidPchHelper(TestHelper):
     def read_pci_reg(self, bus, device, function, address, size):


### PR DESCRIPTION
1.  add cpuid detection string to xml files
2.  add cpuid detection debug mode print, cmdline para "-d" to show cpuid detection debug log 
     sudo python3.6 chipsec_util.py  -d cpu info

Signed-off-by: Zhou Jun, jun2.zhou@intel.com