### PR TITLE
Fix Chipset.set_control call to write_register_field

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -1318,7 +1318,7 @@ class Chipset:
         control = self.Cfg.CONTROLS[control_name]
         reg = control['register']
         field = control['field']
-        return self.write_register_field(reg, field, control_value, cpu_thread)
+        return self.write_register_field(reg, field, control_value, cpu_thread=cpu_thread)
 
     def is_control_defined(self, control_name):
         try:


### PR DESCRIPTION
`Chipset.set_control` calls:

    self.write_register_field(reg, field, control_value, cpu_thread)

But `write_register_field` is defined as:

    def write_register_field(self, reg_name, field_name, field_value, preserve_field_position=False, cpu_thread=0):

So variable `cpu_thread` is given to parameter `preserve_field_position` instead of parameter `cpu_thread`.

Fix this by using `cpu_thread=cpu_thread` syntax in the call.

This bug was found while adding type hints to `chipset`. Mypy reported:

    Argument 4 to "write_register_field" of "Chipset" has incompatible type "int"; expected "bool"