### PR TITLE
Reorder standard Python import statements

### DIFF
--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -24,10 +24,10 @@
 Standalone utility
 """
 
+import argparse
+import importlib
 import os
 import sys
-import importlib
-import argparse
 from time import time
 
 from typing import Sequence, Optional, Dict, Any


### PR DESCRIPTION
Reorder the standard Python library import statements into alphabetical order.