### PR TITLE
Add Intel TXT register definitions from the SEAM Loader

### DIFF
--- a/chipsec/cfg/8086/txt.xml
+++ b/chipsec/cfg/8086/txt.xml
@@ -27,6 +27,7 @@ only the public space registers were described here.
       <field name="SENTER_DONE_STS" bit="0" size="1" desc="SENTER Done"/>
       <field name="SEXIT_DONE_STS" bit="1" size="1" desc="SEXIT Done"/>
       <field name="MEM_UNLOCK_STS" bit="4" size="1" desc="Memory Unlocked"/>
+      <field name="MEM_BASE_LOCK_STS" bit="5" size="1" desc="Memory Base Locked"/>
       <field name="MEM_CONFIG_LOCK_STS" bit="6" size="1" desc="Memory Configuration Locked"/>
       <field name="PRIVATE_OPEN_STS" bit="7" size="1" desc="Open-Private Command Performed"/>
       <field name="NTP_ENABLE_STS" bit="10" size="1" desc="NTP Enabled"/>
@@ -36,12 +37,17 @@ only the public space registers were described here.
       <field name="TXT_LOCALITY3_OPEN_STS" bit="14" size="1" desc="Locality 3 Opened"/>
       <field name="TXT_LOCALITY1_OPEN_STS" bit="15" size="1" desc="Locality 1 Opened"/>
       <field name="TXT_LOCALITY2_OPEN_STS" bit="16" size="1" desc="Locality 2 Opened"/>
+      <field name="SEQ_IN_PROGRESS" bit="17" size="1" desc="Seq In Progress"/>
     </register>
     <register name="TXT_ESTS" type="memory" access="mmio" address="0xFED30000" offset="0x008" size="8" desc="TXT Error Status">
       <field name="TXT_RESET_STS" bit="0" size="1" desc="TXT Reset"/>
       <field name="ROGUE_STS" bit="1" size="1" desc="Rogue Status"/>
+      <field name="MEMORY_ATTACK" bit="2" size="1" desc="Memory Attack"/>
+      <field name="ALIAS_FAULT" bit="5" size="1" desc="Alias Fault"/>
       <field name="WAKE_ERROR_STS" bit="6" size="1" desc="Wake Error"/>
     </register>
+    <register name="TXT_THREADS_EXISTS" type="memory" access="mmio" address="0xFED30000" offset="0x010" size="8" desc="TXT Threads Exists"/>
+    <register name="TXT_THREADS_JOIN" type="memory" access="mmio" address="0xFED30000" offset="0x020" size="8" desc="TXT Threads Join"/>
     <register name="TXT_ERRORCODE" type="memory" access="mmio" address="0xFED30000" offset="0x030" size="8" desc="TXT Error Code (0xC0000001 when successful SINIT)">
       <field name="TYPE2_MODULE_TYPE" bit="0" size="4" desc="Module Type (0 for BIOS ACM, 1 for SINIT)"/>
       <field name="TYPE2_CLASS_CODE" bit="4" size="6" desc="Class Code"/>
@@ -54,7 +60,11 @@ only the public space registers were described here.
     </register>
 
     <!-- TXT_CMD_RESET at offset 0x38 -->
+    <!-- TXT_CMD_OPEN_PRIVATE at offset 0x40 -->
     <!-- TXT_CMD_CLOSE_PRIVATE at offset 0x48 -->
+
+    <!-- TDX's SEAM Loader documents LT_CRASH2 with LT_CRASH being the old name of TXT_ERRORCODE -->
+    <register name="TXT_CRASH2" type="memory" access="mmio" address="0xFED30000" offset="0x050" size="8" desc="Second Error Code"/>
 
     <register name="TXT_SPAD" type="memory" access="mmio" address="0xFED30000" offset="0x0A0" size="8" desc="Boot Status">
       <field name="ACM_INTERNAL" bit="0" size="30" desc="ACM Internal Use"/>
@@ -80,6 +90,7 @@ only the public space registers were described here.
       <field name="RID" bit="32" size="16" desc="Revision ID"/>
       <field name="EXTID" bit="48" size="16" desc="Extended ID"/>
     </register>
+    <register name="TXT_EID" type="memory" access="mmio" address="0xFED30000" offset="0x118" size="8" desc="TXT EID"/>
 
     <!--
       TXT.VER.QPIIF was renamed TXT.VER.EMIF "for EMC Version Number Register"
@@ -92,15 +103,40 @@ only the public space registers were described here.
       <field name="DEBUG_FUSE" bit="31" size="1" desc="Chipset is Production Fused (0 for Debug)"/>
     </register>
 
+    <!-- TXT_CMD_LOCK_MEM_CONFIG at offset 0x210 -->
     <!-- TXT_CMD_UNLOCK_MEM_CONFIG at offset 0x218 -->
+    <!-- TXT_CMD_UNLOCK_MEMORY at offset 0x220 -->
+    <!-- TXT_LOCK_BASE at offset 0x230 -->
+    <!-- TXT_UNLOCK_BASE at offset 0x238 -->
+    <!-- TXT_CMD_CACHE_INVALIDATE at offset 0x250 -->
+    <!-- TXT_CMD_FLUSH_WB at offset 0x258 -->
 
+    <register name="TXT_NODMA_BASE" type="memory" access="mmio" address="0xFED30000" offset="0x260" size="4" desc="No DMA Base Address"/>
+    <register name="TXT_NODMA_SIZE" type="memory" access="mmio" address="0xFED30000" offset="0x268" size="4" desc="No DMA Size"/>
     <register name="TXT_SINIT_BASE" type="memory" access="mmio" address="0xFED30000" offset="0x270" size="4" desc="SINIT Base Address"/>
     <register name="TXT_SINIT_SIZE" type="memory" access="mmio" address="0xFED30000" offset="0x278" size="4" desc="SINIT Size"/>
+
+    <!-- TXT_CMD_LOCK_PMRC at offset 0x280 -->
+    <!-- TXT_CMD_UNLOCK_PMRC at offset 0x288 -->
+
     <register name="TXT_MLE_JOIN" type="memory" access="mmio" address="0xFED30000" offset="0x290" size="4" desc="MLE Join Base Address"/>
+    <register name="TXT_BLOCKMAP_CAP" type="memory" access="mmio" address="0xFED30000" offset="0x2A0" size="8" desc="Block Map CAP"/>
+    <register name="TXT_BLOCKMAP_CNF" type="memory" access="mmio" address="0xFED30000" offset="0x2A8" size="8" desc="Block Map CNF"/>
+    <register name="TXT_BLOCKMAP_POINTER" type="memory" access="mmio" address="0xFED30000" offset="0x2B0" size="8" desc="Block Map Pointer"/>
+
+    <!-- TXT_CMD_BLOCKMAP_EN at offset 0x2C0 -->
+    <!-- TXT_CMD_BLOCKMAP_DIS at offset 0x2C8 -->
+    <!-- TXT_CMD_NODMA_CACHE_EN at offset 0x2D0 -->
+    <!-- TXT_CMD_NODMA_CACHE_DIS at offset 0x2D8 -->
+    <!-- TXT_CMD_NODMA_TABLE_PROTECT_EN at offset 0x2E0 -->
+    <!-- TXT_CMD_NODMA_TABLE_PROTECT_DIS at offset 0x2E8 -->
+    <!-- TXT_CMD_MEM_CONFIG_CHECKED at offset 0x2F0 -->
+
     <register name="TXT_HEAP_BASE" type="memory" access="mmio" address="0xFED30000" offset="0x300" size="4" desc="TXT Heap Base Address"/>
     <register name="TXT_HEAP_SIZE" type="memory" access="mmio" address="0xFED30000" offset="0x308" size="4" desc="TXT Heap Size"/>
     <register name="TXT_MSEG_BASE" type="memory" access="mmio" address="0xFED30000" offset="0x310" size="4" desc="TXT MSEG Base Address"/>
     <register name="TXT_MSEG_SIZE" type="memory" access="mmio" address="0xFED30000" offset="0x318" size="4" desc="TXT MSEG Size"/>
+    <register name="TXT_SCRATCHPAD_0" type="memory" access="mmio" address="0xFED30000" offset="0x320" size="8" desc="TXT Scratchpad 0"/>
     <register name="TXT_ACM_STATUS" type="memory" access="mmio" address="0xFED30000" offset="0x328" size="4" desc="TXT ACM Status">
        <field name="MODULE_TYPE" bit="0" size="4" desc="Module Type"/>
        <field name="CLASS_CODE" bit="4" size="6" desc="Class Code"/>
@@ -109,6 +145,7 @@ only the public space registers were described here.
        <field name="MINOR_ERROR_CODE" bit="16" size="12" desc="Minor Error Code"/>
        <field name="VALID" bit="31" size="1" desc="Valid"/>
     </register>
+    <register name="TXT_ACM_BIOS_POLICY" type="memory" access="mmio" address="0xFED30000" offset="0x32C" size="4" desc="TXT ACM BIOS Policy"/>
     <register name="TXT_DPR" type="memory" access="mmio" address="0xFED30000" offset="0x330" size="4" desc="TXT DMA Protected Range (deprecated, replaced by PCI0.0.0_DPR)">
       <field name="LOCK" bit="0" size="1" desc="Lock Bits 19:0"/>
       <field name="SIZE" bit="4" size="8" desc="Protected Memory Size (in MB)"/>
@@ -121,6 +158,11 @@ only the public space registers were described here.
       <field name="FIT_FALLBACK" bit="3" size="1" desc="FIT Fallback"/>
     </register>
 
+    <register name="TXT_INCREMENT" type="memory" access="mmio" address="0xFED30000" offset="0x350" size="8" desc="TXT Increment"/>
+    <register name="TXT_SPAD_3" type="memory" access="mmio" address="0xFED30000" offset="0x358" size="8" desc="TXT Status 3"/>
+    <register name="TXT_SCRATCHPAD_4" type="memory" access="mmio" address="0xFED30000" offset="0x360" size="8" desc="TXT Scratchpad 4"/>
+    <register name="TXT_SCRATCHPAD_5" type="memory" access="mmio" address="0xFED30000" offset="0x368" size="8" desc="TXT Scratchpad 5"/>
+    <register name="TXT_INCREMENT_2" type="memory" access="mmio" address="0xFED30000" offset="0x370" size="8" desc="TXT Increment 2"/>
     <register name="TXT_SCRATCHPAD" type="memory" access="mmio" address="0xFED30000" offset="0x378" size="8" desc="ACM Policy Status">
       <field name="TPM_TYPE" bit="13" size="2" desc="TPM type detected by Startup ACM (0 for no TPM, 1 for dTPM1.2, 2 for dTPM2.0, 3 for PTT)"/>
       <field name="TPM_SUCCESS" bit="15" size="1" desc="TPM Success"/>
@@ -138,19 +180,34 @@ only the public space registers were described here.
     <!-- TXT_CMD_CLOSE_LOCALITY1 at offset 0x388 -->
     <!-- TXT_CMD_OPEN_LOCALITY2 at offset 0x390 -->
     <!-- TXT_CMD_CLOSE_LOCALITY2 at offset 0x398 -->
+    <!-- TXT_CMD_OPEN_LOCALITY3 at offset 0x3A0 -->
+    <!-- TXT_CMD_CLOSE_LOCALITY3 at offset 0x3A8 -->
 
     <register name="TXT_PUBLIC_KEY_0" type="memory" access="mmio" address="0xFED30000" offset="0x400" size="8" desc="ACM Public Key Hash (bits 0:63)"/>
     <register name="TXT_PUBLIC_KEY_1" type="memory" access="mmio" address="0xFED30000" offset="0x408" size="8" desc="ACM Public Key Hash (bits 64:127)"/>
     <register name="TXT_PUBLIC_KEY_2" type="memory" access="mmio" address="0xFED30000" offset="0x410" size="8" desc="ACM Public Key Hash (bits 128:191)"/>
     <register name="TXT_PUBLIC_KEY_3" type="memory" access="mmio" address="0xFED30000" offset="0x418" size="8" desc="ACM Public Key Hash (bits 192:255)"/>
 
+    <register name="TXT_ESTS_SET" type="memory" access="mmio" address="0xFED30000" offset="0x608" size="8" desc="TXT ESTS Set"/>
+    <register name="TXT_EXISTS_SET" type="memory" access="mmio" address="0xFED30000" offset="0x610" size="8" desc="TXT EXISTS Set"/>
+    <register name="TXT_JOINS_SET" type="memory" access="mmio" address="0xFED30000" offset="0x620" size="8" desc="TXT JOINS Set"/>
+    <register name="TXT_SCLEAN_SET" type="memory" access="mmio" address="0xFED30000" offset="0x670" size="8" desc="TXT SCLEAN Set"/>
+    <register name="TXT_SPAD_SET" type="memory" access="mmio" address="0xFED30000" offset="0x6A0" size="8" desc="TXT SPAD Set"/>
+    <register name="TXT_EXISTS_CLEAR" type="memory" access="mmio" address="0xFED30000" offset="0x710" size="8" desc="TXT EXISTS Clear"/>
+    <register name="TXT_JOINS_CLEAR" type="memory" access="mmio" address="0xFED30000" offset="0x720" size="8" desc="TXT EXISTS Clear"/>
+    <register name="TXT_SCLEAN_CLEAR" type="memory" access="mmio" address="0xFED30000" offset="0x770" size="8" desc="TXT SCLEAN Clear"/>
+    <register name="TXT_SPAD_CLEAR" type="memory" access="mmio" address="0xFED30000" offset="0x7A0" size="8" desc="TXT SPAD Clear"/>
+
+    <register name="TXT_VER_FTIF" type="memory" access="mmio" address="0xFED30000" offset="0x800" size="4" desc="TXT FT Interface">
+      <field name="TPM_IF" bit="16" size="4" desc="TPM Inteface (0 if not present, 1 for LPC, 5 for SPI, 7 for CRB and fTPM)"/>
+    </register>
     <register name="TXT_PCH_DIDVID" type="memory" access="mmio" address="0xFED30000" offset="0x810" size="8" desc="TXT Platform Controller Hub Device ID">
       <field name="VID" bit="0" size="16" desc="Vendor ID"/>
       <field name="DID" bit="16" size="16" desc="Device ID"/>
       <field name="RID" bit="32" size="16" desc="Revision ID"/>
     </register>
 
-    <register name="INSMM" type="memory" access="mmio" address="0xFED30000" offset="0x880" size="4" desc="InSMM.STS">
+    <register name="INSMM" type="memory" access="mmio" address="0xFED30000" offset="0x880" size="4" desc="InSMM.STS (also known as LT.UCS)">
       <field name="STS" bit="0" size="1" desc="BIOS Write Enable when enabled by SPI.BC.EISS=1"/>
     </register>
 
@@ -158,8 +215,31 @@ only the public space registers were described here.
     <!-- TXT_CMD_NO_SECRETS at offset 0x8E8 -->
 
     <register name="TXT_E2STS" type="memory" access="mmio" address="0xFED30000" offset="0x8F0" size="8" desc="TXT Extended Error Status">
+      <field name="SLEEP_ENTRY_ERROR_STS" bit="0" size="1" desc="Sleep Entry Error"/>
       <field name="SECRETS_STS" bit="1" size="1" desc="Secrets in Memory"/>
+      <field name="BLOCK_MEM_STS" bit="2" size="1" desc="Block Memory"/>
+      <field name="RESET_STS" bit="3" size="1" desc="Reset Status"/>
+      <field name="RESET_STS" bit="32" size="1" desc="Reset Policy"/>
     </register>
+
+    <register name="TXT_FT_REGS1" type="memory" access="mmio" address="0xFED30000" offset="0x900" size="4" desc="TXT FT Regs 1"/>
+    <register name="TXT_FT_REGS2" type="memory" access="mmio" address="0xFED30000" offset="0x904" size="4" desc="TXT FT Regs 2"/>
+
+    <register name="TXT_SEQ_START" type="memory" access="mmio" address="0xFED30000" offset="0xD80" size="8" desc="TXT Seq Start"/>
+    <register name="TXT_SEQ_DONE" type="memory" access="mmio" address="0xFED30000" offset="0xD90" size="8" desc="TXT Seq Done"/>
+
+    <register name="TXT_INCREMENT_3" type="memory" access="mmio" address="0xFED30000" offset="0xD98" size="8" desc="TXT Increment 3"/>
+    <register name="TXT_SCRATCHPAD_7" type="memory" access="mmio" address="0xFED30000" offset="0xDA0" size="8" desc="TXT Scratchpad 7"/>
+    <register name="TXT_INCREMENT_4" type="memory" access="mmio" address="0xFED30000" offset="0xDA8" size="8" desc="TXT Increment 4"/>
+    <register name="TXT_SCRATCHPAD_8" type="memory" access="mmio" address="0xFED30000" offset="0xDB0" size="8" desc="TXT Scratchpad 8"/>
+    <register name="TXT_INCREMENT_5" type="memory" access="mmio" address="0xFED30000" offset="0xDB8" size="8" desc="TXT Increment 5"/>
+    <register name="TXT_SCRATCHPAD_9" type="memory" access="mmio" address="0xFED30000" offset="0xDC0" size="8" desc="TXT Scratchpad 9"/>
+    <register name="TXT_INCREMENT_6" type="memory" access="mmio" address="0xFED30000" offset="0xDC8" size="8" desc="TXT Increment 6"/>
+    <register name="TXT_SCRATCHPAD_10" type="memory" access="mmio" address="0xFED30000" offset="0xDD0" size="8" desc="TXT Scratchpad 10"/>
+    <register name="TXT_INCREMENT_7" type="memory" access="mmio" address="0xFED30000" offset="0xDD8" size="8" desc="TXT Increment 7"/>
+    <register name="TXT_SCRATCHPAD_11" type="memory" access="mmio" address="0xFED30000" offset="0xDE0" size="8" desc="TXT Scratchpad 11"/>
+    <register name="TXT_INCREMENT_8" type="memory" access="mmio" address="0xFED30000" offset="0xDE8" size="8" desc="TXT Increment 8"/>
+    <register name="TXT_SCRATCHPAD_12" type="memory" access="mmio" address="0xFED30000" offset="0xDF0" size="8" desc="TXT Scratchpad 12"/>
   </registers>
 
   <controls>


### PR DESCRIPTION
Hello,

Intel published the names of more registers in the source code of the SEAM (Secure Arbitration Mode) Loader used in TDX (Intel Trust Domain Extensions). It was previously available on https://github.com/intel/seam-loader/blob/eadff76d36d214419c801f1cee1828ea437c91a5/np-seam-loader/seamldr_src/Core/Include/common.h#L573-L726.
This repository has been removed and its content moved to a ZIP archive hosted on https://www.intel.de/content/www/de/de/download/738874/intel-trust-domain-extension-intel-tdx-loader.html (tdx-loader-v1.0.01.01.zip contains `seam-loader-main/seam-loader-main/np-seam-loader/seamldr_src/Core/Include/common.h`).

Some old bits were also documented in Intel® Xeon® Processor 3400 Series Datasheet – Volume 2 (January 2010, Document Number: 322372-002). It can be downloaded on https://usermanual.wiki/m/0f9860c7501c379fd53b7963aa41cbb7911ac71732b0ba044a8c5820b3042cfd.pdf and defines the registers in sections "3.6 Intel® Trusted Execution Technology (Intel® TXT) Register Map".

There are some inconsistencies. For example the datasheet documents `TXT.ALIAS.FAULT` as bit 5 of `TXT.ESTS` while the SEAM Loader defines `UINT32  Aliasi_Fault : 1;` in structure `REG_ESTS`. This `i` is probably a typo.

This Pull Request adds the names of registers and bits to `chipsec/cfg/8086/txt.xml`.