### PR TITLE
Add MCHBAR to Raptor Lake configuration

### DIFF
--- a/chipsec/cfg/8086/rpl.xml
+++ b/chipsec/cfg/8086/rpl.xml
@@ -61,6 +61,7 @@ https://cdrdv2.intel.com/v1/dl/getContent/743844
     </info>
 
     <mmio>
+        <bar name="MCHBAR" bus="0" dev="0" fun="0" reg="0x48" width="8" mask="0x3FFFFFE0000" size="0x20000" enable_bit="0" desc="Host Memory Mapped Register Range"/>
         <bar name="TMBAR"      register="TMBAR"      base_field="BA" size="0x20000"   desc=""/>
         <bar name="GTTMMADR"   register="GTTMMADR"   base_field="BA" size="0x1000000" desc=""/>
     </mmio>


### PR DESCRIPTION
According to documentation (Document Number: 743846), MCHBAR is present in 13 Gen, the mask is for [41:17] bits and the enable bit is [0]