### PR TITLE
Fix Chipsec failures to detect certain EFI modules (#2253)

### DIFF
--- a/chipsec/hal/spi_uefi.py
+++ b/chipsec/hal/spi_uefi.py
@@ -344,11 +344,11 @@ def build_efi_tree(data: bytes, fwtype: Optional[str]) -> List['EFI_MODULE']:
 # and build_efi_modules_tree (SECTION), in succession, stopping on first successful call.
 #
 def find_efi_modules(data: bytes, fwtype: Optional[str], polarity: bool, data_size: Optional[int] = None,
-                     data_start: Optional[int] = None) -> list['EFI_MODULE']:
+                     data_start: Optional[int] = None) -> List['EFI_MODULE']:
     data_len: int = len(data) if data_size is None else data_size
     data_off: int = 0 if data_start is None else data_start
 
-    efi_tree: list['EFI_MODULE'] = build_efi_tree(data=data[data_off:data_len], fwtype=fwtype)
+    efi_tree: List['EFI_MODULE'] = build_efi_tree(data=data[data_off:data_len], fwtype=fwtype)
 
     if not efi_tree:
         efi_tree = build_efi_file_tree(fv_img=data[data_off:data_len], fwtype=fwtype)


### PR DESCRIPTION
Fixed two Chipsec issues, which affect the proper detection of the VariableSmm binary (among others)

* The “efi_data_search” method was not taking into account the data start and data size values
  * This is important for “build_efi_modules_tree” (SECTION) as it requires such initialization
  * Added two new method arguments: “data_start” and “data_size”
    * “data_start” is either provided or defaults to 0 (i.e. start of data buffer)
    * “data_size” is either provided or default to the size of input data buffer
  * For the successive “build_efi_tree” (FV) and “build_efi_file_tree” (FILE) calls
    * The data buffer is now explicitly set between “data_start” and “data_size”
  * The “efi_data_search” method has now been renamed to “find_efi_modules”
    * More descriptive and previous logic flow is incompatible with new/fixed one

* The “NextFwVolume” method was not validating the Firmware Volume size correctly
  * All “build_efi_tree” (FV) calls were affected, as false positive FV could be allowed
  * The “size” argument of “ValidateFwVolumeHeader” method was wrongly initialized
    * “NextFwVolume” would supply the size of its input buffer, not the one from FV
      * Example: Input buffer is 100 bytes, FV starts at byte 20, FV size is 90 bytes
        * Check should be 90 <= 100 - 20, thus 90 <= 80 → false → incomplete FV
        * Check was bad as 90 <= 100 → true → false positive FV being accepted
    * “NextFwVolume” now passes the correct FV Image size to “ValidateFwVolumeHeader”
    * Revamped the “ValidateFwVolumeHeader” method with HAL-level warnings on all checks