### PR TITLE
Replace print_buffer(bytestostring(data)) with print_buffer_bytes

### DIFF
--- a/chipsec/hal/msr.py
+++ b/chipsec/hal/msr.py
@@ -35,7 +35,7 @@ usage:
 """
 
 from typing import Dict, Tuple, Optional
-from chipsec.logger import logger, print_buffer
+from chipsec.logger import logger, print_buffer_bytes
 
 
 DESCRIPTOR_TABLE_CODE_IDTR = 0
@@ -141,14 +141,14 @@ class Msr:
         logger().log(f'[cpu{cpu_thread_id:d}] Physical Address: 0x{pa:016X}')
         logger().log(f'[cpu{cpu_thread_id:d}] # of entries    : {total_num:d}')
         logger().log(f'[cpu{cpu_thread_id:d}] Contents ({num_entries:d} entries):')
-        print_buffer(dt)
+        print_buffer_bytes(dt)
         logger().log('--------------------------------------')
         logger().log('#    segment:offset         attributes')
         logger().log('--------------------------------------')
         for i in range(0, num_entries):
-            offset = (ord(dt[i * 16 + 11]) << 56) | (ord(dt[i * 16 + 10]) << 48) | (ord(dt[i * 16 + 9]) << 40) | (ord(dt[i * 16 + 8]) << 32) | (ord(dt[i * 16 + 7]) << 24) | (ord(dt[i * 16 + 6]) << 16) | (ord(dt[i * 16 + 1]) << 8) | ord(dt[i * 16 + 0])
-            segsel = (ord(dt[i * 16 + 3]) << 8) | ord(dt[i * 16 + 2])
-            attr = (ord(dt[i * 16 + 5]) << 8) | ord(dt[i * 16 + 4])
+            offset = (dt[i * 16 + 11] << 56) | (dt[i * 16 + 10] << 48) | (dt[i * 16 + 9] << 40) | (dt[i * 16 + 8] << 32) | (dt[i * 16 + 7] << 24) | (dt[i * 16 + 6] << 16) | (dt[i * 16 + 1] << 8) | dt[i * 16 + 0]
+            segsel = (dt[i * 16 + 3] << 8) | dt[i * 16 + 2]
+            attr = (dt[i * 16 + 5] << 8) | dt[i * 16 + 4]
             logger().log(f'{i:03d}  {segsel:04X}:{offset:016X}  0x{attr:04X}')
 
         return (pa, dt)

--- a/chipsec/hal/spi.py
+++ b/chipsec/hal/spi.py
@@ -47,7 +47,7 @@ import time
 from typing import Dict, Tuple, Optional
 from chipsec.defines import ALIGNED_4KB, BIT0, BIT1, BIT2, BIT5
 from chipsec.file import write_file, read_file
-from chipsec.logger import print_buffer, print_buffer_bytes
+from chipsec.logger import print_buffer_bytes
 from chipsec.hal import hal_base, mmio
 from chipsec.helper import oshelper
 from chipsec.hal.spi_jedec_ids import JEDEC_ID
@@ -577,7 +577,7 @@ class SPI(hal_base.HALBase):
         if filename is not None:
             write_file(filename, buf)
         else:
-            print_buffer(buf, 16)
+            print_buffer_bytes(buf, 16)
         return buf
 
     def write_spi_from_file(self, spi_fla: int, filename: str) -> bool:

--- a/chipsec/hal/spi_descriptor.py
+++ b/chipsec/hal/spi_descriptor.py
@@ -29,8 +29,7 @@ usage:
 
 import struct
 from typing import Dict, List, Optional, Tuple
-from chipsec.logger import logger, print_buffer
-from chipsec.defines import bytestostring
+from chipsec.logger import logger, print_buffer_bytes
 from chipsec.hal import spi
 from binascii import hexlify
 
@@ -254,7 +253,7 @@ def parse_spi_flash_descriptor(cs, rom: bytes) -> None:
     logger().log('')
     logger().log(f'+ 0x{0xF00:04X} OEM Section:')
     logger().log('========================================================')
-    print_buffer(bytestostring(fd[0xF00:]))
+    print_buffer_bytes(fd[0xF00:])
 
     logger().log('')
     logger().log('########################################################')

--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -35,7 +35,7 @@ from chipsec.hal.uefi_common import EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS, EFI
 from chipsec.hal.uefi_common import EFI_VARIABLE_BOOTSERVICE_ACCESS, EFI_VARIABLE_RUNTIME_ACCESS, EFI_VARIABLE_HARDWARE_ERROR_RECORD, SECURE_BOOT_SIG_VAR
 from chipsec.hal.uefi_common import IS_VARIABLE_ATTRIBUTE, EFI_TABLE_HEADER_FMT, EFI_SYSTEM_TABLE_SIGNATURE, EFI_RUNTIME_SERVICES_SIGNATURE, EFI_BOOT_SERVICES_SIGNATURE
 from chipsec.hal.uefi_common import EFI_DXE_SERVICES_TABLE_SIGNATURE, EFI_CONFIGURATION_TABLE, ACPI_VARIABLE_SET_STRUCT_SIZE
-from chipsec.logger import logger, print_buffer
+from chipsec.logger import logger, print_buffer_bytes
 from chipsec.file import write_file, read_file
 from chipsec.defines import bytestostring
 from chipsec.helper.oshelper import OsHelperError
@@ -73,7 +73,7 @@ def parse_script(script: bytes, log_script: bool = False) -> List['S3BOOTSCRIPT_
     logger().log_hal(f'[uefi] S3 Resume Boot-Script size: 0x{off:X}')
     logger().log_hal('\n[uefi] [++++++++++ S3 Resume Boot-Script Buffer ++++++++++]')
     if logger().HAL:
-        print_buffer(bytestostring(script[: off]))
+        print_buffer_bytes(script[: off])
 
     return s3_boot_script_entries
 
@@ -204,13 +204,13 @@ def print_efi_variable(offset: int, var_buf: bytes, var_header: EFI_TABLE_HEADER
 
     # Print Variable Data
     logger().log('Data:')
-    print_buffer(bytestostring(var_data))
+    print_buffer_bytes(var_data)
 
     # Print Variable Full Contents
     if logger().VERBOSE:
         logger().log('Full Contents:')
         if var_buf is not None:
-            print_buffer(bytestostring(var_buf))
+            print_buffer_bytes(var_buf)
 
 
 def print_sorted_EFI_variables(variables: Dict[str, 'EfiVariableType']) -> None:
@@ -405,7 +405,7 @@ class UEFI(hal_base.HALBase):
                 logger().log_hal(f'[uefi] Found: {efivar_name} {{{guid}}} {get_attr_string(attrs)} variable')
                 logger().log_hal(f'[uefi] {efivar_name} variable data:')
                 if logger().HAL:
-                    print_buffer(bytestostring(data))
+                    print_buffer_bytes(data)
 
                 varsz = len(data)
                 if 4 == varsz:
@@ -424,7 +424,7 @@ class UEFI(hal_base.HALBase):
                 AcpiVariableSet = self.helper.read_phys_mem(AcpiGlobalAddr, ACPI_VARIABLE_SET_STRUCT_SIZE)
                 logger().log_hal('[uefi] AcpiVariableSet structure:')
                 if logger().HAL:
-                    print_buffer(bytestostring(AcpiVariableSet))
+                    print_buffer_bytes(AcpiVariableSet)
                 AcpiVariableSet_fmt = '<6Q'
                 # if len(AcpiVariableSet) < struct.calcsize(AcpiVariableSet_fmt):
                 #    logger().log_error( 'Unrecognized format of AcpiVariableSet structure' )
@@ -481,7 +481,7 @@ class UEFI(hal_base.HALBase):
                 write_file(filename, var)
             if logger().UTIL_TRACE or logger().HAL:
                 logger().log(f'[uefi] EFI variable {guid}:{name} :')
-                print_buffer(bytestostring(var))
+                print_buffer_bytes(var)
         return var
 
     def set_EFI_variable(self, name: str, guid: str, var: bytes, datasize: Optional[int] = None, attrs: Optional[int] = None) -> Optional[int]:
@@ -558,7 +558,7 @@ class UEFI(hal_base.HALBase):
                         table_buf = self.cs.mem.read_physical_mem(table_pa, EFI_TABLE_HEADER_SIZE + table_size)
                     table = EFI_TABLES[table_sig]['struct'](*struct.unpack_from(EFI_TABLES[table_sig]['fmt'], table_buf[EFI_TABLE_HEADER_SIZE:]))
                     if logger().HAL:
-                        print_buffer(bytestostring(table_buf))
+                        print_buffer_bytes(table_buf)
                     logger().log_hal(f'[uefi] {EFI_TABLES[table_sig]["name"]}:')
                     logger().log_hal(str(table_header))
                     logger().log_hal(str(table))
@@ -628,33 +628,33 @@ class UEFI(hal_base.HALBase):
         if found:
             logger().log('[uefi] EFI System Table:')
             if table_buf is not None:
-                print_buffer(bytestostring(table_buf))
+                print_buffer_bytes(table_buf)
             logger().log(str(hdr))
             logger().log(str(table))
         (found, _, ect, ect_buf) = self.find_EFI_Configuration_Table()
         if found:
             logger().log('\n[uefi] EFI Configuration Table:')
             if ect_buf is not None:
-                print_buffer(bytestostring(ect_buf))
+                print_buffer_bytes(ect_buf)
             logger().log(str(ect))
         (found, pa, hdr, table, table_buf) = self.find_EFI_RuntimeServices_Table()
         if found:
             logger().log('\n[uefi] EFI Runtime Services Table:')
             if table_buf is not None:
-                print_buffer(bytestostring(table_buf))
+                print_buffer_bytes(table_buf)
             logger().log(str(hdr))
             logger().log(str(table))
         (found, pa, hdr, table, table_buf) = self.find_EFI_BootServices_Table()
         if found:
             logger().log('\n[uefi] EFI Boot Services Table:')
             if table_buf is not None:
-                print_buffer(bytestostring(table_buf))
+                print_buffer_bytes(table_buf)
             logger().log(str(hdr))
             logger().log(str(table))
         (found, pa, hdr, table, table_buf) = self.find_EFI_DXEServices_Table()
         if found:
             logger().log('\n[uefi] EFI DXE Services Table:')
             if table_buf is not None:
-                print_buffer(bytestostring(table_buf))
+                print_buffer_bytes(table_buf)
             logger().log(str(hdr))
             logger().log(str(table))

--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -316,7 +316,6 @@ class LinuxHelper(Helper):
         in_buf = struct.pack(f'3{self._pack}', io_port, size, 0)
         out_buf = self.ioctl(IOCTL_RDIO, in_buf)
         try:
-            # print_buffer(out_buf)
             if 1 == size:
                 value = struct.unpack(f'3{self._pack}', out_buf)[2] & 0xff
             elif 2 == size:

--- a/chipsec/modules/common/bios_kbrd_buffer.py
+++ b/chipsec/modules/common/bios_kbrd_buffer.py
@@ -34,7 +34,7 @@ Examples:
 """
 
 from chipsec.module_common import BaseModule, ModuleResult, MTAG_BIOS
-from chipsec.logger import print_buffer
+from chipsec.logger import print_buffer_bytes
 
 TAGS = [MTAG_BIOS]
 
@@ -54,8 +54,8 @@ class bios_kbrd_buffer(BaseModule):
         self.logger.log("[*] Keyboard buffer head pointer = 0x{:X} (at 0x41A), tail pointer = 0x{:X} (at 0x41C)".format(kbrd_buf_head, kbrd_buf_tail))
         bios_kbrd_buf = self.cs.mem.read_physical_mem(0x41E, 32)
         self.logger.log("[*] Keyboard buffer contents (at 0x41E):")
+        print_buffer_bytes(bios_kbrd_buf)
         bios_kbrd_buf = bios_kbrd_buf.decode('latin_1')
-        print_buffer(bios_kbrd_buf)
 
         has_contents = False
 

--- a/chipsec/utilcmd/igd_cmd.py
+++ b/chipsec/utilcmd/igd_cmd.py
@@ -33,7 +33,7 @@ Examples:
 """
 
 from chipsec.command import BaseCommand
-from chipsec.logger import print_buffer
+from chipsec.logger import print_buffer_bytes
 from argparse import ArgumentParser
 from chipsec.file import read_file, write_file
 from chipsec.hal import igd
@@ -72,7 +72,7 @@ class IgdCommand(BaseCommand):
             write_file(self.file_name, buffer)
             self.logger.log("[CHIPSEC] Written 0x{:X} bytes to '{}'".format(len(buffer), self.file_name))
         else:
-            print_buffer(buffer)
+            print_buffer_bytes(buffer)
 
     def write_dma(self):
         if not os.path.exists(self.file_value):

--- a/chipsec/utilcmd/mem_cmd.py
+++ b/chipsec/utilcmd/mem_cmd.py
@@ -49,7 +49,7 @@ from chipsec.command import BaseCommand
 from chipsec.defines import ALIGNED_4KB, BOUNDARY_4KB, bytestostring
 from chipsec_util import get_option_width, is_option_valid_width, CMD_OPTS_WIDTH
 from chipsec.file import read_file, write_file, get_main_dir
-from chipsec.logger import print_buffer
+from chipsec.logger import print_buffer_bytes
 from argparse import ArgumentParser
 
 # Physical Memory
@@ -147,7 +147,7 @@ class MemCommand(BaseCommand):
             write_file(self.file_name, buffer)
             self.logger.log("[CHIPSEC] Written 0x{:X} bytes to '{}'".format(len(buffer), self.file_name))
         else:
-            print_buffer(bytestostring(buffer))
+            print_buffer_bytes(buffer)
 
     def mem_readval(self):
         width = 0x4

--- a/chipsec/utilcmd/smbios_cmd.py
+++ b/chipsec/utilcmd/smbios_cmd.py
@@ -32,8 +32,7 @@ from argparse import ArgumentParser
 from time import time
 from chipsec.command import BaseCommand
 from chipsec.hal.smbios import SMBIOS
-from chipsec.logger import print_buffer
-from chipsec.defines import bytestostring
+from chipsec.logger import print_buffer_bytes
 
 
 class smbios_cmd(BaseCommand):
@@ -81,7 +80,7 @@ class smbios_cmd(BaseCommand):
                 if header is not None:
                     self.logger.log(header)
                 self.logger.log('[CHIPSEC] Raw Data')
-                print_buffer(bytestostring(data))
+                print_buffer_bytes(data)
             elif self.method == 'decoded':
                 self.logger.log(data)
             self.logger.log('==================================================================')

--- a/chipsec/utilcmd/vmem_cmd.py
+++ b/chipsec/utilcmd/vmem_cmd.py
@@ -49,7 +49,7 @@ import chipsec_util
 from chipsec.command import BaseCommand
 from chipsec.hal import virtmem
 from chipsec.defines import bytestostring
-from chipsec.logger import print_buffer
+from chipsec.logger import print_buffer_bytes
 from chipsec.file import write_file, read_file
 from argparse import ArgumentParser
 
@@ -112,7 +112,7 @@ class VMemCommand(BaseCommand):
             write_file(self.buf_file, buffer)
             self.logger.log("[CHIPSEC] Written 0x{:X} bytes to '{}'".format(len(buffer), self.buf_file))
         else:
-            print_buffer(bytestostring(buffer))
+            print_buffer_bytes(buffer)
 
     def vmem_readval(self):
         width = 0x4

--- a/tests/software/test_acpi.py
+++ b/tests/software/test_acpi.py
@@ -36,7 +36,7 @@ class TestACPIChipsecUtil(util.TestChipsecUtil):
 
             def read_phys_mem(self, pa, length):
                 if (pa & 0xffffffff) == 0x400:
-                    return "EFGH"
+                    return b"EFGH"
                 else:
                     parent = super(ACPIHelper, self)
                     return parent.read_phys_mem(pa, length)
@@ -57,11 +57,11 @@ class TestACPIChipsecUtil(util.TestChipsecUtil):
                 if (pa_lo >= self.EBDA_ADDRESS and
                         pa_lo < self.RSDP_ADDRESS + len(self.rsdp_descriptor)):
                     # Simulate a condition where there is no RSDP in EBDA
-                    return "\xFF" * length
+                    return b"\xFF" * length
                 elif pa_lo == 0xE0000:
                     return self.rsdp_descriptor[:length]
                 elif pa_lo == 0x300:
-                    return "ABCD"
+                    return b"ABCD"
                 else:
                     parent = super(ACPIHelper, self)
                     return parent.read_phys_mem(pa, length)

--- a/tests/software/test_desc.py
+++ b/tests/software/test_desc.py
@@ -31,7 +31,7 @@ class TestDescChipsecUtil(util.TestChipsecUtil):
                 return (63, 0x1000, 0x0)
 
             def read_phys_mem(self, pa, length):
-                return "\xff" * length
+                return b"\xff" * length
 
         self._chipsec_util("gdt 0", GDTHelper)
         self.assertIn(b"# of entries    : 4", self.log)


### PR DESCRIPTION
`print_buffer_bytes` can directly handle bytes, instead of converting them to a string.

While at it, replace buggy calls to `print_buffer(buffer)` (when `buffer` uses type `bytes`) with `print_buffer_bytes(buffer)`.

This fixes `./chipsec_util.py idt 0`. Before it failed with:

    [CHIPSEC] Dumping IDT of 8 CPU threads
    [cpu0] Physical Address: 0x000000036639E000
    [cpu0] # of entries    : 256
    [cpu0] Contents (4 entries):
    Traceback (most recent call last):
      File "./chipsec_util.py", line 210, in <module>
        sys.exit(main())
      File "./chipsec_util.py", line 205, in main
        return chipsecMain.main()
      File "./chipsec_util.py", line 190, in main
        comm.run()
      File "chipsec/utilcmd/desc_cmd.py", line 84, in run
        self.cs.msr.IDT_all(4)
      File "chipsec/hal/msr.py", line 166, in IDT_all
        self.IDT(tid, num_entries)
      File "chipsec/hal/msr.py", line 158, in IDT
        return self.dump_Descriptor_Table(cpu_thread_id, DESCRIPTOR_TABLE_CODE_IDTR, num_entries)
      File "chipsec/hal/msr.py", line 144, in dump_Descriptor_Table
        print_buffer(dt)
      File "chipsec/logger.py", line 493, in print_buffer
        prt_str = bytes2string(arr, length)
      File "chipsec/logger.py", line 466, in bytes2string
        num_string += [f'{ord(c):02X} ']
    TypeError: ord() expected string of length 1, but int found

There was another bug in `hal/msr.py` where `ord(dt[...])` was used instead of `dt`.