### PR TITLE
Update lock_check_cmd to poke 'cs.consistency_checking'

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -39,7 +39,7 @@ from chipsec.config import Cfg, CHIPSET_CODE_UNKNOWN, PROC_FAMILY
 # DEBUG Flags
 QUIET_PCI_ENUM = True
 LOAD_COMMON = True
-CONSISTENCY_CHECKING = False
+
 
 
 class RegisterType:
@@ -77,6 +77,8 @@ class Chipset:
         self.Cfg.load_parsers()
         self.Cfg.load_platform_info()
         self.using_return_codes = False
+        self.consistency_checking = False
+
     def set_hal_objects(self):
         #
         # Initializing 'basic primitive' HAL components
@@ -425,7 +427,7 @@ class Chipset:
             f = reg['fun']
             o = reg['offset']
             size = reg['size']
-            if do_check and CONSISTENCY_CHECKING:
+            if do_check and self.consistency_checking:
                 if self.pci.get_DIDVID(b, d, f) == (0xFFFF, 0xFFFF):
                     raise CSReadError(f'PCI Device is not available ({b}:{d}.{f})')
             if RegisterType.PCICFG == rtype:

--- a/chipsec/utilcmd/lock_check_cmd.py
+++ b/chipsec/utilcmd/lock_check_cmd.py
@@ -80,12 +80,17 @@ class LOCKCHECKCommand(BaseCommand):
         parser.parse_args(self.argv, namespace=self)
 
     def set_up(self) -> None:
-        CONSISTENCY_CHECKING = True # TODO: Not doing anything.
+        self.flip_consistency_checking = False
+        if not self.cs.consistency_checking:
+            self.flip_consistency_checking = True
+            self.cs.consistency_checking = True
         self.logger.set_always_flush(True)
         self._locks = locks(self.cs)
     
     def tear_down(self) -> None:
         self.logger.set_always_flush(False)
+        if self.flip_consistency_checking:
+            self.cs.consistency_checking = False
 
     def log_key(self) -> None:
         self.logger.log("""


### PR DESCRIPTION
Original code was setting a local variable when it was supposed to be touching the global in the CS object.

Moved the global to an instance variable and changed the util cmd to poke it. 