### PR TITLE
Attempt logger "color" command for ANSI on Windows OS only

### DIFF
--- a/chipsec/library/logger.py
+++ b/chipsec/library/logger.py
@@ -100,7 +100,8 @@ class chipsecStreamFormatter(logging.Formatter):
     # when the output is not a terminal (eg. redirection to a file)
     mPlatform = platform.system().lower()
     if is_atty and os.getenv('NO_COLOR') is None and (("windows" == mPlatform) or "linux" == mPlatform):
-        os.system('color')
+        if mPlatform == 'windows':
+            _ = os.system('color')
         colors = {
             'GREY':'\033[90m',
             'RED':'\033[91m',


### PR DESCRIPTION
On Windows, it may be needed to enable ANSI color sequences for earlier builds of Windows 10 or older. From online reports, it would appear that even an empty command will have the same effect ("" instead of "color").

On Linux, this is neither present nor needed and causes "sh: 1: color: not found" error 
Fixes https://github.com/chipsec/chipsec/issues/2213