### PR TITLE
Fix `io list` util command

### DIFF
--- a/chipsec/hal/iobar.py
+++ b/chipsec/hal/iobar.py
@@ -165,7 +165,7 @@ class IOBAR(hal_base.HALBase):
                 if 'offset' in _bar:
                     _s += (f' + 0x{int(_bar["offset"], 16):X}')
             else:
-                _s = f'{int(_bar["bus"], 16):02X}:{int(_bar["dev"], 16):02X}.{int(_bar["fun"], 16):01X} + {_bar["reg"]}'
+                _s = f'{_bar["bus"][0]:02X}:{_bar["dev"]:02X}.{_bar["fun"]:01X} + {_bar["reg"]}'
 
             logger().log(f' {_bar_name:12} | {_s:14} | {_base:016X} | {_size:08X} | {_en:d}   | {_bar["desc"]}')
 


### PR DESCRIPTION
###### Tested on a SKX platform with C620 PCH
This PR fixes a bug in the IO ranges printing. The `io list` util command would exit abnormally, causing it to emit only a subset of the platform IO ranges. This is how the command output looks like:
```
[CHIPSEC] Executing command 'io' with args ['list']


--------------------------------------------------------------------------------
 I/O Range    | BAR Register   | Base             | Size     | En? | Description
--------------------------------------------------------------------------------
 ABASE        | ABASE          | 0000000000000500 | 00000100 | 1   | ACPI Base Address
 PMBASE       | ABASE          | 0000000000000500 | 00000100 | 1   | ACPI Base Address
 TCOBASE      | TCOBASE        | 0000000000000400 | 00000020 | 1   | TCO Base Address
ERROR: An error occured during the execution of the command!
ERROR: Please run with the debug option for further details
[CHIPSEC] Time elapsed 0.001
```

It turned out that `_bar["bus"]` holds a list which the code attempts to convert to an integer. The exception raised causes the loop to break. I haven't dived any deeper than that so I am not sure why it holds a list (maybe because it runs on a server platform..?) and whether there could be more than one element in that list.

The fixed line uses the first element from the list and avoid converting the rest of the data to integers as it seems that they are all already integers.

This is the output after the fix:
```
[CHIPSEC] Executing command 'io' with args ['list']


--------------------------------------------------------------------------------
 I/O Range    | BAR Register   | Base             | Size     | En? | Description
--------------------------------------------------------------------------------
 ABASE        | ABASE          | 0000000000000500 | 00000100 | 1   | ACPI Base Address
 PMBASE       | ABASE          | 0000000000000500 | 00000100 | 1   | ACPI Base Address
 TCOBASE      | TCOBASE        | 0000000000000400 | 00000020 | 1   | TCO Base Address
 SMBUS_BASE   | 00:1F.4 + 32   | 0000000000000780 | 00000080 | 1   | SMBus Base Address
[CHIPSEC] Time elapsed 0.000
```