### PR TITLE
Move helper.getcwd() from *helper to oshelper

### DIFF
--- a/chipsec/helper/basehelper.py
+++ b/chipsec/helper/basehelper.py
@@ -218,12 +218,6 @@ class Helper:
         raise NotImplementedError()
 
     #
-    # File system
-    #
-    def getcwd(self):
-        raise NotImplementedError()
-
-    #
     # Speculation control
     #
     def retpoline_enabled(self):

--- a/chipsec/helper/dal/dalhelper.py
+++ b/chipsec/helper/dal/dalhelper.py
@@ -399,8 +399,6 @@ class DALHelper(Helper):
     def hypercall(self, rcx, rdx, r8, r9, r10, r11, rax, rbx, rdi, rsi, xmm_buffer):
         raise UnimplementedAPIError('hypercall')
 
-    def getcwd(self):
-        raise UnimplementedAPIError('getcwd')
 
 
 def get_helper() -> DALHelper:

--- a/chipsec/helper/efi/efihelper.py
+++ b/chipsec/helper/efi/efihelper.py
@@ -246,9 +246,6 @@ class EfiHelper(Helper):
         tool_path = os.path.join(get_tools_path(), self.os_system.lower())
         return (tool_name, tool_path)
 
-    def getcwd(self) -> str:
-        return os.getcwd()
-
     #
     # EFI Variable API
     #

--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -630,9 +630,6 @@ class LinuxHelper(Helper):
         tool_path = os.path.join(get_tools_path(), self.os_system.lower())
         return tool_name, tool_path
 
-    def getcwd(self) -> str:
-        return os.getcwd()
-
     def get_page_is_ram(self) -> Optional[bytes]:
         PROC_KALLSYMS = "/proc/kallsyms"
         symarr = chipsec.file.read_file(PROC_KALLSYMS).splitlines()

--- a/chipsec/helper/linuxnative/linuxnativehelper.py
+++ b/chipsec/helper/linuxnative/linuxnativehelper.py
@@ -165,8 +165,6 @@ class LinuxNativeHelper(Helper):
             os.close(self.dev_mem)
         self.dev_mem = None
         
-    def getcwd(self) -> str:
-        return(os.getcwd())
 
 ###############################################################################################
 # Actual API functions to access HW resources

--- a/chipsec/helper/oshelper.py
+++ b/chipsec/helper/oshelper.py
@@ -132,6 +132,10 @@ class OsHelper:
 
     def is_macos(self) -> bool:
         return 'darwin' == platform.system().lower()
+    
+    def getcwd(self) -> str:
+        return os.getcwd()
+
 
    
 

--- a/chipsec/helper/windows/windowshelper.py
+++ b/chipsec/helper/windows/windowshelper.py
@@ -501,9 +501,6 @@ class WindowsHelper(Helper):
             sum = sum + procs
         return sum
 
-    def getcwd(self) -> str:
-        return (f'\\\\?\\{os.getcwd()}')
-
     #
     # Generic IOCTL call function
     #

--- a/chipsec/utilcmd/decode_cmd.py
+++ b/chipsec/utilcmd/decode_cmd.py
@@ -91,7 +91,7 @@ class DecodeCommand(BaseCommand):
 
         _orig_logname = self.logger.LOG_FILE_NAME
 
-        pth = os.path.join(self.cs.helper.getcwd(), self._rom + ".dir")
+        pth = os.path.join(self.cs.os_helper.getcwd(), self._rom + ".dir")
         if not os.path.exists(pth):
             os.makedirs(pth)
 

--- a/chipsec/utilcmd/uefi_cmd.py
+++ b/chipsec/utilcmd/uefi_cmd.py
@@ -298,7 +298,7 @@ class UEFICommand(BaseCommand):
         self.logger.log("[CHIPSEC] Parsing EFI volumes from '{}'..".format(self.filename))
         _orig_logname = self.logger.LOG_FILE_NAME
         self.logger.set_log_file(self.filename + '.UEFI.lst')
-        cur_dir = self.cs.helper.getcwd()
+        cur_dir = self.cs.os_helper.getcwd()
         ftypes = []
         inv_filetypes = {v: k for k, v in FILE_TYPE_NAMES.items()}
         if self.filetypes:


### PR DESCRIPTION
Does not make sense for each helper to have it's own version, so moving the call to the oshelper class. 