### PR TITLE
remove the windows build tool version dependency

### DIFF
--- a/drivers/windows/install.cmd
+++ b/drivers/windows/install.cmd
@@ -75,10 +75,6 @@ goto :finish
 
 :donesetup
 if %CHIPSEC_BUILD% == "0" goto :finish
-if defined VS140COMNTOOLS goto :newbuild
-if defined VS160COMNTOOLS goto :newbuild
-if defined VS170COMNTOOLS goto :newbuild
-goto :finish
 
 :newbuild
 if %CHIPSEC_BUILD% == "64" call msbuild /t:Build /p:Configuration=Debug /p:Platform=x64 chipsec_hlpr.vcxproj


### PR DESCRIPTION
windows 2019 & visual studio2017 env, cmd shell build failed.
the install.cmd shell depends on the specified build tool version， VS150COMNTOOLS not in the check list

:donesetup
if %CHIPSEC_BUILD% == "0" goto :finish
if defined VS140COMNTOOLS goto :newbuild
if defined VS160COMNTOOLS goto :newbuild
if defined VS170COMNTOOLS goto :newbuild
goto :finish

 remove all the version check to support VS15, and future build versions