### PR TITLE
Make EC, SMBus and SPD use bytes instead of list of characters

### DIFF
--- a/chipsec/hal/ec.py
+++ b/chipsec/hal/ec.py
@@ -43,7 +43,7 @@ Usage:
 """
 from typing import List, Optional
 from chipsec.hal import hal_base
-from chipsec.logger import print_buffer
+from chipsec.logger import print_buffer_bytes
 
 #
 # Embedded Controller ACPI ports
@@ -134,34 +134,33 @@ class EC(hal_base.HALBase):
         self.write_data(word_offset >> 8)
         return self.write_data(data)
 
-    def read_range(self, start_offset: int, size: int) -> List[str]:
-        buffer = [chr(0xFF)] * size
+    def read_range(self, start_offset: int, size: int) -> bytes:
+        buffer = [0xFF] * size
         for i in range(size):
             if start_offset + i < 0x100:
                 mem_value = self.read_memory(start_offset + i)
                 if mem_value is not None:
-                    buffer[i] = chr(mem_value)
+                    buffer[i] = mem_value
                 else:
                     self.logger.log_hal(f'[ec] Unable to read EC offset 0x{start_offset + i:X}')
             else:
                 mem_value = self.read_memory_extended(start_offset + i)
                 if mem_value is not None:
-                    buffer[i] = chr(mem_value)
+                    buffer[i] = mem_value
                 else:
                     self.logger.log_hal(f'[ec] Unable to read EC offset 0x{start_offset + i:X}')
 
         self.logger.log_hal(f'[ec] read EC memory from offset {start_offset:X} size {size:X}:')
         if self.logger.HAL:
-            print_buffer(buffer)
-        return buffer
+            print_buffer_bytes(buffer)
+        return bytes(buffer)
 
-    def write_range(self, start_offset: int, buffer: List[str]) -> bool:
-        size = len(buffer)
-        for i in range(size):
-            self.write_memory(start_offset + i, ord(buffer[i]))
-        self.logger.log_hal(f'[ec] write EC memory to offset {start_offset:X} size {size:X}:')
+    def write_range(self, start_offset: int, buffer: bytes) -> bool:
+        for i, b in enumerate(buffer):
+            self.write_memory(start_offset + i, b)
+        self.logger.log_hal(f'[ec] write EC memory to offset {start_offset:X} size {len(buffer):X}:')
         if self.logger.HAL:
-            print_buffer(buffer)
+            print_buffer_bytes(buffer)
         return True
 
     #

--- a/chipsec/hal/smbus.py
+++ b/chipsec/hal/smbus.py
@@ -223,16 +223,13 @@ class SMBus(hal_base.HALBase):
         self.logger.log_hal(f'[smbus] write to device {target_address:X} off {offset:X} = {value:X}')
         return True
 
-    def read_range(self, target_address: int, start_offset: int, size: int) -> List[str]:
-        buffer = [chr(0xFF)] * size
-        for i in range(size):
-            buffer[i] = chr(self.read_byte(target_address, start_offset + i))
+    def read_range(self, target_address: int, start_offset: int, size: int) -> bytes:
+        buffer = bytes(self.read_byte(target_address, start_offset + i) for i in range(size))
         self.logger.log_hal(f'[smbus] reading {size:d} bytes from device 0x{target_address:X} at offset {start_offset:X}')
         return buffer
 
-    def write_range(self, target_address: int, start_offset: int, buffer: List[str]) -> bool:
-        size = len(buffer)
-        for i in range(size):
-            self.write_byte(target_address, start_offset + i, ord(buffer[i]))
+    def write_range(self, target_address: int, start_offset: int, buffer: bytes) -> bool:
+        for i, b in enumerate(buffer):
+            self.write_byte(target_address, start_offset + i, b)
         self.logger.log_hal(f'[smbus] writing {size:d} bytes to device 0x{target_address:X} at offset {start_offset:X}')
         return True

--- a/chipsec/utilcmd/ec_cmd.py
+++ b/chipsec/utilcmd/ec_cmd.py
@@ -40,7 +40,7 @@ from argparse import ArgumentParser
 
 from chipsec.command import BaseCommand
 
-from chipsec.logger import print_buffer
+from chipsec.logger import print_buffer_bytes
 from chipsec.hal.ec import EC
 
 
@@ -82,7 +82,7 @@ class ECCommand(BaseCommand):
         self.logger.log("[CHIPSEC] EC dump")
 
         buf = self._ec.read_range(0, self.size)
-        print_buffer(buf)
+        print_buffer_bytes(buf)
 
     def command(self):
         self.logger.log("[CHIPSEC] Sending EC command 0x{:X}".format(self.cmd))
@@ -93,7 +93,7 @@ class ECCommand(BaseCommand):
         if self.size:
             buf = self._ec.read_range(self.offset, self.size)
             self.logger.log("[CHIPSEC] EC memory read: offset 0x{:X} size 0x{:X}".format(self.offset, self.size))
-            print_buffer(buf)
+            print_buffer_bytes(buf)
         else:
             val = self._ec.read_memory(
                 self.offset) if self.offset < 0x100 else self._ec.read_memory_extended(self.offset)
@@ -114,10 +114,8 @@ class ECCommand(BaseCommand):
             self.logger.log("[CHIPSEC] EC index I/O: reading memory offset 0x{:X}: 0x{:X}".format(self.offset, val))
         else:
             self.logger.log("[CHIPSEC] EC index I/O: dumping memory...")
-            mem = []
-            for off in range(0x10000):
-                mem.append(chr(self._ec.read_idx(off)))
-            print_buffer(mem)
+            mem = [self._ec.read_idx(off) for off in range(0x10000)]
+            print_buffer_bytes(mem)
 
     def run(self):
         t = time.time()

--- a/chipsec/utilcmd/smbus_cmd.py
+++ b/chipsec/utilcmd/smbus_cmd.py
@@ -30,7 +30,7 @@ Examples:
 import time
 
 from chipsec.command import BaseCommand
-from chipsec.logger import print_buffer
+from chipsec.logger import print_buffer_bytes
 from chipsec.hal.smbus import SMBus
 from argparse import ArgumentParser
 
@@ -59,7 +59,7 @@ class SMBusCommand(BaseCommand):
         if self.size is not None:
             buf = self._smbus.read_range(self.dev_addr, self.start_off, self.size)
             self.logger.log("[CHIPSEC] SMBus read: device 0x{:X} offset 0x{:X} size 0x{:X}".format(self.dev_addr, self.start_off, self.size))
-            print_buffer(buf)
+            print_buffer_bytes(buf)
         else:
             val = self._smbus.read_byte(self.dev_addr, self.start_off)
             self.logger.log("[CHIPSEC] SMBus read: device 0x{:X} offset 0x{:X} = 0x{:X}".format(self.dev_addr, self.start_off, val))


### PR DESCRIPTION
Using a list of unicode characters instead of bytes is strange in Python 3. Replace these lists with bytes, which is the usual type to hold binary data.