### PR TITLE
Format bytes with .hex() instead of :8X in linuxnativehelper.py

### DIFF
--- a/chipsec/helper/linuxnative/linuxnativehelper.py
+++ b/chipsec/helper/linuxnative/linuxnativehelper.py
@@ -366,7 +366,7 @@ class LinuxNativeHelper(Helper):
             buf = struct.pack("2I", eax, edx)
             written = os.write(self.dev_msr[thread_id], buf)
             if written != 8:
-                logger().log_debug(f"Cannot write {buf:8X} to MSR {msr_addr:x}")
+                logger().log_debug(f"Cannot write {buf.hex()} to MSR {msr_addr:x}")
             return written
         return False
 


### PR DESCRIPTION
Using `{buf:8X}` does not work in `LinuxNativeHelper.write_msr`: this raises an expection

    TypeError: unsupported format string passed to bytes.__format__

Use `{buf.hex()}` instead to format the bytes in the error message.