### PR TITLE
Remove global variable chipsec.helper.oshelper.avail_helper

### DIFF
--- a/chipsec/helper/oshelper.py
+++ b/chipsec/helper/oshelper.py
@@ -37,8 +37,6 @@ from chipsec.logger import logger
 from chipsec.helper.basehelper import Helper
 from chipsec.exceptions import UnimplementedAPIError, OsHelperError
 
-avail_helpers = []
-
 
 def get_tools_path() -> str:
     return os.path.normpath(os.path.join(get_main_dir(), TOOLS_DIR))

--- a/docs/sphinx/development/OS-Helpers-and-Drivers.rst
+++ b/docs/sphinx/development/OS-Helpers-and-Drivers.rst
@@ -33,16 +33,14 @@ A new helper folder should be created under
 ``chipsec/helper/new_helper``
 
 ``chipsec/helper/new_helper/__init__.py`` within the new folder needs to
-add the helper to avail_helpers list
+add the helper name to list ``__all__``
 
 ::
 
    import platform
-   from chipsec.helper.oshelper import avail_helpers
 
    if "linux" == platform.system().lower():
        __all__ = [ "linuxhelper" ]
-       avail_helpers.append("linuxhelper")
    else:
        __all__ = [ ]
 


### PR DESCRIPTION
This global variable is no longer used after commit 4b9ab9983995 ("Change the way helper loading is done"). Update the documentation too.