### PR TITLE
Fix EFI binary scanning due to bad efi_data_search calls at build_efi_file_tree

### DIFF
--- a/chipsec/hal/spi_uefi.py
+++ b/chipsec/hal/spi_uefi.py
@@ -269,7 +269,7 @@ def build_efi_file_tree(fv_img: bytes, fwtype: str) -> List[EFI_FILE]:
                 fv.append(non_UEFI)
         padding += fw_offset
         if fwbin.Type not in (EFI_FV_FILETYPE_ALL, EFI_FV_FILETYPE_RAW, EFI_FV_FILETYPE_FFS_PAD):
-            fwbin.children = efi_data_search(fwbin.Image, fwtype, polarity)
+            fwbin.children = efi_data_search(fwbin.Image[fwbin.HeaderSize:], fwtype, polarity)
             fv.append(fwbin)
         elif fwbin.Type == EFI_FV_FILETYPE_RAW:
             if fwbin.Name != NVAR_NVRAM_FS_FILE:
@@ -286,7 +286,7 @@ def build_efi_file_tree(fv_img: bytes, fwtype: str) -> List[EFI_FILE]:
             if non_UEFI.children:
                 fv.append(non_UEFI)
         elif fwbin.State not in (EFI_FILE_HEADER_CONSTRUCTION, EFI_FILE_HEADER_INVALID, EFI_FILE_HEADER_VALID):
-            fwbin.children = efi_data_search(fwbin.Image, fwtype, polarity)
+            fwbin.children = efi_data_search(fwbin.Image[fwbin.HeaderSize:], fwtype, polarity)
             fv.append(fwbin)
         fwbin = NextFwFile(fv_img, fv_size, fw_offset, polarity)
         if fwbin is None and fv_size > fw_offset:


### PR DESCRIPTION
Fixes logic of commit https://github.com/chipsec/chipsec/commit/f530b70174f338527cf8c461b963bef60a5539fa, which resulted in only 1 (last) EFI binary getting detected by omitting the FW Volume Header during some "efi_data_search" calls.

References:
- https://github.com/chipsec/chipsec/issues/1790#issuecomment-1719184898
- https://github.com/BrentHoltsclaw/chipsec/pull/1/files