### PR TITLE
Add Alpine 3.18 and Debian 12 to Github Action test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         distro:
+          - {name: "alpine", tag: "3.18", variant: "-lts", image_prefix: "docker.io/library/"}
           - {name: "alpine", tag: "3.17", variant: "-lts", image_prefix: "docker.io/library/"}
           - {name: "alpine", tag: "3.16", variant: "-lts", image_prefix: "docker.io/library/"}
           - {name: "alpine", tag: "3.15", variant: "-lts", image_prefix: "docker.io/library/"}
@@ -19,6 +20,7 @@ jobs:
           - {name: "centos", tag: "stream9", image_prefix: "quay.io/centos/"}
           - {name: "centos", tag: "stream8", image_prefix: "quay.io/centos/"}
           - {name: "centos", tag: "7", image_prefix: "quay.io/centos/"}
+          - {name: "debian", tag: "bookworm-slim", image_prefix: "docker.io/library/"}
           - {name: "debian", tag: "11", image_prefix: "docker.io/library/"}
           - {name: "debian", tag: "10", image_prefix: "docker.io/library/"}
           - {name: "ubuntu", tag: "23.04", image_prefix: "docker.io/library/"}


### PR DESCRIPTION
Alpine 3.18 was released on 2023-05-19 and Debian 12 "Bookworm" on 2023-06-10.

N.B. There is no `debian:12` image tag on [Docker Hub](https://hub.docker.com/_/debian/), so this Pull Request uses the tag `debian:bookworm-slim`.