### PR TITLE
Remove from_file from method start in base helper

### DIFF
--- a/chipsec/helper/basehelper.py
+++ b/chipsec/helper/basehelper.py
@@ -50,7 +50,7 @@ class Helper(ABC):
         pass
 
     @abstractmethod
-    def start(self, start_driver: bool, from_file: bool) -> bool:
+    def start(self, start_driver: bool) -> bool:
         pass
 
     @abstractmethod

--- a/tests/software/mock_helper.py
+++ b/tests/software/mock_helper.py
@@ -43,7 +43,7 @@ class TestHelper(Helper):
     def delete(self, start_driver):
         return True
 
-    def start(self, start_driver, driver_exists=False, tofile=None, fromfile=None):
+    def start(self, start_driver, driver_exists=False):
         return True
 
     def stop(self, start_driver):


### PR DESCRIPTION
Commit 99f905243826 ("Remove filehelper") removed `from_file` and `to_file` from `OsHelper` but it remained in `BaseHelper`. Remove these parameters too.

While at it, remove the similar parameters from the mock helper used in tests.