### PR TITLE
Fix iobar offset conversion error

### DIFF
--- a/chipsec/hal/iobar.py
+++ b/chipsec/hal/iobar.py
@@ -163,7 +163,7 @@ class IOBAR(hal_base.HALBase):
             if 'register' in _bar:
                 _s = _bar['register']
                 if 'offset' in _bar:
-                    _s += (f' + 0x{int(_bar["offset"], 16):X}')
+                    _s += (f' + 0x{int(str(_bar["offset"]), 16):X}')
             else:
                 _s = f'{int(_bar["bus"], 16):02X}:{int(_bar["dev"], 16):02X}.{int(_bar["fun"], 16):01X} + {_bar["reg"]}'
 


### PR DESCRIPTION
Fixing a error when running the command 
`python3 chipsec_util.py io list`

Python 3.12.3

This fix is enforcing the bar offset to be a string instead a integer to be able to convert to hex correctly.
The debug log of the error is described bellow:

```
--------------------------------------------------------------------------------
 I/O Range    | BAR Register   | Base             | Size     | En? | Description
--------------------------------------------------------------------------------
[*] [HAL] [pci] reading B/D/F: 0/31/0, offset: 0x40, value: 0x00000401
 ABASE        | ABASE          | 0000000000000400 | 00000080 | 1   | ACPI Base Address
[*] [HAL] [pci] reading B/D/F: 0/31/0, offset: 0x40, value: 0x00000401
 PMBASE       | ABASE          | 0000000000000400 | 00000080 | 1   | ACPI Base Address
[*] [HAL] [pci] reading B/D/F: 0/31/0, offset: 0x40, value: 0x00000401
ERROR: An error occured during the execution of the command!
ERROR: Please run with the debug option for further details
Traceback (most recent call last):
  File "/home/..../git/chipsec/chipsec/command.py", line 36, in run
    self.func()
  File "/home/..../chipsec/chipsec/utilcmd/io_cmd.py", line 75, in io_list
    self._iobar.list_IO_BARs()
  File "/home/..../chipsec/chipsec/hal/iobar.py", line 166, in list_IO_BARs
    _s += (f' + 0x{int(_bar["offset"], 16):X}')
                   ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: int() can't convert non-string with explicit base
[CHIPSEC] Time elapsed 0.003
[*] [DEBUG] Module for /dev/chipsec unloaded successfully
[*] [DEBUG] [helper] Linux Helper stopped/unloaded
[*] [DEBUG] [helper] Linux Helper deleted

```