### PR TITLE
Only add pci_dev if not previously added in core_parser

### DIFF
--- a/chipsec/cfg/parsers/core_parsers.py
+++ b/chipsec/cfg/parsers/core_parsers.py
@@ -131,12 +131,14 @@ class CoreConfig(BaseConfigParser):
         return Stage.DEVICE_CFG
 
     def _process_pci_dev(self, vid_str, dev_name, dev_attr):
+        device_added = False
         if 'did' in dev_attr:
             for did in dev_attr['did']:
                 did_str = self.cfg._make_hex_key_str(did)
                 if did_str in self.cfg.CONFIG_PCI_RAW[vid_str]:
                     pci_data = self.cfg.CONFIG_PCI_RAW[vid_str][did_str]
                     self._add_dev(vid_str, dev_name, pci_data, dev_attr)
+                    device_added = True
                     break
         else:
             for did_str in self.cfg.CONFIG_PCI_RAW[vid_str]:
@@ -145,8 +147,10 @@ class CoreConfig(BaseConfigParser):
                 if dev_attr['bus'] in pci_data['bus'] and dev_attr['dev'] == pci_data['dev'] and \
                    dev_attr['fun'] == pci_data['fun']:
                     self._add_dev(vid_str, dev_name, pci_data, dev_attr)
+                    device_added = True
                     break
-        self._add_dev(vid_str, dev_name, None, dev_attr)
+        if not device_added:
+            self._add_dev(vid_str, dev_name, None, dev_attr)
 
     def _add_dev(self, vid_str, name, pci_info, dev_attr):
         if pci_info:


### PR DESCRIPTION
When going through a config, if it found a device that's not in the defined location, it'll add it at the correct location but then over write it at the pre-defined location again, ignorning what it found. This patch corrects this. 