### PR TITLE
Use raw string in the regular expression used in chipsec/module.py

### DIFF
--- a/chipsec/module.py
+++ b/chipsec/module.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     _importlib = False
 
-MODPATH_RE = re.compile("^\w+(\.\w+)*$")
+MODPATH_RE = re.compile(r"^\w+(\.\w+)*$")
 
 
 class Module:


### PR DESCRIPTION
`chipsec/module.py` uses a normal string to define a regular expression, which makes flake8 report:

    chipsec/module.py:34:27: W605 invalid escape sequence '\w'
    chipsec/module.py:34:31: W605 invalid escape sequence '\.'
    chipsec/module.py:34:33: W605 invalid escape sequence '\w'

To prevent the Python interpreter from trying to interpret the escape sequences, use a raw string.