### PR TITLE
Add CET module

### DIFF
--- a/chipsec/cfg/8086/common.xml
+++ b/chipsec/cfg/8086/common.xml
@@ -654,7 +654,30 @@ Common (default) XML platform configuration file
     <register name="SGX_DEBUG_MODE" type="msr" msr="0x503" desc="SGX debug mode resiter">
       <field name="SGX_DEBUG_MODE_STATUS_BIT"   bit="1"  size="1" desc="Debug mode status but"/>
     </register>
-
+    <register name="IA32_U_CET" type="msr" msr="0x6A0" desc="CET user configuration">
+      <field name="SH_STK_EN" bit="0" size="1" desc="Enable shadow stacks at CPL3" />
+      <field name="WR_SHSTK_EN" bit="1" size="1" desc="Enables the WRSSD/WRSSQ instructions" />
+      <field name="ENDBR_EN" bit="2" size="1" desc="Enable indirect branch tracking" />
+      <field name="LEG_IW_EN" bit="3" size="1" desc="Enable legacy compatibility treatment for indirect branch tracking" />
+      <field name="NO_TRACK_EN" bit="4" size="1" desc="Enables use of no track prefix for indirect branch tracking" />
+      <field name="SUPPRESS_DIS" bit="5" size="1" desc="Disables suppression of CET indirect branch tracking on legacy compatibility" />
+      <field name="RESERVED" bit="6" size="4" desc="RESERVED" />
+      <field name="SUPPRESS" bit="10" size="1" desc="Indirect branch tracking is suppressed" />
+      <field name="TRACKER" bit="11" size="1" desc="Value of the indirect branch tracking state machine" />
+      <field name="EB_LEG_BITMAP_BASE" bit="12" size="52" desc="Linear address bits of legacy code page bitmap" />
+  </register>
+  <register name="IA32_S_CET" type="msr" msr="0x6A2" desc="CET supervisor configuration">
+      <field name="SH_STK_EN" bit="0" size="1" desc="Enable shadow stacks at CPL3" />
+      <field name="WR_SHSTK_EN" bit="1" size="1" desc="Enables the WRSSD/WRSSQ instructions" />
+      <field name="ENDBR_EN" bit="2" size="1" desc="Enable indirect branch tracking" />
+      <field name="LEG_IW_EN" bit="3" size="1" desc="Enable legacy compatibility treatment for indirect branch tracking" />
+      <field name="NO_TRACK_EN" bit="4" size="1" desc="Enables use of no track prefix for indirect branch tracking" />
+      <field name="SUPPRESS_DIS" bit="5" size="1" desc="Disables suppression of CET indirect branch tracking on legacy compatibility" />
+      <field name="RESERVED" bit="6" size="4" desc="RESERVED" />
+      <field name="SUPPRESS" bit="10" size="1" desc="Indirect branch tracking is suppressed" />
+      <field name="TRACKER" bit="11" size="1" desc="Value of the indirect branch tracking state machine" />
+      <field name="EB_LEG_BITMAP_BASE" bit="12" size="52" desc="Linear address bits of legacy code page bitmap" />
+  </register>
   </registers>
 
 

--- a/chipsec/cfg/8086/common.xml
+++ b/chipsec/cfg/8086/common.xml
@@ -654,7 +654,7 @@ Common (default) XML platform configuration file
     <register name="SGX_DEBUG_MODE" type="msr" msr="0x503" desc="SGX debug mode resiter">
       <field name="SGX_DEBUG_MODE_STATUS_BIT"   bit="1"  size="1" desc="Debug mode status but"/>
     </register>
-    <register name="IA32_U_CET" type="msr" msr="0x6A0" desc="CET user configuration">
+    <register name="IA32_U_CET" type="msr" msr="0x6A0" desc="CET User configuration">
       <field name="SH_STK_EN" bit="0" size="1" desc="Enable shadow stacks at CPL3" />
       <field name="WR_SHSTK_EN" bit="1" size="1" desc="Enables the WRSSD/WRSSQ instructions" />
       <field name="ENDBR_EN" bit="2" size="1" desc="Enable indirect branch tracking" />

--- a/chipsec/modules/common/cet.py
+++ b/chipsec/modules/common/cet.py
@@ -1,0 +1,110 @@
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2023, Intel Corporation
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Contact information:
+# chipsec@intel.com
+#
+
+"""
+Reports CET Settings
+
+Usage:
+  ``chipsec_main -m common.cet``
+
+Example:
+    >>> chipsec_main.py -m common.cet
+
+.. note::
+    - cpuid(7, 0) must return 1 at bit 7 to run
+    - IA32_U_CET and IA32_S_CET must be defined for addition information.
+    - Module is INFORMATION only and does NOT return a Pass/Fail
+"""
+
+from chipsec.module_common import BaseModule, ModuleResult
+from chipsec.defines import BIT7, BIT20
+
+
+class cet(BaseModule):
+    def __init__(self):
+        super(cet, self).__init__()
+        self.cpuid_7_0__ecx_val = None
+
+    def is_supported(self):
+        supported = self.support_shadow()
+        if supported:
+            return True
+        self.logger.log_important('CET is not defined for the platform.  Skipping module.')
+        self.res = ModuleResult.NOTAPPLICABLE
+        return False
+
+    def get_cpuid_value(self) -> None:
+        (_, _, self.cpuid_7_0__ecx_val, _) = self.cs.cpu.cpuid(7, 0)
+
+    def support_shadow(self) -> bool:
+        if self.cpuid_7_0__ecx_val is None:
+            self.get_cpuid_value()
+        return self.cpuid_7_0__ecx_val & BIT7 != 0
+
+    def support_ibt(self) -> bool:
+        if self.cpuid_7_0__ecx_val is None:
+            self.get_cpuid_value()
+        return self.cpuid_7_0__ecx_val & BIT20 != 0
+
+    def setting_enabled(self, msr_val, field, mask, desc):
+        enabled = all((i & mask) != 0 for i in msr_val )
+        part_enabled = any((i & mask) != 0 for i in msr_val)
+        if enabled:
+            self.logger.log(f'  {field}: {desc} is ENABLED')
+        elif part_enabled:
+            self.logger.log(f'  {field}: {desc} is ENABLED on 1 or more threads')
+        else:
+            self.logger.log(f'  {field}: {desc} is NOT ENABLED')
+
+    def print_cet_state(self, cet_msr):
+        fields = ['SH_STK_EN',
+                  'WR_SHSTK_EN',
+                  'ENDBR_EN',
+                  'LEG_IW_EN',
+                  'NO_TRACK_EN',
+                  'SUPPRESS_DIS',
+                  'SUPPRESS']
+        msr_vals = self.cs.read_register_all(cet_msr)
+        reg = self.cs.get_register_def(cet_msr)
+        self.logger.log(f'{cet_msr} Settings:')
+        for key in fields:
+            mask = self.cs.get_register_field_mask(cet_msr, key, True)
+            desc = reg['FIELDS'][key]['desc']
+            self.setting_enabled(msr_vals, key, mask, desc)
+
+    def check_cet(self):
+        res = ModuleResult.INFORMATION
+        if self.support_shadow():
+            self.logger.log("CET Shadow Stack is supported")
+        else:
+            self.logger.log("CET Shadow Stack is unsupported")
+        if self.support_ibt():
+            self.logger.log("CET Indirect Branch Tracking is supported")
+        else:
+            self.logger.log("CET Indirect Branch Tracking is unsupported")
+        if self.cs.is_register_defined("IA32_U_CET") and self.cs.is_register_defined("IA32_S_CET"):
+            self.print_cet_state("IA32_U_CET")
+            self.print_cet_state('IA32_S_CET')
+        return res
+
+    def run(self, module_argv):
+        self.logger.start_test("Checking CET Settings")
+        self.res = self.check_cet()
+        return self.res


### PR DESCRIPTION
Reports CET settings if supported on the platform
```
[*] Running module: chipsec.modules.common.cet
[x][ =======================================================================
[x][ Module: Checking CET Settings
[x][ =======================================================================
CET Shadow Stack is supported
CET Indirect Branch Tracking is unsupported
IA32_U_CET Settings:
  SH_STK_EN: Enable shadow stacks at CPL3 is NOT ENABLED
  WR_SHSTK_EN: Enables the WRSSD/WRSSQ instructions is NOT ENABLED
  ENDBR_EN: Enable indirect branch tracking is NOT ENABLED
  LEG_IW_EN: Enable legacy compatibility treatment for indirect branch tracking is NOT ENABLED
  NO_TRACK_EN: Enables use of no track prefix for indirect branch tracking is NOT ENABLED
  SUPPRESS_DIS: Disables suppression of CET indirect branch tracking on legacy compatibility is NOT ENABLED
  SUPPRESS: Indirect branch tracking is suppressed is NOT ENABLED
IA32_S_CET Settings:
  SH_STK_EN: Enable shadow stacks at CPL3 is NOT ENABLED
  WR_SHSTK_EN: Enables the WRSSD/WRSSQ instructions is NOT ENABLED
  ENDBR_EN: Enable indirect branch tracking is NOT ENABLED
  LEG_IW_EN: Enable legacy compatibility treatment for indirect branch tracking is NOT ENABLED
  NO_TRACK_EN: Enables use of no track prefix for indirect branch tracking is NOT ENABLED
  SUPPRESS_DIS: Disables suppression of CET indirect branch tracking on legacy compatibility is NOT ENABLED
  SUPPRESS: Indirect branch tracking is suppressed is NOT ENABLED```