### PR TITLE
Make defines.is_printable support bytes

### DIFF
--- a/chipsec/defines.py
+++ b/chipsec/defines.py
@@ -197,8 +197,8 @@ def os_version() -> Tuple[str, str, str, str]:
     return platform.system(), platform.release(), platform.version(), platform.machine()
 
 
-def is_printable(seq) -> bool:
-    return set(seq).issubset(set(string.printable))
+def is_printable(seq: AnyStr) -> bool:
+    return set(bytestostring(seq)).issubset(set(string.printable))
 
 
 def is_hex(maybe_hex: Iterable) -> bool:


### PR DESCRIPTION
`uefi_search.py` calls `is_printable` with bytes, in: https://github.com/chipsec/chipsec/blob/a01d537a758d1f7eca23d3a30b59f0574c552f1e/chipsec/hal/uefi_search.py#L145-L150

... because `_str` has actually type `bytes`, not `str`.

When `is_printable` is called with bytes, it always return `False`, because in

    set(seq).issubset(set(string.printable))

`set(seq)` is a set of integers and `set(string.printable)` is a set of strings.

Fix this by always converting the parameter to string, using `bytestostring`. This is not the most efficient way of doing this (a more efficient would be `set(seq).issubset(set(string.printable.encode()))` with some caching of the second set) but it is simple and makes caller less likely to use the function in an unsupported way.