### PR TITLE
Fix Linux native helper MMIO read/write

### DIFF
--- a/chipsec/helper/linuxnative/linuxnativehelper.py
+++ b/chipsec/helper/linuxnative/linuxnativehelper.py
@@ -234,17 +234,23 @@ class LinuxNativeHelper(Helper):
                 if not region:
                     logger().log_error(f"Unable to map region {phys_address:08x}")
 
-            # Create memoryview into mmap'ed region in dword granularity
+            # Create memoryview into mmap'ed region
             region_mv = memoryview(region)
-            region_dw = region_mv.cast('I')
-            # read one DWORD
-            offset_in_region = (phys_address - region.start) // 4
-            reg = region_dw[offset_in_region]
-            return reg
+            offset_in_region = phys_address - region.start
+            if size == 1:
+                return region_mv[offset_in_region]
+
+            if offset_in_region % size == 0:
+                # Read aligned value
+                region_casted = region_mv.cast(defines.SIZE2FORMAT[size])
+                return region_casted[offset_in_region // size]
+
+            # Read unaligned value
+            return defines.unpack1(region_mv[offset_in_region:offset_in_region + size], size)
         return 0
 
     # @TODO fix memory mapping and bar_size
-    def write_mmio_reg(self, phys_address: int, size: int, value: int) -> int:
+    def write_mmio_reg(self, phys_address: int, size: int, value: int) -> None:
         if self.devmem_available():
             reg = defines.pack1(value, size)
             region = self.memory_mapping(phys_address, size)
@@ -254,16 +260,21 @@ class LinuxNativeHelper(Helper):
                 if not region:
                     logger().log_error(f"Unable to map region {phys_address:08x}")
 
-            # Create memoryview into mmap'ed region in dword granularity
+            # Create memoryview into mmap'ed region
             region_mv = memoryview(region)
-            region_dw = region_mv.cast('I')
-            # Create memoryview containing data in dword
-            data_mv = memoryview(reg)
-            data_dw = data_mv.cast('I')
-            # write one DWORD
-            offset_in_region = (phys_address - region.start) // 4
-            region_dw[offset_in_region] = data_dw[0]
-        return 0
+            offset_in_region = phys_address - region.start
+            if size == 1:
+                region_mv[offset_in_region] = value
+                return
+
+            if offset_in_region % size == 0:
+                # Write aligned value
+                region_casted = region_mv.cast(defines.SIZE2FORMAT[size])
+                region_casted[offset_in_region // size] = value
+                return
+
+            # Write unaligned value
+            region_mv[offset_in_region:offset_in_region + size] = reg
 
 
     def memory_mapping(self, base: int, size: int) -> Optional[MemoryMapping]:


### PR DESCRIPTION
Reading 64-bit MMIO registers does not work with Linux native helper. For example:

    $ ./chipsec_util.py --helper linuxnativehelper txt state
    ...
    TXT Public Key Hash: 9c78f0d8000000002f47761c00000000164a66a90000000092e3144f00000000

(The zeros here are not expected)

This value comes from four 64-bit MMIO registers (`TXT_PUBLIC_KEY_0` to `TXT_PUBLIC_KEY_3`). This is caused by `LinuxNativeHelper.read_mmio_reg` assuming the size cannot be larger than 4 bytes. And it also assumes that the physical address is always aligned on a 4-byte boundary.

Reading a value as a "32-bit integer" can be important for MMIO registers, so do not change this case, when the physical address is aligned. In practice:

- If `size == 1`, the result can be directly read from the mapping.
- Otherwise, if the address is aligned, `region_mv.cast(defines.SIZE2FORMAT[size])` can be used to trigger an atomic read of the requested size.
- In the unaligned case, the bytes are read from the memory view, possibly one by one, and `defines.unpack1` is used to glue them back to an integer.

Implement a similar logic in `write_mmio_reg` too. While at it, as the `return 0` did not make much sense in this function, remove it.

With this commit:

    $ ./chipsec_util.py --helper linuxnativehelper txt state
    ...
    TXT Public Key Hash: 9c78f0d853de854a2f47761c72b86a11164a66a984c1aad792e3144fb71c2d11