### PR TITLE
Fix error when generating pypi package to include .h files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 chipsec.egg-info
 dist
 build
+MANIFEST
 
 # Linux driver
 chipsec/helper/linux/*.ko

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft chipsec_tools/compression/Include


### PR DESCRIPTION
Include a manifest file that forces in the header files for compression into the pypi package. 