### PR TITLE
Fix SPI write when data size is not a multiple of 4

### DIFF
--- a/chipsec/hal/spi.py
+++ b/chipsec/hal/spi.py
@@ -670,7 +670,7 @@ class SPI(hal_base.HALBase):
                 self.logger.log(f'[spi] Writing remaining 0x{r:x} bytes to FLA = 0x{spi_fla + n * dbc:x}')
             dword_value = 0
             for j in range(r):
-                dword_value |= (ord(buf[n * dbc + j]) << 8 * j)
+                dword_value |= (buf[n * dbc + j] << 8 * j)
             if self.logger.HAL:
                 self.logger.log(f'[spi] in FDATA00 = 0x{dword_value:08X}')
             self.spi_reg_write(self.fdata0_off, dword_value)


### PR DESCRIPTION
In `SPI.write_spi`, When `len(buf) % 4 != 0`, a dword value to be written is computed with `ord(buf[...])`. This does not work, as in Python 3, `buf[...]` directly gives an integer.

Fix this issue by removing the call to `ord`.

Fixes: https://github.com/chipsec/chipsec/issues/1775 (the previous fix was incomplete)

For information, I stumbled upon this issue while testing `mypy` on chipsec:

```text
$ mypy --strict chipsec/hal/spi.py
...
chipsec/hal/spi.py:673: error: Argument 1 to "ord" has incompatible type "int"; expected "Union[str, bytes]"
```