### PR TITLE
Remove empty class definition parentheses

### DIFF
--- a/chipsec/hal/acpi.py
+++ b/chipsec/hal/acpi.py
@@ -194,7 +194,7 @@ ACPI_RSDP_EXT_SIZE = struct.calcsize(ACPI_RSDP_FORMAT + ACPI_RSDP_EXT_FORMAT)
 assert ACPI_RSDP_EXT_SIZE == 36
 
 
-class RSDP():
+class RSDP:
     def __init__(self, table_content):
         if len(table_content) == ACPI_RSDP_SIZE:
             (self.Signature, self.Checksum, self.OEMID,

--- a/chipsec/hal/acpi_tables.py
+++ b/chipsec/hal/acpi_tables.py
@@ -36,7 +36,7 @@ from chipsec.hal.uefi_common import EFI_GUID_FMT, EFI_GUID_STR
 from chipsec.defines import bytestostring
 
 
-class ACPI_TABLE():
+class ACPI_TABLE:
     def parse(self, table_content):
         return
 

--- a/chipsec/hal/uefi_common.py
+++ b/chipsec/hal/uefi_common.py
@@ -669,7 +669,7 @@ class S3BootScriptSmbusOperation:
     BWBR_PROCESS_CALL = 0x0B
 
 
-class op_io_pci_mem():
+class op_io_pci_mem:
     def __init__(self, opcode, size, width, address, unknown, count, buffer, value=None, mask=None):
         self.opcode = opcode
         self.size = size
@@ -709,7 +709,7 @@ class op_io_pci_mem():
         return str_r
 
 
-class op_smbus_execute():
+class op_smbus_execute:
     def __init__(self, opcode, size, address, command, operation, peccheck):
         self.opcode = opcode
         self.size = size
@@ -734,7 +734,7 @@ class op_smbus_execute():
 # } EFI_BOOT_SCRIPT_STALL;
 
 
-class op_stall():
+class op_stall:
     def __init__(self, opcode, size, duration):
         self.opcode = opcode
         self.size = size
@@ -753,7 +753,7 @@ class op_stall():
 # } EFI_BOOT_SCRIPT_DISPATCH;
 
 
-class op_dispatch():
+class op_dispatch:
     def __init__(self, opcode, size, entrypoint, context=None):
         self.opcode = opcode
         self.size = size
@@ -778,7 +778,7 @@ class op_dispatch():
 # } EFI_BOOT_SCRIPT_MEM_POLL;
 
 
-class op_mem_poll():
+class op_mem_poll:
     def __init__(self, opcode, size, width, address, duration, looptimes):
         self.opcode = opcode
         self.size = size
@@ -802,7 +802,7 @@ class op_mem_poll():
 # } EFI_BOOT_SCRIPT_TERMINATE;
 
 
-class op_terminate():
+class op_terminate:
     def __init__(self, opcode, size):
         self.opcode = opcode
         self.size = size
@@ -812,7 +812,7 @@ class op_terminate():
         return "  Opcode     : {} (0x{:02X})\n".format(self.name, self.opcode)
 
 
-class op_unknown():
+class op_unknown:
     def __init__(self, opcode, size):
         self.opcode = opcode
         self.size = size
@@ -821,7 +821,7 @@ class op_unknown():
         return "  Opcode     : unknown (0x{:02X})\n".format(self.opcode)
 
 
-class S3BOOTSCRIPT_ENTRY():
+class S3BOOTSCRIPT_ENTRY:
     def __init__(self, script_type, index, offset_in_script, length, data=None):
         self.script_type = script_type
         self.index = index
@@ -1037,7 +1037,7 @@ class EFI_VENDOR_TABLE(namedtuple('EFI_VENDOR_TABLE', 'VendorGuidData VendorTabl
         return EFI_GUID_STR(self.VendorGuidData)
 
 
-class EFI_CONFIGURATION_TABLE():
+class EFI_CONFIGURATION_TABLE:
     def __init__(self):
         self.VendorTables = {}
 

--- a/chipsec/hal/vmm.py
+++ b/chipsec/hal/vmm.py
@@ -137,7 +137,7 @@ def get_virtio_devices(devices):
     return virtio_devices
 
 
-class VirtIO_Device():
+class VirtIO_Device:
 
     def __init__(self, cs, b, d, f):
         self.cs = cs

--- a/chipsec/module.py
+++ b/chipsec/module.py
@@ -35,7 +35,7 @@ except ImportError:
 MODPATH_RE = re.compile("^\w+(\.\w+)*$")
 
 
-class Module():
+class Module:
     def __init__(self, name):
         self.logger = chipsec.logger.logger()
         self.name = name

--- a/chipsec/testcase.py
+++ b/chipsec/testcase.py
@@ -55,7 +55,7 @@ class ExitCode:
 """
 
 
-class ChipsecResults():
+class ChipsecResults:
     def __init__(self):
         self.test_cases = []
         self.properties = None
@@ -246,7 +246,7 @@ class ChipsecResults():
         return ret_string
 
 
-class TestCase():
+class TestCase:
     def __init__(self, name):
         self.name = name
         self.result = ''


### PR DESCRIPTION
Per the python3 recommendations: https://docs.python.org/3/tutorial/classes.html#class-definition-syntax

Signed-off-by: Nathaniel Mitchell <nathaniel.p.mitchell@intel.com>