### PR TITLE
Fix CPUID detection value of Gemini Lake (GLK)

### DIFF
--- a/chipsec/cfg/8086/glk.xml
+++ b/chipsec/cfg/8086/glk.xml
@@ -9,7 +9,7 @@
   <!-- Information                          -->
   <!--                                      -->
   <!-- #################################### -->
-  <info family="atom" detection_value="7006a">
+  <info family="atom" detection_value="706ax">
     <sku did="0x3180" name="Gemini Lake" code="GLK" longname="Gemini Lake" />
     <sku did="0x31F0" name="Gemini Lake" code="GLK" longname="Gemini Lake" />
   </info>


### PR DESCRIPTION
The value `7006a` is not a valid CPUID: it would be "family 0, model 0x76, stepping 0xa".

According to the relase notes in Intel Microcode Data Files repository https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/2be47edc99eeeb5b6d76bf9450b74747cdaf3263/releasenote.md there are at least two possible CPUIDs related to GLK:

- 06-7a-01 (which is value 0x706a1) is "GLK"
- 06-7a-08 (which is value 0x706a8) is "GLK-R"

Fix the detection value for GLK processor to `706ax`, meaning "family 6, model 0x7a, any stepping".