### PR TITLE
Make chipsec.init() resilient to platform with unknown VID/DID

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -233,10 +233,10 @@ class Chipset:
         if platform_code is None:
             # platform code was not passed in try to determine based upon cpu id
             vid_found = vid in self.chipset_dictionary
-            did_found = did in self.chipset_dictionary[vid]
+            did_found = vid_found and (did in self.chipset_dictionary[vid])
             #check if multiple platform found by [vid][did]
-            multiple_found = len(self.chipset_dictionary[vid][did]) > 1
-            logger().log_debug(f'read out cpuid:{self.cpuid}, platforms found per vid & did:{self.chipset_dictionary[vid][did]}, multiple:{multiple_found}')
+            multiple_found = did_found and len(self.chipset_dictionary[vid][did]) > 1
+            logger().log_debug(f'read out cpuid:{self.cpuid}, platforms found per vid & did:{self.chipset_dictionary[vid][did] if did_found else None}, multiple:{multiple_found}')
             for i in self.detection_dictionary.keys():
                 logger().log_debug(f'cpuid detection val:{i}, plat:{self.detection_dictionary[i]}')
             cpuid_found = self.cpuid in self.detection_dictionary.keys()


### PR DESCRIPTION
If the vendor ID or the device ID returned by `detect_platform()` is not known in `chipset_dictionary`, accessing
`self.chipset_dictionary[vid][did]` raises a `KeyError` exception. To prevent this, use the variables `vid_found` and `did_found` before accessing `self.chipset_dictionary[vid][did]`.

(For information, I stumbled upon this bug while working on another topic which broke `helper.read_pci_reg`, as VID/DID `0xFFFF`/`0xFFFF` is not known)