### PR TITLE
Print all devices on bus 0 with fun 0 when pch is not detected

### DIFF
--- a/chipsec/banner.py
+++ b/chipsec/banner.py
@@ -57,7 +57,7 @@ def chipsec_banner_properties(cs: Chipset, os_version: Tuple[str, str, str, str]
     python_version = platform.python_version()
     python_arch = '64-bit' if is_python_64 else '32-bit'
     (helper_name, driver_path) = cs.helper.get_info()
-    include_pch_str = cs.reqs_pch or (cs.reqs_pch is None)
+    include_pch_str = cs.Cfg.is_pch_req() or (cs.Cfg.is_pch_req() is None)
 
     banner_prop = f'''
 [CHIPSEC] OS      : {system} {release} {version} {machine}
@@ -82,6 +82,7 @@ def chipsec_banner_properties(cs: Chipset, os_version: Tuple[str, str, str, str]
 
 
 def print_banner_properties(cs: Chipset, os_version: Tuple[str, str, str, str]) -> None:
+
     if not cs.load_config:
         logger().log_warning("Not loading configurations. Platform will remain unknown.")
     logger().log(chipsec_banner_properties(cs, os_version))

--- a/chipsec/cfg/parsers/core_parsers.py
+++ b/chipsec/cfg/parsers/core_parsers.py
@@ -79,7 +79,7 @@ class PlatformInfo(BaseConfigParser):
 
     def handle_info(self, et_node, stage_data):
         platform = ''
-        req_pch = False
+        req_pch = None
         family = None
         proc_code = None
         pch_code = None
@@ -106,7 +106,7 @@ class PlatformInfo(BaseConfigParser):
             if 'detection_value' in cfg_info:
                 detect_vals = cfg_info['detection_value']
             for sku in info.iter('sku'):
-                sku_info = _config_convert_data(sku)
+                sku_info = _config_convert_data(sku, True)
                 if 'code' not in sku_info or sku_info['code'] != platform.upper():
                     sku_info['code'] = platform.upper()
                 if 'vid' not in sku_info:

--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -118,7 +118,6 @@ class Chipset:
         _cs.start_helper()
         return _cs
     def init(self, platform_code, req_pch_code, helper_name=None, start_helper=True, load_config=True, ignore_platform=False):
-        self.reqs_pch = None
         self.load_config = load_config
         _unknown_proc = True
         _unknown_pch = True
@@ -139,11 +138,11 @@ class Chipset:
             if not ignore_platform:
                 self.Cfg.platform_detection(platform_code, req_pch_code, self.cpuid)
                 _unknown_proc = self.Cfg.get_chipset_code() is None
-                _unknown_pch = self.Cfg.is_pch_req() and self.Cfg.get_pch_code() == CHIPSET_CODE_UNKNOWN
-
+                if self.Cfg.is_pch_req() == False or self.Cfg.get_pch_code() != CHIPSET_CODE_UNKNOWN:
+                    _unknown_pch = False
                 if _unknown_proc:
-                    msg = 'Unknown Platform: VID = 0x{:04X}, DID = 0x{:04X}, RID = 0x{:02X}'.format(self.Cfg.vid, self.Cfg.did, self.Cfg.rid)
-                    if start_driver:
+                    msg = f'Unknown Platform: VID = 0x{self.Cfg.vid:04X}, DID = 0x{self.Cfg.did:04X}, RID = 0x{self.Cfg.rid:02X}, CPUID = 0x{self.cpuid:X}'
+                    if start_helper:
                         logger().log_error(msg)
                         raise UnknownChipsetError(msg)
                     else:
@@ -154,8 +153,9 @@ class Chipset:
                 if logger().DEBUG:
                     logger().log("[*] Discovering Bus Configuration:")
             if _unknown_pch:
+                self.Cfg.print_bus_zero_dids()
                 msg = 'Unknown PCH: VID = 0x{:04X}, DID = 0x{:04X}, RID = 0x{:02X}'.format(self.Cfg.pch_vid, self.Cfg.pch_did, self.Cfg.pch_rid)
-                if self.reqs_pch and start_driver:
+                if self.Cfg.is_pch_req() and start_helper:
                     logger().log_error("Chipset requires a supported PCH to be loaded. {}".format(msg))
                     raise UnknownChipsetError(msg)
                 else:


### PR DESCRIPTION
Print all DIDs of devices on bus 0 function 0 when PCH is not detected. 
Slightly change behavior to match assumptions made prior to the config loading changes in 1.12.0. 
Move some prints to f'strings.
Allow ranges in `<info><sku did="0x1000-0x101F" /></info>` attribute. 
