### PR TITLE
Intel TXT: fix some misspellings

### DIFF
--- a/chipsec/cfg/8086/txt.xml
+++ b/chipsec/cfg/8086/txt.xml
@@ -199,7 +199,7 @@ only the public space registers were described here.
     <register name="TXT_SPAD_CLEAR" type="memory" access="mmio" address="0xFED30000" offset="0x7A0" size="8" desc="TXT SPAD Clear"/>
 
     <register name="TXT_VER_FTIF" type="memory" access="mmio" address="0xFED30000" offset="0x800" size="4" desc="TXT FT Interface">
-      <field name="TPM_IF" bit="16" size="4" desc="TPM Inteface (0 if not present, 1 for LPC, 5 for SPI, 7 for CRB and fTPM)"/>
+      <field name="TPM_IF" bit="16" size="4" desc="TPM Interface (0 if not present, 1 for LPC, 5 for SPI, 7 for CRB and fTPM)"/>
     </register>
     <register name="TXT_PCH_DIDVID" type="memory" access="mmio" address="0xFED30000" offset="0x810" size="8" desc="TXT Platform Controller Hub Device ID">
       <field name="VID" bit="0" size="16" desc="Vendor ID"/>
@@ -219,7 +219,7 @@ only the public space registers were described here.
       <field name="SECRETS_STS" bit="1" size="1" desc="Secrets in Memory"/>
       <field name="BLOCK_MEM_STS" bit="2" size="1" desc="Block Memory"/>
       <field name="RESET_STS" bit="3" size="1" desc="Reset Status"/>
-      <field name="RESET_STS" bit="32" size="1" desc="Reset Policy"/>
+      <field name="RESET_POLICY" bit="32" size="1" desc="Reset Policy"/>
     </register>
 
     <register name="TXT_FT_REGS1" type="memory" access="mmio" address="0xFED30000" offset="0x900" size="4" desc="TXT FT Regs 1"/>


### PR DESCRIPTION
Bit 32 of TXT_E2STS is defined as `UINT32  Reset_Policy : 1;` in the SEAM Loader (https://www.intel.de/content/www/de/de/download/738874/intel-trust-domain-extension-intel-tdx-loader.html file `np-seam-loader/seamldr_src/Core/Include/common.h`).

There was also a spelling mistake in the description of field `TPM_IF`.