### PR TITLE
Remove invalid escape sequences in Windows path

### DIFF
--- a/chipsec/helper/windows/windowshelper.py
+++ b/chipsec/helper/windows/windowshelper.py
@@ -68,7 +68,7 @@ DEVICE_FILE = "\\\\.\\chipsec_hlpr"
 SERVICE_NAME = "chipsec"
 DISPLAY_NAME = "CHIPSEC Service"
 
-CHIPSEC_INSTALL_PATH = os.path.join(sys.prefix, "Lib\site-packages\chipsec")
+CHIPSEC_INSTALL_PATH = os.path.join(sys.prefix, "Lib", "site-packages", "chipsec")
 
 # Status Codes
 STATUS_PRIVILEGED_INSTRUCTION = 0xC0000096


### PR DESCRIPTION
`windowshelper.py` uses a path with backslashes without proper escaping. While this works because `\s` and `\c` are not valid escape sequences, this makes flake8 report:

   /chipsec/helper/windows/windowshelper.py:71:53: W605 invalid escape sequence '\s'
   /chipsec/helper/windows/windowshelper.py:71:67: W605 invalid escape sequence '\c'

Fix this by splitting the path when invoking `os.path.join`.

N.B. Actually it seems `CHIPSEC_INSTALL_PATH` is never used, and there is another Python issue in `chipsec/helper/windows/windowshelper.py`: `OPEN_EXISTING` is defined twice (from importing `win32file` and from a direct definition). While this Pull Request only fixes a linter error, feel free to reject it if you prefer cleaning this file up in a different way.