### PR TITLE
Make OsHelper.get_available_helpers return a sorted list

### DIFF
--- a/chipsec/helper/oshelper.py
+++ b/chipsec/helper/oshelper.py
@@ -93,7 +93,7 @@ class OsHelper:
         return ret
     
     def get_available_helpers(self) -> List[str]:
-        return self.avail_helpers.keys()
+        return sorted(self.avail_helpers.keys())
 
     def get_base_helper(self):
         return Helper()

--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -86,7 +86,7 @@ def parse_args(argv: Sequence[str]) -> Optional[Dict[str, Any]]:
     adv_options.add_argument('--failfast', help="fail on any exception and exit (don't mask exceptions)", action='store_true')
     adv_options.add_argument('--no_time', help="don't log timestamps", action='store_true')
     adv_options.add_argument('--deltas', dest='_deltas_file', help='specifies a JSON log file to compute result deltas from')
-    adv_options.add_argument('--helper', dest='_helper', help='specify OS Helper', choices=[i for i in helper().get_available_helpers()])
+    adv_options.add_argument('--helper', dest='_helper', help='specify OS Helper', choices=helper().get_available_helpers())
     adv_options.add_argument('-nb', '--no_banner', dest='_show_banner', action='store_false', help="chipsec won't display banner information")
     adv_options.add_argument('--skip_config', dest='_load_config', action='store_false', help='skip configuration and driver loading')
 

--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -101,7 +101,7 @@ def parse_args(argv: Sequence[str]) -> Optional[Dict[str, Any]]:
                          help="chipsec won't need kernel mode functions so don't load chipsec driver")
     options.add_argument('-i', '--ignore_platform', dest='_unknownPlatform', action='store_false',
                          help='run chipsec even if the platform is not recognized')
-    options.add_argument('--helper', dest='_helper', help='specify OS Helper', choices=[i for i in helper().get_available_helpers()])
+    options.add_argument('--helper', dest='_helper', help='specify OS Helper', choices=helper().get_available_helpers())
     options.add_argument('_cmd', metavar='Command', nargs='?', choices=sorted(cmds.keys()), type=str.lower, default="help",
                          help="Util command to run: {{{}}}".format(','.join(sorted(cmds.keys()))))
     options.add_argument('_cmd_args', metavar='Command Args', nargs=argparse.REMAINDER, help=global_usage)


### PR DESCRIPTION
`OsHelper.get_available_helpers` is returning a list of helper names in the order they are stored in the dict `self.avail_helpers`. This order seems to come from the order in which `os.listdir(helper_dir)` reads the content of the directory.

To make this order more predictible and meaningful, sort the list in `get_available_helpers`. This function was only called when generating the documentation ofi option `--helper` and this makes it more reproducible too.