### PR TITLE
Use the right dictionary in handle_ima

### DIFF
--- a/chipsec/cfg/parsers/core_parsers.py
+++ b/chipsec/cfg/parsers/core_parsers.py
@@ -182,7 +182,7 @@ class CoreConfig(BaseConfigParser):
         return self._add_entry_simple(self.cfg.IO_BARS, stage_data, et_node, 'bar')
 
     def handle_ima(self, et_node, stage_data):
-        return self._add_entry_simple(self.cfg.IO_BARS, stage_data, et_node, 'indirect')
+        return self._add_entry_simple(self.cfg.IMA_REGISTERS, stage_data, et_node, 'indirect')
 
     def handle_locks(self, et_node, stage_data):
         return self._add_entry_simple(self.cfg.LOCKS, stage_data, et_node, 'lock')


### PR DESCRIPTION
`CoreConfig.handle_ima` was adding entries to `cfg.IO_BARS` instead of `cfg.IMA_REGISTERS`. Moreover `Chipset.get_register_def` uses `IMA_REGISTERS` when looking for registers with type `"indirect"`, which confirms there was a bug.