### PR TITLE
Update Linux max phys mem write size from 0xFFFF to 0xFFFFFFFF

### DIFF
--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -242,7 +242,7 @@ class LinuxHelper(Helper):
             else:
                 res = self.dev_fh.write(newval)
                 self.dev_fh.flush()
-                return res.to_bytes(2, 'little')
+                return res.to_bytes(4, 'little')
         return b''
 
     def write_phys_mem(self, phys_address: int, length: int, newval: bytes) -> int:


### PR DESCRIPTION
If trying to write 0x1_0000 bytes or more at once using linuxhelper.write_phys_mem(), it would write but raise an exception saying `int too big to convert` 