### PR TITLE
Add ability to parse non-UEFI section data

### DIFF
--- a/chipsec/hal/spi_uefi.py
+++ b/chipsec/hal/spi_uefi.py
@@ -269,7 +269,7 @@ def build_efi_file_tree(fv_img: bytes, fwtype: str) -> List[EFI_FILE]:
                 fv.append(non_UEFI)
         padding += fw_offset
         if fwbin.Type not in (EFI_FV_FILETYPE_ALL, EFI_FV_FILETYPE_RAW, EFI_FV_FILETYPE_FFS_PAD):
-            fwbin.children = build_efi_modules_tree(fwtype, fwbin.Image, fwbin.Size, fwbin.HeaderSize, polarity)
+            fwbin.children = efi_data_search(fwbin.Image, fwtype, polarity)
             fv.append(fwbin)
         elif fwbin.Type == EFI_FV_FILETYPE_RAW:
             if fwbin.Name != NVAR_NVRAM_FS_FILE:
@@ -286,7 +286,7 @@ def build_efi_file_tree(fv_img: bytes, fwtype: str) -> List[EFI_FILE]:
             if non_UEFI.children:
                 fv.append(non_UEFI)
         elif fwbin.State not in (EFI_FILE_HEADER_CONSTRUCTION, EFI_FILE_HEADER_INVALID, EFI_FILE_HEADER_VALID):
-            fwbin.children = build_efi_modules_tree(fwtype, fwbin.Image, fwbin.Size, fwbin.HeaderSize, polarity)
+            fwbin.children = efi_data_search(fwbin.Image, fwtype, polarity)
             fv.append(fwbin)
         fwbin = NextFwFile(fv_img, fv_size, fw_offset, polarity)
         if fwbin is None and fv_size > fw_offset:

--- a/chipsec/hal/uefi_fv.py
+++ b/chipsec/hal/uefi_fv.py
@@ -275,7 +275,7 @@ class EFI_SECTION(EFI_MODULE):
         if self.DataOffset:
             _s += f' DataOffset {self.DataOffset:04X}h'
         if self.Comments:
-            _s += f'Comments {self.Comments}'
+            _s += f' Comments {self.Comments}'
         _s += super(EFI_SECTION, self).__str__()
         return bytestostring(_s)
 


### PR DESCRIPTION
Attempt to address #1790.  Add ability to parse for modules when a large section of unidentified data is found.