### PR TITLE
Replace binascii.hexlify with bytes.hex

### DIFF
--- a/chipsec/hal/spi_descriptor.py
+++ b/chipsec/hal/spi_descriptor.py
@@ -31,7 +31,6 @@ import struct
 from typing import Dict, List, Optional, Tuple
 from chipsec.logger import logger, print_buffer_bytes
 from chipsec.hal import spi
-from binascii import hexlify
 
 SPI_FLASH_DESCRIPTOR_SIGNATURE = struct.pack('=I', 0x0FF0A55A)
 SPI_FLASH_DESCRIPTOR_SIZE = 0x1000
@@ -101,7 +100,7 @@ def parse_spi_flash_descriptor(cs, rom: bytes) -> None:
     fd = rom[fd_off: fd_off + SPI_FLASH_DESCRIPTOR_SIZE]
     fd_sig = struct.unpack_from('=I', fd[0x10:0x14])[0]
 
-    logger().log(f'+ 0x0000 Reserved : 0x{hexlify(fd[0x0:0xF]).upper()}')
+    logger().log(f'+ 0x0000 Reserved : 0x{fd[0x0:0xF].hex().upper()}')
     logger().log(f'+ 0x0010 Signature: 0x{fd_sig:08X}')
 
     #

--- a/chipsec/hal/tpm_eventlog.py
+++ b/chipsec/hal/tpm_eventlog.py
@@ -26,7 +26,6 @@ Based on the following specifications:
 `TCG PC Client Platform Firmware Profile Specification <https://trustedcomputinggroup.org/wp-content/uploads/PC-ClientSpecific_Platform_Profile_for_TPM_2p0_Systems_v51.pdf>`_
 """
 
-import binascii
 import struct
 
 from typing import Any, Dict, BinaryIO, Optional, Type, TypeVar
@@ -81,7 +80,7 @@ class TcgPcrEvent:
             t = self.event_type_name
         else:
             t = f'(0x{self.event_type:x}'
-        return f'PCR: {self.pcr_index:d}\ttype: {t.ljust(EVENT_TYPE_MAX_LENGTH)}\tsize: 0x{self.event_size:x}\tdigest: {binascii.hexlify(self.digest)}'
+        return f'PCR: {self.pcr_index:d}\ttype: {t.ljust(EVENT_TYPE_MAX_LENGTH)}\tsize: 0x{self.event_size:x}\tdigest: {self.digest.hex()}'
 
 
 class SCRTMVersion(TcgPcrEvent):

--- a/chipsec/hal/uefi_search.py
+++ b/chipsec/hal/uefi_search.py
@@ -33,7 +33,6 @@ usage:
 """
 
 import re
-import binascii
 from uuid import UUID
 from typing import Dict, Callable, Optional, Any
 
@@ -146,7 +145,7 @@ def check_rules(efi: EFI_SECTION, rules: Dict[str, Any], entry_name: str, _log: 
             if m:
                 match_result |= MATCH_REGEXP
                 _str = m.group(0)
-                hexver = binascii.hexlify(_str)
+                hexver = _str.hex()
                 printver = f" ('{_str}')" if defines.is_printable(_str) else ''
                 what = f"bytes '{hexver}'{printver}"
                 offset = m.start()

--- a/chipsec/modules/tools/vmm/common.py
+++ b/chipsec/modules/tools/vmm/common.py
@@ -29,7 +29,6 @@ import random
 import os.path
 import json
 import pprint
-import binascii
 from random import getrandbits, randint
 from time import strftime, localtime
 from chipsec.module_common import BaseModule

--- a/chipsec/modules/tools/vmm/hv/hypercall.py
+++ b/chipsec/modules/tools/vmm/hv/hypercall.py
@@ -26,7 +26,6 @@ Hyper-V specific hypercall functionality
 import os
 import sys
 import time
-import binascii
 import chipsec_util
 from random import *
 from struct import *
@@ -411,7 +410,7 @@ class HyperVHypercall(BaseModuleHwAccess):
                         buffer = pack('<4LQ', connid, 0, messagetype, payloadsize, message0)
                         result = hv.hypercall64_memory_based(hciv, buffer)
                         statistics[result] = 1 if result not in statistics else statistics[result] + 1
-                        self.dbg(f'HvPostMessage: {get_hypercall_status(result)} {binascii.hexlify(buffer)}')
+                        self.dbg(f'HvPostMessage: {get_hypercall_status(result)} {buffer.hex()}')
 
         elif hcname == 'HvSignalEvent':
             self.msg(f'Hypercall: {hcname} ')

--- a/chipsec/modules/tools/vmm/hv/synth_dev.py
+++ b/chipsec/modules/tools/vmm/hv/synth_dev.py
@@ -37,7 +37,6 @@ Note: the fuzzer is incompatible with native VMBus driver (``vmbus.sys``). To us
 import time
 from struct import *
 from random import *
-from binascii import *
 from chipsec.modules.tools.vmm.hv.define import *
 from chipsec.modules.tools.vmm.common import *
 from chipsec.modules.tools.vmm.hv.vmbus import *
@@ -83,7 +82,7 @@ class VMBusDeviceFuzzer(VMBusDiscovery):
         if len(info) == 0:
             return
         for i in self.responses:
-            self.msg(f'{"  " * indent}{hexlify(i):20}:{hexlify(info[i]["message"]):20}  {info[i]["count"]:4d}')
+            self.msg(f'{"  " * indent}{i.hex():20}:{info[i]["message"].hex():20}  {info[i]["count"]:4d}')
             self.print_1(info[i]['next'], indent + 1)
         return
 

--- a/chipsec/modules/tools/vmm/hv/vmbus.py
+++ b/chipsec/modules/tools/vmm/hv/vmbus.py
@@ -25,7 +25,6 @@ Hyper-V VMBus functionality
 import os
 import sys
 import time
-import binascii
 import chipsec_util
 from struct import *
 from random import *

--- a/chipsec/modules/tools/vmm/xen/hypercall.py
+++ b/chipsec/modules/tools/vmm/xen/hypercall.py
@@ -23,7 +23,6 @@
 Xen specific hypercall functionality
 """
 
-import binascii
 import collections
 from chipsec.modules.tools.vmm.xen.define import *
 from chipsec.hal.vmm import *
@@ -80,7 +79,7 @@ class XenHypercall(BaseModuleHwAccess):
     def hypercall(self, args, size=0, data=''):
         data = data.ljust(4096, '\x00')[:4096]
         self.cs.mem.write_physical_mem(self.buff_pa, len(data), data)
-        self.dbg(f'ARGS: {" ".join([f"{x:016X}" for x in args])}  DATA: {binascii.hexlify(data[:32])}')
+        self.dbg(f'ARGS: {" ".join([f"{x:016X}" for x in args])}  DATA: {data[:32].hex()}')
         try:
             rax = self.vmm.hypercall64_five_args(*args)
             val = self.cs.mem.read_physical_mem(self.buff_pa, size) if size > 0 else ''

--- a/chipsec/utilcmd/txt_cmd.py
+++ b/chipsec/utilcmd/txt_cmd.py
@@ -26,7 +26,6 @@ Usage:
 """
 
 from argparse import ArgumentParser
-import binascii
 from chipsec.command import BaseCommand
 from chipsec.exceptions import HWAccessViolationError
 import struct
@@ -115,8 +114,7 @@ class TXTCommand(BaseCommand):
                                  self.cs.read_register("TXT_PUBLIC_KEY_2"),
                                  self.cs.read_register("TXT_PUBLIC_KEY_3"),
                                  )
-        self.logger.log("[CHIPSEC] TXT Public Key Hash: {}".format(
-            binascii.hexlify(txt_pubkey).decode("ascii")))
+        self.logger.log("[CHIPSEC] TXT Public Key Hash: {}".format(txt_pubkey.hex()))
 
         try:
             eax, edx = self.cs.msr.read_msr(0, 0x20)
@@ -127,8 +125,7 @@ class TXTCommand(BaseCommand):
             pubkey_in_msr += struct.pack("<II", eax, edx)
             eax, edx = self.cs.msr.read_msr(0, 0x23)
             pubkey_in_msr += struct.pack("<II", eax, edx)
-            self.logger.log("[CHIPSEC] Public Key Hash in MSR[0x20...0x23]: {}".format(
-                binascii.hexlify(pubkey_in_msr).decode("ascii")))
+            self.logger.log("[CHIPSEC] Public Key Hash in MSR[0x20...0x23]: {}".format(pubkey_in_msr.hex()))
         except HWAccessViolationError as exc:
             # Report the exception and continue
             self.logger.log("[CHIPSEC] Unable to read Public Key Hash in MSR[0x20...0x23]: {}".format(exc))


### PR DESCRIPTION
Python 3.5 introduced `bytes.hex` to represent bytes in hexadecimal: https://docs.python.org/3.5/library/stdtypes.html#bytes.hex

This function directly returns a string, contrary to `binascii.hexlify` which returns bytes. Using `binascii.hexlify` without transforming the output to string actually produced buggy output. For example:

    $ ./chipsec_util.py spidesc spi_rom.bin
    ...
    + 0x0000 Reserved : 0xb'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'

This `b'` is not desired. Using `bytes.hex` fixes this issue and makes the code simpler.

While at it, remove unused `binascii` imports.