### PR TITLE
Add try except for collections.abc in create_manual

### DIFF
--- a/docs/create_manual.py
+++ b/docs/create_manual.py
@@ -40,8 +40,11 @@ https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
 """
 
 import os
-#from collections.abc import Sequence
-from typing import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from typing import Sequence
+    print('!! Unable to import collections.abc !!')
 import shutil
 import sys
 


### PR DESCRIPTION
First try to import from collections.abc (python 3.10+)
If that fails, fall back to typing (python 3.6-3.9)