### PR TITLE
Fix spidesc table of Master Read/Write Access to Flash Regions

### DIFF
--- a/chipsec/hal/spi_descriptor.py
+++ b/chipsec/hal/spi_descriptor.py
@@ -222,7 +222,7 @@ def parse_spi_flash_descriptor(cs, rom: bytes) -> None:
     logger().log(s)
     logger().log('--------------------------------------------------------')
     for r in range(nr):
-        s = 'f{r:-2d} {spi.SPI_REGION_NAMES[r]:20s} '
+        s = f'{r:-2d} {spi.SPI_REGION_NAMES[r]:20s} '
         for m in range(nm):
             access_s = ''
             mask = (0x1 << r)


### PR DESCRIPTION
Currently, `chipsec_util.py spidesc spi_rom.bin` displays:

    Master Read/Write Access to Flash Regions
    --------------------------------------------------------
     Region                 | CPU      | ME
    --------------------------------------------------------
    f{r:-2d} {spi.SPI_REGION_NAMES[r]:20s} |          |

The `f` was not positioned correctly in the formatted string.