### PR TITLE
Fix no-member crash errors at logger, uefi

### DIFF
--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -342,7 +342,7 @@ class UEFI(hal_base.HALBase):
 
     def read_EFI_variables_from_SPI(self, BIOS_region_base, BIOS_region_size):
         rom = self.cs.spi.read_spi(BIOS_region_base, BIOS_region_size)
-        efi_var_store = self.find_EFI_variable_store(rom, self._FWType)
+        efi_var_store = find_EFI_variable_store(rom, self._FWType)
         if efi_var_store:
             efi_vars = uefi_platform.EFI_VAR_DICT[self._FWType]['func_getefivariables']
             return efi_vars
@@ -350,7 +350,7 @@ class UEFI(hal_base.HALBase):
 
     def read_EFI_variables_from_file(self, filename):
         rom = read_file(filename)
-        efi_var_store = self.find_EFI_variable_store(rom, self._FWType)
+        efi_var_store = find_EFI_variable_store(rom, self._FWType)
         if efi_var_store:
             efi_vars = uefi_platform.EFI_VAR_DICT[self._FWType]['func_getefivariables']
             return efi_vars

--- a/chipsec/logger.py
+++ b/chipsec/logger.py
@@ -385,7 +385,7 @@ class Logger:
 
     def _write_log(self, text, filename):
         """Write text to defined log file"""
-        self.chipsecLogger.log(self.info, text)
+        self.chipsecLogger.log(level.INFO.value, text)
         if self.ALWAYS_FLUSH:
             try:
                 self.logfile.close()


### PR DESCRIPTION
Upon quick lynting of latest [v1.10.1 release](https://github.com/chipsec/chipsec/releases/tag/1.10.1), the following critical errors/crashes were found:

``` python
logger.py : 1 error, 12 warnings, 42 conventions, 6 refactors 
    Instance of 'Logger' has no 'info' member (388:31) [no-member]

uefi.py : 2 errors, 29 warnings, 176 conventions, 12 refactors 
    Instance of 'UEFI' has no 'find_EFI_variable_store' member (345:24) [no-member]
    Instance of 'UEFI' has no 'find_EFI_variable_store' member (353:24) [no-member]

uefi_compression.py : 3 errors, 4 warnings, 17 conventions, 3 refactors 
    Instance of 'UEFICompression' has no 'rotate_list' member (118:16) [no-member]
    Instance of 'UEFICompression' has no 'decompress_file' member (127:18) [no-member]
    Instance of 'UEFICompression' has no 'rotate_list' member (129:16) [no-member]
```

**Note 1:** It appears that the errors at "uefi_compression.py" have already been caught and are being addressed at #1658 

**Note 2:** Please validate that the wanted logic at the logger module method is really "level.INFO.value" but that's my best guess