### PR TITLE
Read the AMD LPC revision ID using the correct BDF address

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -180,7 +180,7 @@ class Chipset:
                 vid_did = self.pci.read_dword(bus, dev, fun, 0)
                 pch_vid = vid_did & 0xFFFF
                 pch_did = (vid_did >> 16) & 0xFFFF
-                pch_rid = self.pci.read_byte(0, 31, 0, PCI_HDR_RID_OFF)
+                pch_rid = self.pci.read_byte(bus, dev, fun, PCI_HDR_RID_OFF)
             except:
                 if logger().DEBUG:
                     logger().log_error("pci.read_dword couldn't read PCH VID/DID")


### PR DESCRIPTION
On AMD, the "PCH" is the LPC device on PCI 0:14.3. According to "PPR for AMD Family 17h Model 18h B1. 55570-B1 Rev 3.16 - Apr 14, 2021." available on https://www.amd.com/en/support/tech-docs/processor-programming-reference-ppr-for-amd-family-17h-model-18h-revision-b1, the low byte at `D14F3x008` (bus 0 device 14 function 3 offset 8) is the RevisionID of this device.

Using 0:1F.0 to read the RID in `Chipset.detect_platform` is likely to be a bug from commit 2691f50bae8a ("Detect PCH based on platform vendor ID"), which introduced AMD support in this function. Fix this by using `bus, dev, fun` to read `pch_rid`.

@kerneis-anssi Could you please check whether this fix is correct? 