### PR TITLE
Fix premature return at module children updating

### DIFF
--- a/chipsec/hal/spi_uefi.py
+++ b/chipsec/hal/spi_uefi.py
@@ -326,7 +326,7 @@ def update_efi_tree(modules, parent_guid=None):
                 # and propagate it up untill and including parent EFI file
                 for m1 in modules:
                     m1.ui_string = m.ui_string
-                return m.ui_string
+                ui_string = m.ui_string
         # update parent file's GUID in all children nodes
         if len(m.children) > 0:
             ui_string = update_efi_tree(m.children, parent_guid)


### PR DESCRIPTION
When update_efi_tree() is called recursively to update the attributes of a module which contains children, it is possible for the children attributes to be partially updated (effectively skipped) because a premature return occurs when a UI section is encountered. This means that the children modules may have missing (i.e. None) value for (parent) GUID.

The bug can be fixed by replacing the premature return statement with a "ui_string" variable assignment instead, which is then properly returned at the end of the update_efi_tree() function.

This PR solves #1637