### PR TITLE
Don't display extended_banner if using --skip_config

### DIFF
--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -454,11 +454,11 @@ class ChipsecMain:
                 if self.failfast:
                     raise be
                 return ExitCode.EXCEPTION
+
+            if self._show_banner:
+                print_banner_properties(self._cs, defines.os_version())
         else:
             self.logger.log_warning("Platform dependent functionality is likely to be incorrect")
-
-        if self._show_banner:
-            print_banner_properties(self._cs, defines.os_version())
 
         self.logger.log(" ")
 

--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -190,13 +190,13 @@ class ChipsecUtil:
             except Exception as msg:
                 self.logger.log(str(msg), level.ERROR)
                 sys.exit(ExitCode.EXCEPTION)
+
+            if self._show_banner:
+                print_banner_properties(self._cs, os_version())
         else:
             if comm.requires_driver():
                 self.logger.log("Cannot run without driver loaded", level.ERROR)
                 sys.exit(ExitCode.OK)
-
-        if self._show_banner:
-            print_banner_properties(self._cs, os_version())
 
         self.logger.log("[CHIPSEC] Executing command '{}' with args {}\n".format(self._cmd, self.argv[2:]))
         comm.run()


### PR DESCRIPTION
Don't display extended_banner if using the `--skip_config` switch (no need to).