### PR TITLE
8086/meteorlake: fix issue #2276

### DIFF
--- a/chipsec/cfg/8086/mtl.xml
+++ b/chipsec/cfg/8086/mtl.xml
@@ -38,6 +38,10 @@ https://www.intel.com/content/www/us/en/products/docs/processors/core/core-techn
     <sku did="0x7D16" name="Meteor Lake" code="MTL" longname="MTL-P 242" />
 </info>
 
+<pci>
+    <device name="PMC" bus="0" dev="0x1F" fun="2" vid="0x8086" did="0x7E21" />
+</pci>
+
 <mmio>
     <bar name="MCHBAR"     bus="0" dev="0"    fun="0" reg="0x48" width="8" mask="0x3FFFFFE0000" size="0x8000" enable_bit="0" desc="Host Memory Mapped Register Range"/>
     <bar name="SPIBAR"     bus="0" dev="0x1F" fun="5" reg="0x10" width="4" mask="0xFFFFF000"    size="0x1000" desc="SPI Controller Register Range" offset="0x0"/>
@@ -47,8 +51,13 @@ https://www.intel.com/content/www/us/en/products/docs/processors/core/core-techn
     <bar name="GTTMMADR"   register="GTTMMADR"   base_field="BA" size="0x1000000" desc="" />
     <bar name="IPUVTDBAR"  register="IPUVTDBAR"  base_field="BA" size="0x1000"    desc="" />
     <bar name="ABASE"      register="ABASE"      base_field="BA" size="0x100"     desc="ACPI Base Address"/>
-    <bar name="PWRMBASE"   register="PWRMBASE"   base_field="BA" size="0x2000"    desc="Power Management Register Range"/>
+    <bar name="PWRMBASE"   register="PWRMBASE"   base_field="BA" size="0x4000"    fixed_address="0xFE000000" desc="Power Management Register Range"/>
+    <bar name="SBREGBAR" register="SBREG_BAR" base_field="RBA"   size="0x1000000" fixed_address="0xFD000000" desc="Sideband Register Access BAR"/>
 </mmio>
+
+<io>
+    <bar name="SMBUS_BASE" bus="0" dev="0x1F" fun="4" reg="0x20" mask="0xFFE0" size="0x80" desc="SMBus Base Address"/>
+</io>
 
 <pci>
     <device name="SPI"    bus="0" dev="0x1F" fun="5" vid="0x8086" />
@@ -57,6 +66,15 @@ https://www.intel.com/content/www/us/en/products/docs/processors/core/core-techn
 </pci>
 
 <registers>
+
+    <!-- RTC registers -->
+    <register name="RC" type="mm_msgbus" port="0xC3" offset="0x3400" size="4" desc="RTC Configuration">
+      <field name="UE"   bit="2"  size="1" desc="Upper 128 Byte Enable"/>
+      <field name="LL"   bit="3"  size="1" desc="Lower 128 Byte Lock"/>
+      <field name="UL"   bit="4"  size="1" desc="Upper 128 Byte Lock"/>
+      <field name="BILD" bit="31" size="1" desc="BIOS Interface Lock-Down"/>
+    </register>
+
     <!-- Host Bridge -->
     <register name="PCI0.0.0_GGC" type="pcicfg" bus="0" dev="0" fun="0" offset="0x50" size="2" desc="Graphics Control" >
         <field name="GMS"     bit="8" size="8" desc="GMS" />
@@ -125,6 +143,16 @@ https://www.intel.com/content/www/us/en/products/docs/processors/core/core-techn
     <register name="PCI0.0.0_REMAPLIMIT" type="mmio" bar="MCHBAR" offset="0xD898" size="8" desc="" >
     </register>
 
+    <!-- PMC PCI Registers (D31:F2) -->
+    <register name="ABASE" type="pcicfg" device="PMC" offset="0x20" size="4" desc="ACPI Base Address">
+        <field name="STYPE" bit="0" size="1" desc="Space Type (hardwired to 1 - IO) (MESSAGE_SPACE)"/>
+        <field name="BA"    bit="7" size="25" desc="Base Address"/>
+    </register>
+    <register name="PWRMBASE" type="pcicfg" device="PMC" offset="0x10" size="4" desc="PM Base Address">
+      <field name="STYPE" bit="0"  size="1"  desc="Space Type (hardwired to 0 - memory space) (MESSAGE_SPACE)"/>
+      <field name="BA"    bit="14" size="18" desc="Base Address"/>
+    </register>
+
     <!-- Sideband Register Access Registers -->
     <register name="SBREG_BAR" type="pcicfg" device="P2SBC" offset="0x10" size="8" desc="Sideband Register Access BAR">
         <field name="RBA" bit="28" size="36" desc="Register Base Address"/>
@@ -186,12 +214,21 @@ https://www.intel.com/content/www/us/en/products/docs/processors/core/core-techn
     </register>
 
     <!-- SMBus Host Controller -->
-    <!-- SBA -->
-    <register name="TCOBASE"    type="pcicfg" device="SMBUS" offset="0x50" size="4" desc="TCO Base Address">
+    <register name="SMBUS_VID"  type="pcicfg" bus="0" dev="0x1F" fun="4" offset="0x00" size="2" desc="VID" />
+    <register name="SMBUS_DID"  type="pcicfg" bus="0" dev="0x1F" fun="4" offset="0x02" size="2" desc="DID" />
+    <register name="SMBUS_CMD"  type="pcicfg" bus="0" dev="0x1F" fun="4" offset="0x04" size="2" desc="CMD" />
+    <register name="SMBUS_HCFG" type="pcicfg" bus="0" dev="0x1F" fun="4" offset="0x40" size="1" desc="Host Configuration">
+        <field name="HST_EN"     bit="0" size="1"/>
+        <field name="SMB_SMI_EN" bit="1" size="1"/>
+        <field name="I2C_EN"     bit="2" size="1"/>
+        <field name="SSRESET"    bit="3" size="1"/>
+        <field name="SPD_WD"     bit="4" size="1"/>
+    </register>
+    <register name="TCOBASE"    type="pcicfg" bus="0" dev="0x1F" fun="4" offset="0x50" size="4" desc="TCO Base Address">
         <field name="IOS"   bit="0" size="1"  desc="I/O space"/>
         <field name="TCOBA" bit="5" size="11" desc="TCO Base Address"/>
     </register>
-    <register name="TCOCTL"     type="pcicfg" device="SMBUS" offset="0x54" size="4" desc="TCO Control">
+    <register name="TCOCTL"     type="pcicfg" bus="0" dev="0x1F" fun="4" offset="0x54" size="4" desc="TCO Control">
         <field name="TCO_BASE_LOCK" bit="0" size="1" desc="TCO Base Lock"/>
         <field name="TCO_BASE_EN"   bit="8" size="1" desc="TCO Base Enable"/>
     </register>
@@ -331,5 +368,9 @@ https://www.intel.com/content/www/us/en/products/docs/processors/core/core-techn
     <register name="MSR_LT_LOCK_MEMORY"   undef="Not defined for the platform" />
     <register name="LT_LOCK_MEMORY"       undef="Not defined for the platform" />
 </registers>
+
+<controls>
+    <control name="SMILock" register="GEN_PMCON_2" field="SMI_LOCK" desc="SMI Global Configuration Lock"/>
+</controls>
 
 </configuration>


### PR DESCRIPTION
This patch resolves three exceptions on meteorlake. 
Fixes #2276

**Exception 1**
 ***Description:*** ```common.rtclock``` throws an exception when trying to read
 the ```RC``` register.
 ***Changes made to resolve this issue:***
  - override the ```RC``` register inherited from ```8086/common.xml``` so that we don't rely on ```RCBA``` anymore
  - define the ```SBREGBAR```

**Exception 2**
 ***Description:*** ```common.spd_wd``` throws an exception when trying
 to access the ```SMBUS_BASE```. It also tried to read the ```SMBus HCFG``` from
 ```00:31.3 + 0x40``` instead of ```00:31.4 + 0x40```.
***Changes made to resolve this issue:***
  - define the ```SMBUS_BASE```
  - extend the definition for the SMBus PCI configuration space

**Exception 3**
 ***Description:*** ```common.bios_smi``` throws an exception when trying
 to access ```ABASE```.
 ***Changes made to resolve this issue:***
  - add ```PMC``` device definition at ```00:31.2```
  - add ```PWRMBASE``` and ```ABASE``` register definitions
  - add ```SMILock``` control

Please review for any potential configuration errors.