### PR TITLE
Fix issues with `chipsec_util.py mmio list` command

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -437,7 +437,7 @@ class Chipset:
             if logger().DEBUG:
                 logger().log_important(f"Using discovered bus values for device '{dev_name}'")
             return buses
-        if 'bus' in self.Cfg.CONFIG_PCI[dev_name]:
+        if dev_name in self.Cfg.CONFIG_PCI and 'bus' in self.Cfg.CONFIG_PCI[dev_name]:
             (bus, dev, fun) = self.get_device_BDF(dev_name)
             if self.pci.is_enabled(bus, dev, fun):
                 if logger().DEBUG:

--- a/chipsec/hal/mmio.py
+++ b/chipsec/hal/mmio.py
@@ -389,6 +389,7 @@ class MMIO(hal_base.HALBase):
             else:
                 continue
             for bus in bus_data:
+                bus = self.cs.get_first(bus)
                 try:
                     (_base, _size) = self.get_MMIO_BAR_base_address(_bar_name, bus)
                 except:
@@ -401,7 +402,7 @@ class MMIO(hal_base.HALBase):
                     if 'offset' in _bar:
                         _s += (f' + 0x{_bar["offset"]:X}')
                 else:
-                    bus_value = _bar["bus"]
+                    bus_value = self.cs.get_first(_bar["bus"])
                     dev_value = _bar["dev"]
                     fun_value = _bar["fun"]
                     _s = f'{bus_value:02X}:{dev_value:02X}.{fun_value:01X} + {_bar["reg"]}'


### PR DESCRIPTION
Fix issues printing bus when it was passed as an array and when a register is defined, but the device is not present. 