### PR TITLE
Import modules traceback and errno when they are needed

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -21,6 +21,8 @@
 """
 Contains platform identification functions
 """
+import errno
+import traceback
 
 from chipsec.helper.oshelper import helper as os_helper
 from chipsec.helper.basehelper import Helper
@@ -186,7 +188,7 @@ class Chipset:
                 raise OsHelperError("failed to start OS helper", 1)
         except Exception as msg:
             logger().log_debug(traceback.format_exc())
-            error_no = ENXIO
+            error_no = errno.ENXIO
             if hasattr(msg, 'errorcode'):
                 error_no = msg.errorcode
             raise OsHelperError("Message: \"{}\"".format(msg), error_no)

--- a/chipsec/modules/tools/vmm/hv/synth_dev.py
+++ b/chipsec/modules/tools/vmm/hv/synth_dev.py
@@ -35,6 +35,7 @@ Usage:
 Note: the fuzzer is incompatible with native VMBus driver (``vmbus.sys``). To use it, remove ``vmbus.sys``
 """
 import time
+import traceback
 from struct import *
 from random import *
 from chipsec.modules.tools.vmm.hv.define import *

--- a/chipsec/modules/tools/vmm/hv/synth_kbd.py
+++ b/chipsec/modules/tools/vmm/hv/synth_kbd.py
@@ -27,6 +27,7 @@ Usage:
 
 Note: the fuzzer is incompatible with native VMBus driver (``vmbus.sys``). To use it, remove ``vmbus.sys``
 """
+import traceback
 from struct import *
 from random import *
 from chipsec.modules.tools.vmm.hv.define import *


### PR DESCRIPTION
When loading the kernel module fails on Linux, `chipsec_util.py` raises an error in

    logger().log_debug(traceback.format_exc())

because `traceback` was not imported.

Fix this issue by importing the missing modules `traceback` and `errno`. While at it, import `traceback` too in other files where it was missing.