### PR TITLE
LinuxHelper: open the device with buffering=0 to avoid caching 

### DIFF
--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -188,7 +188,8 @@ class LinuxHelper(Helper):
 
         estr = "Unable to open chipsec device. Did you run as root/sudo and load the driver?\n {}"
         try:
-            self.dev_fh = open(self.DEVICE_NAME, "rb+")
+            # Do not buffer access to physical memory...
+            self.dev_fh = open(self.DEVICE_NAME, "rb+", buffering=0)
             self.driver_loaded = True
         except IOError as e:
             raise OsHelperError(estr.format(str(e)), e.errno)


### PR DESCRIPTION
LinuxHelper: open the device with buffering=0 to avoid caching when reading physical memory

I am using chipsec to read and write physical memory, and particularly expect this memory to change because some devices use it for DMA.

On linux, the python helper _linuxhelper.py_ opens the device "/dev/chipsec" without setting `buffering=0`. It implies that calling the `read_physical_mem` API will be cached if `flush()` is not called. `flush()` is only called when writing. So if I expect a change in the DMA, it will never occur until I use `write_physical_mem`.

I think the read/write accesses to the device and therefore to physical memory should never be cached by the python bindings.

It might have some performance impact on the tool, but I don't think this is the behavior expected.