### PR TITLE
Include options/*.ini when installing using `setup.py install`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ class sdist(_sdist):
 package_data = {
     # Include any configuration file.
     '': ['*.ini', '*.cfg', '*.json'],
-    'chipsec': ['*VERSION*', 'WARNING.txt'],
+    'chipsec': ['*VERSION*', 'WARNING.txt', 'options/*.ini'],
     'chipsec.cfg': ['8086/*.xml', '1022/*.xml', '*.xml', '*.xsd'],
 }
 data_files = [('', ['chipsec-manual.pdf'])]


### PR DESCRIPTION
Addresses issue #2047 