### PR TITLE
Add type hints to chipsec.helper.linuxnative.cpuid

### DIFF
--- a/chipsec/helper/linuxnative/cpuid.py
+++ b/chipsec/helper/linuxnative/cpuid.py
@@ -26,8 +26,6 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-from __future__ import print_function
-
 import platform
 from ctypes import c_uint32, c_void_p, c_ubyte, sizeof, addressof
 from ctypes import Structure, POINTER, CFUNCTYPE

--- a/chipsec/helper/linuxnative/cpuid.py
+++ b/chipsec/helper/linuxnative/cpuid.py
@@ -29,7 +29,7 @@
 from __future__ import print_function
 
 import platform
-from ctypes import c_uint32, c_void_p, c_voidp, c_ubyte, sizeof, addressof
+from ctypes import c_uint32, c_void_p, c_ubyte, sizeof, addressof
 from ctypes import Structure, POINTER, CFUNCTYPE
 import mmap
 
@@ -70,7 +70,7 @@ _CDECL_32_OPC = [
     0xc3                     # ret
 ]
 
-is_64bit = sizeof(c_voidp) == 8
+is_64bit = sizeof(c_void_p) == 8
 
 
 class CPUID_struct(Structure):

--- a/chipsec/helper/linuxnative/linuxnativehelper.py
+++ b/chipsec/helper/linuxnative/linuxnativehelper.py
@@ -33,6 +33,7 @@ from typing import Optional, Tuple
 from chipsec import defines
 from chipsec.exceptions import OsHelperError
 from chipsec.helper.basehelper import Helper
+from chipsec.helper.linuxnative.cpuid import CPUID
 from chipsec.helper.linuxnative.legacy_pci import LegacyPci
 from chipsec.logger import logger
 
@@ -398,8 +399,7 @@ class LinuxNativeHelper(Helper):
         raise NotImplementedError()
     
     def cpuid(self, eax: int, ecx: int) -> Tuple[int, int, int, int]:
-        import chipsec.helper.linuxnative.cpuid as cpuid
-        _cpuid = cpuid.CPUID()
+        _cpuid = CPUID()
         return _cpuid(eax, ecx)
     
     def msgbus_send_read_message(self, mcr, mcrx):


### PR DESCRIPTION
Hello,

While looking at `chipsec/helper/linuxnative/cpuid.py`, I did not find any bug, but a few things could be improved:

- `ctypes.c_voidp` is actually the same as `ctypes.c_void_p` (cf. https://github.com/python/cpython/blob/2.6/Lib/ctypes/__init__.py#L257 )
- the way the machine code was mapped was more complex what it needs to be: declaring the code `bytes` instead of `list` helps using it.
- type hints annotations were missing.
- and some other things detailed in the commits.

Here is a Pull Request which add type hints to `chipsec.helper.linuxnative.cpuid` and simplify/improve the code. I tested it with `chipsec_util.py --helper linuxnativehelper ...` and by running `chipsec/helper/linuxnative/cpuid.py` directly. Also, `mypy --strict` does not report any issue with the new type hints.