### PR TITLE
Add error message when UEFI compression modules are missing

### DIFF
--- a/chipsec/hal/uefi_compression.py
+++ b/chipsec/hal/uefi_compression.py
@@ -18,24 +18,42 @@
 # chipsec@intel.com
 
 
-try:
-    import brotli
-    has_brotli = True
-except ImportError:
-    has_brotli = False
-try:
-    import lzma
-    has_lzma = True
-except ImportError:
-    has_lzma = False
-try:
-    import EfiCompressor
-    has_eficomp = True
-except ImportError:
-    has_eficomp = False
+import platform
 
 from typing import List, Any
+
 from chipsec.library.logger import logger
+
+def show_import_error(import_name: str) -> None:
+    if platform.system().lower() in ('windows', 'linux', 'darwin'):
+        logger().log_error(f'Failed to import compression module "{import_name}"')
+
+try:
+    import brotli
+
+    has_brotli = True
+except ImportError as exception:
+    has_brotli = False
+
+    show_import_error(exception.name)
+
+try:
+    import lzma
+
+    has_lzma = True
+except ImportError as exception:
+    has_lzma = False
+
+    show_import_error(exception.name)
+
+try:
+    import EfiCompressor
+
+    has_eficomp = True
+except ImportError as exception:
+    has_eficomp = False
+
+    show_import_error(exception.name)
 
 #
 # Compression Types


### PR DESCRIPTION
Fixes https://github.com/chipsec/chipsec/issues/1925

![](https://github.com/user-attachments/assets/556de1a3-d608-46e1-a981-af7eda7a66da)