### PR TITLE
Fix test_pch_invalid() test failing

### DIFF
--- a/tests/software/mock_helper.py
+++ b/tests/software/mock_helper.py
@@ -438,7 +438,7 @@ class InvalidPchHelper(TestHelper):
             elif size == 2:
                 return 0x8086
             else:
-                return 0x19048086
+                return 0xBEEF8086
         elif (bus, device, function) == (0, 0x1f, 0):
             if size == 1:
                 return 0x86


### PR DESCRIPTION
the test invalid pch mock helper returned invalid pch id, but valid plat id, if plat id matched xml file defined reqs_pch=true, will cause exception, the mocked plat id corresponding xml is reqs_pch=true.