### PR TITLE
HALData and MMIO update

### DIFF
--- a/chipsec/cfg/8086/HOSTCTL/hostctl1.xml
+++ b/chipsec/cfg/8086/HOSTCTL/hostctl1.xml
@@ -3,7 +3,7 @@
 
   <mmio>
     <bar name="PXPEPBAR" register="PXPEPBAR" base_field="PXPEPBAR" size="0x1000" enable_bit="0" desc="PCI Express Egress Port Register Range"/>
-    <bar name="MCHBAR"   register="MCHBAR" base_field="MCHBAR" size="0x8000" enable_bit="0" desc="Host Memory Mapped Register Range"/>
+    <!-- <bar name="MCHBAR"   register="MCHBAR" base_field="MCHBAR" size="0x8000" enable_bit="0" desc="Host Memory Mapped Register Range"/> -->
     <bar name="MMCFG"    register="PCIEXBAR" base_field="PXPEPBAR" size="0x1000" enable_bit="0" desc="PCI Express Register Range"/>
     <bar name="DMIBAR"   register="DMIBAR" base_field="DMIBAR" size="0x1000" enable_bit="0" desc="Root Complex Register Range"/>
     <bar name="VTBAR"    register="VTBAR"    base_field="Base" size="0x1000" enable_field="Enable" desc="Intel VT-d Register Register Range"/>
@@ -124,23 +124,7 @@
       <field name="VTDD" bit="23" size="1" desc="Enable/Disable VTd"/>
     <register name="CAPID0_B"   type="pcicfg" offset="0xE8" size="4" desc="Capabilities B"/>
 
-    <register name="GFXVTBAR" type="mmio" bar="MCHBAR" offset="0x5400" size="8" desc="Processor Graphics VT-d MMIO Base Address">
-      <field name="Enable" bit="0"  size="1" desc="Enable"/>
-      <field name="Base"   bit="12" size="27" desc="GFX VTD Base Address"/>
-    </register>
-
-    <register name="VTBAR" type="mmio" bar="MCHBAR" offset="0x5410" size="8" desc="VT-d MMIO Base Address">
-      <field name="Enable" bit="0"  size="1"  desc="Enable"/>
-      <field name="Base"   bit="12" size="27" desc="VTD Base Address"/>
-    </register>
-
-    <register name="REMAPBASE"  type="mmio" bar="MCHBAR" offset="0x5090" size="8" desc="Memory Remap Base Address">
-        <field name="REMAPBASE"  bit="20" size="19" desc="lower boundry of Remap Window"/>
-    </register>
-
-    <register name="REMAPLIMIT" type="mmio" bar="MCHBAR" offset="0x5098" size="8" desc="Memory Remap Limit Address">
-      <field name="REMAPLMT"  bit="20" size="19" desc="lower boundry of Remap Window"/>
-    </register>
+    
 
   </registers>
 

--- a/chipsec/cfg/8086/MMIO/mmio0.xml
+++ b/chipsec/cfg/8086/MMIO/mmio0.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<configuration>
+
+  <registers>
+  
+    <register name="GFXVTBAR" type="mmio" bar="MCHBAR" offset="0x5400" size="8" desc="Processor Graphics VT-d MMIO Base Address">
+      <field name="Enable" bit="0"  size="1" desc="Enable"/>
+      <field name="Base"   bit="12" size="27" desc="GFX VTD Base Address"/>
+    </register>
+
+    <register name="VTBAR" type="mmio" bar="MCHBAR" offset="0x5410" size="8" desc="VT-d MMIO Base Address">
+      <field name="Enable" bit="0"  size="1"  desc="Enable"/>
+      <field name="Base"   bit="12" size="27" desc="VTD Base Address"/>
+    </register>
+
+    <register name="REMAPBASE"  type="mmio" bar="MCHBAR" offset="0xD890" size="8" desc="Memory Remap Base Address">
+        <field name="REMAPBASE"  bit="20" size="19" desc="lower boundry of Remap Window"/>
+    </register>
+
+    <register name="REMAPLIMIT" type="mmio" bar="MCHBAR" offset="0xD890" size="8" desc="Memory Remap Limit Address">
+      <field name="REMAPLMT"  bit="20" size="19" desc="lower boundry of Remap Window"/>
+    </register>
+
+  </registers>
+    
+</configuration>

--- a/chipsec/cfg/8086/TPM/tpm12.xml
+++ b/chipsec/cfg/8086/TPM/tpm12.xml
@@ -26,7 +26,7 @@ XML configuration file for TPM address space
 -->
   <registers>
 
-    <register name="TPM_ACCESS" type="memory" access="mmio" address="0xFED40000" offset="0x000" size="1" desc="TPM ACCESS">
+    <register name="TPM_ACCESS" type="memory" range="TPM" offset="0x000" size="1" desc="TPM ACCESS">
       <field name="tpmRegValidSts"   bit="7" size="1" desc="tpmRegValidSts"/>
       <field name="reserved"         bit="6" size="1" desc="reserved"/>
       <field name="activeLocality"   bit="5" size="1" desc="activeLocality"/>
@@ -37,7 +37,7 @@ XML configuration file for TPM address space
       <field name="tpmEstablishment" bit="0" size="1" desc="tpmEstablishment"/>
     </register>
 
-    <register name="TPM_STS" type="memory" access="mmio" address="0xFED40018" offset="0x000" size="4" desc="TPM STATUS">
+    <register name="TPM_STS" type="memory" range="TPM" offset="0x018" size="4" desc="TPM STATUS">
       <field name="burstCount"    bit="8" size="24" desc="burstCount"/>
       <field name="stsValid"      bit="7" size="1"  desc="stsValid"/>
       <field name="commandReady"  bit="6" size="1"  desc="commandReady"/>
@@ -49,16 +49,16 @@ XML configuration file for TPM address space
       <field name="Reserved"      bit="0" size="1"  desc="Reserved"/>
     </register>
 
-    <register name="TPM_DID_VID" type="memory" access="mmio" address="0xFED40F00" offset="0x000" size="4" desc="TPM DID/VID">
+    <register name="TPM_DID_VID" type="memory" range="TPM" offset="0xF00" size="4" desc="TPM DID/VID">
       <field name="did" bit="16" size="16" desc="did"/>
       <field name="vid" bit="0"  size="16" desc="vid"/>
     </register>
 
-    <register name="TPM_RID" type="memory" access="mmio" address="0xFED40F04" offset="0x000" size="1" desc="TPM RID">
+    <register name="TPM_RID" type="memory" range="TPM" offset="0xF04" size="1" desc="TPM RID">
       <field name="rid" bit="0" size="8" desc="rid"/>
     </register>
 
-    <register name="TPM_INTF_CAPABILITY" type="memory" access="mmio" address="0xFED40014" offset="0x000" size="4" desc="TPM INTF CAPABILITY">
+    <register name="TPM_INTF_CAPABILITY" type="memory" range="TPM" offset="0x014" size="4" desc="TPM INTF CAPABILITY">
       <field name="Reserved"                 bit="9" size="23" desc="Reserved"/>
       <field name="BurstCountStatic"         bit="8" size="1"  desc="BurstCountStatic"/>
       <field name="CommandReadyIntSupport"   bit="7" size="1"  desc="CommandReadyIntSupport"/>
@@ -71,7 +71,7 @@ XML configuration file for TPM address space
       <field name="dataAvailIntSupport"      bit="0" size="1"  desc="dataAvailIntSupport"/>
     </register>
 
-    <register name="TPM_INT_ENABLE" type="memory" access="mmio" address="0xFED40008" offset="0x000" size="4" desc="TPM INT ENABLE">
+    <register name="TPM_INT_ENABLE" type="memory" range="TPM" offset="0x008" size="4" desc="TPM INT ENABLE">
       <field name="globalIntEnable"         bit="31" size="1"  desc="CommandReadyIntSupport"/>
       <field name="Reserved"                bit="8"  size="23" desc="InterruptEdgeFalling"/>
       <field name="commandReadyEnable"      bit="7"  size="1"  desc="InterruptEdgeRising"/>

--- a/chipsec/cfg/8086/adl.xml
+++ b/chipsec/cfg/8086/adl.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0"?>
+<configuration platform="ADL" req_pch="False"> 
+<!-- TODO: req_pch = True -->
+<!--
+CHIPSEC: Platform Security Assessment Framework
+Copyright (c) 2023, Intel Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; Version 2.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+Contact information:
+chipsec@intel.com
+-->
+
+<!--
+XML configuration file for Alder Lake based platforms
+
+http://www.intel.com/content/www/us/en/processors/core/core-technical-resources.html
+
+* 12th Generation Intel(R) Core Processor Family Datasheet
+Review:    !!!
+* Intel(R) 600 Series Chipset Family on-package Platform Controller Hub (PCH)
+-->
+
+  <!-- #################################### -->
+  <!--                                      -->
+  <!-- Information                          -->
+  <!--                                      -->
+  <!-- #################################### -->
+
+  <info family="core" detection_value="0x90670-0x90672, 0x90674-0x90675, 0x906a0-0x906a4">
+    <sku did="0x4601" name="AlderLake" code="ADL" longname="ADL-P/U15 2+8"/>
+    <sku did="0x4602" name="AlderLake" code="ADL" longname="ADL-U9 2+8"/>
+    <sku did="0x4609" name="AlderLake" code="ADL" longname="ADL-U15 2+4"/>
+    <sku did="0x460A" name="AlderLake" code="ADL" longname="ADL-U9 2+4"/>
+    <sku did="0x4610" name="AlderLake" code="ADL" longname="ADL-S LGA 2+0"/>
+    <sku did="0x4619" name="AlderLake" code="ADL" longname="ADL-U15 1+4"/>
+    <sku did="0x461A" name="AlderLake" code="ADL" longname="ADL-U9 1+4"/>
+    <sku did="0x4621" name="AlderLake" code="ADL" longname="ADL-P/H 4+8"/>
+    <sku did="0x4629" name="AlderLake" code="ADL" longname="ADL-H 4+4"/>
+    <sku did="0x4630" name="AlderLake" code="ADL" longname="ADL-S LGA 4+0"/>
+    <sku did="0x4641" name="AlderLake" code="ADL" longname="ADL-P/H 6+8"/>
+    <sku did="0x4648" name="AlderLake" code="ADL" longname="ADL-S LGA 6+4"/>
+    <sku did="0x4649" name="AlderLake" code="ADL" longname="ADL-H 6+4"/>
+    <sku did="0x4650" name="AlderLake" code="ADL" longname="ADL-S LGA 6+0"/>
+    <sku did="0x4660" name="AlderLake" code="ADL" longname="ADL-S LGA 8+8"/>
+    <sku did="0x4668" name="AlderLake" code="ADL" longname="ADL-S LGA 8+4"/>
+  </info>
+
+
+
+  <!-- #################################### -->
+  <!--                                      -->
+  <!-- Integrated devices                   -->
+  <!--                                      -->
+  <!-- #################################### -->
+  <pci>
+    <!-- Review !!!!                                           !!!!                /-->
+    <device name="HOSTCTL" bus="0x00" dev="0x00" fun="0" did="0x4621,0x4660" config="IOMMU.iommu.xml, HOSTCTL.hostctl1.xml" >
+      <subcomponent type="mmiobar" name="MCHBAR" register="MCHBAR" base_field="MCHBAR" size="0x8000" enable_bit="0" desc="Host Memory Mapped Register Range" config="MMIO.mmio0.xml" />
+      <subcomponent type="mmiobar" name="MCHBARMC1" register="MCHBAR" base_field="MCHBAR" offset="0x10000" size="0x8000" enable_bit="0" desc="Host Memory Mapped Register Range" config="MMIO.mmio0.xml" />
+    </device>
+    <!-- <device name="HOSTCTL" bus="0x00" dev="0x00" fun="0" config=""/> -->
+    <device name="IGD"     bus="0x00" dev="0x02" fun="0" config="IGD.igd0.xml" />
+    <device name="MEI1"    bus="0x00" dev="0x16" fun="0" config="ME.mei0.xml" />
+    <device name="SMBUS"   bus="0x00" dev="0x1F" fun="4" config="SMBUS.smbus0.xml" />
+    <device name="SPI"     bus="0x00" dev="0x1F" fun="5" config="SPI.spi0.xml" />
+    <device name="SPI"     bus="0x00" dev="0x1F" fun="5" config="SPI.descriptor0.xml" />
+  </pci>
+
+  <msr>
+    <definition name="MSR" config="MSR.msr2.xml" />
+  </msr>
+
+  <!-- #################################### -->
+  <!--                                      -->
+  <!-- Memory ranges                        -->
+  <!--                                      -->
+  <!-- #################################### -->
+  <memory>
+    <range name="TPM" access="mmio" address="0xFED40000" size="0x10000" config="TPM.tpm12.xml" />
+  </memory>
+
+  
+
+</configuration>

--- a/chipsec/cfg/parsers/ip/mmio_bar.py
+++ b/chipsec/cfg/parsers/ip/mmio_bar.py
@@ -33,11 +33,11 @@ class MMIOObj:
 class MMIOBarConfig(GenericConfig):
     def __init__(self, cfg_obj):
         super(MMIOBarConfig, self).__init__(cfg_obj)
-        self.device = cfg_obj['device']
+        self.device = cfg_obj['device'] if 'device' in cfg_obj else cfg_obj['component'] if 'component' in cfg_obj else None
         self.register = cfg_obj['register']
         self.base_field = cfg_obj['base_field']
         self.size = cfg_obj['size'] if 'did' in cfg_obj else None
-        self.desc = cfg_obj['desc']
+        self.desc = cfg_obj['desc'] if 'desc' in cfg_obj else self.name
         self.reg_align = cfg_obj['reg_align'] if 'reg_align' in cfg_obj else None
         self.registerh = cfg_obj['registerh'] if 'registerh' in cfg_obj else None
         self.reg_alignh = cfg_obj['reg_alignh'] if 'reg_alignh' in cfg_obj else None

--- a/chipsec/cfg/parsers/ip/pci_device.py
+++ b/chipsec/cfg/parsers/ip/pci_device.py
@@ -19,7 +19,6 @@
 
 from chipsec.cfg.parsers.ip.generic import GenericConfig
 
-
 class PCIObj:
     def __init__(self, cfg_obj):
         self.bus = cfg_obj['bus']
@@ -31,6 +30,10 @@ class PCIObj:
         ret = f'bus: {self.bus}, dev: {self.dev}, func: {self.fun}'
         ret += f', rid:{self.rid}'
         return ret
+    
+    def __repr__(self) -> str:
+        return str(self)
+
 
 
 class PCIConfig(GenericConfig):
@@ -55,6 +58,14 @@ class PCIConfig(GenericConfig):
                 rid = inst.rid
                 break
         return rid
+    
+    def get_enabled_instances(self) -> bool:
+        enabled = []
+        for inst in self.instances.values():
+            if inst.bus is not None:
+                enabled.append(inst)
+        return enabled
+
 
     def update_name(self, name):
         self.name = name

--- a/chipsec/cfg/parsers/registers/mmio.py
+++ b/chipsec/cfg/parsers/registers/mmio.py
@@ -19,17 +19,24 @@
 
 from chipsec.chipset import cs
 from chipsec.library.register import BaseConfigRegisterHelper
-from chipsec.library.exceptions import CSReadError
+from chipsec.library.exceptions import CSReadError, CSConfigError
 
 
 class MMIORegisters(BaseConfigRegisterHelper):
     def __init__(self, cfg_obj):
         super(MMIORegisters, self).__init__(cfg_obj)
+        self.cs = cs()
         self.size = cfg_obj['size']
         self.offset = cfg_obj['offset']
-        self.bar = cfg_obj['bar']
         self.bar_base = None
         self.bar_size = None
+        self.bar = None
+        self.range = None
+        if 'bar' in cfg_obj:
+            self.bar = cfg_obj['bar']
+        elif 'range' in cfg_obj:
+            self.range = cfg_obj['range']
+            
 
     def __repr__(self) -> str:
         reg_str = ''
@@ -60,28 +67,39 @@ class MMIORegisters(BaseConfigRegisterHelper):
         reg_str += self._register_fields_str()
         return reg_str
 
+    def populate_base_address(self):
+        if self.bar_base is None:
+            if self.bar:
+                (self.bar_base, self.bar_size) = self.cs.hals.MMIO.get_MMIO_BAR_base_address(self.bar, self.instance)
+            elif self.range:
+                mem_range_def = self.cs.hals.MemRange.get_def(self.range)
+                if mem_range_def:
+                    if mem_range_def.access == 'mmio':
+                        self.bar_size = mem_range_def.size
+                        self.bar_base = mem_range_def.address
+                    else:
+                        raise CSConfigError(f"Memory Range ({self.range}) access type ({mem_range_def.access}) is not MMIO.")
+                else:
+                    raise CSConfigError(f"Memory Range ({self.range}) cannot be found.")
+            else:
+                raise CSConfigError(f"Unable to populate MMIO Base Address: {self.name}")
+
     def read(self):
         """Read the object"""
         self.logger.log_debug(f'reading {self.name}')
-        _cs = cs()
-        if self.bar_base is None:
-            (self.bar_base, self.bar_size) = _cs.hals.MMIO.get_MMIO_BAR_base_address(self.bar, self.instance.instance)
-        self.value = _cs.hals.MMIO.read_MMIO_reg(self.bar_base, self.offset, self.size, self.bar_size)
+        self.populate_base_address()
+        self.value = self.cs.hals.MMIO.read_MMIO_reg(self.bar_base, self.offset, self.size, self.bar_size)
         self.logger.log_debug('done reading')
         return self.value
 
     def write(self, value):
         """Write the object"""
-        _cs = cs()
-        if self.bar_base is None:
-            (self.bar_base, self.bar_size) = _cs.hals.MMIO.get_MMIO_BAR_base_address(self.bar, self.instance.instance)
-        _cs.hals.MMIO.write_MMIO_reg(self.bar_base, self.offset, value, self.size, self.bar_size)
+        self.populate_base_address()
+        self.cs.hals.MMIO.write_MMIO_reg(self.bar_base, self.offset, value, self.size, self.bar_size)
 
     def write_subset(self, value, size, offset=0):
-        _cs = cs()
         if offset < self.size and size <= self.size - offset:
-            if self.bar_base is None:
-                (self.bar_base, self.bar_size) = _cs.hals.MMIO.get_MMIO_BAR_base_address(self.bar, self.instance.instance)
-            _cs.hals.MMIO.write_MMIO_reg(self.bar_base, self.offset + offset, value, size, self.bar_size)
+            self.populate_base_address()
+            self.cs.hals.MMIO.write_MMIO_reg(self.bar_base, self.offset + offset, value, size, self.bar_size)
         else:
             raise CSReadError(f"Improper Offset or Size requested in write subset for {self.name}")

--- a/chipsec/config.py
+++ b/chipsec/config.py
@@ -23,6 +23,7 @@ from fnmatch import fnmatch
 import importlib
 import re
 import os
+from typing import Dict
 import xml.etree.ElementTree as ET
 from chipsec.library.defines import is_hex, CHIPSET_CODE_UNKNOWN
 from chipsec.library.exceptions import CSConfigError, DeviceNotFoundError
@@ -414,6 +415,9 @@ class Cfg:
                 if 0 in self.CONFIG_PCI_RAW[vid][did].cfg['bus'] and self.CONFIG_PCI_RAW[vid][did].cfg['dev'] == 0 and self.CONFIG_PCI_RAW[vid][did].cfg['fun'] == 0:
                     return self.CONFIG_PCI_RAW[vid][did].cfg
         return {'vid': 0xFFFF, 'did': 0xFFFF, 'rid': 0xFF}
+    
+    def add_memory_range(self, mem_range_obj:Dict):
+        self.cfg.MEMORY_RANGES[mem_range_obj['vid_str']][mem_range_obj['name']] = mem_range_obj
 
     def platform_detection(self, proc_code, pch_code, cpuid):
         # Detect processor files

--- a/chipsec/hal/common/memrange.py
+++ b/chipsec/hal/common/memrange.py
@@ -62,10 +62,9 @@ class MemRange(HALBase):
     
     def get_def(self, range_name: str) -> Dict[str, Any]:
         '''Return address access of a MEM register'''
-        scope = self.cs.Cfg.get_scope(range_name)
-        vid, range, _, _ = self.cs.Cfg.convert_internal_scope(scope, range_name)
-        if vid in self.cs.Cfg.MEMORY_RANGES and range in self.cs.Cfg.MEMORY_RANGES[vid]:
-            return self.cs.Cfg.MEMORY_RANGES[vid][range]
+        ranges = self.cs.Cfg.get_objlist(self.cs.Cfg.MEMORY_RANGES, range_name)
+        if ranges:
+            return ranges[0]
         return None
 
 

--- a/chipsec/hal/common/memrange.py
+++ b/chipsec/hal/common/memrange.py
@@ -1,0 +1,72 @@
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Contact information:
+# chipsec@intel.com
+#
+
+"""
+Access to physical memory
+
+usage:
+    >>> read_physical_mem( 0xf0000, 0x100 )
+    >>> write_physical_mem( 0xf0000, 0x100, buffer )
+    >>> write_physical_mem_dowrd( 0xf0000, 0xdeadbeef )
+    >>> read_physical_mem_dowrd( 0xfed40000 )
+"""
+
+from struct import unpack, pack
+from typing import Any, Dict, Tuple, Optional
+from chipsec.hal.hal_base import HALBase
+from chipsec.library.logger import print_buffer_bytes
+from chipsec.library.bits import make_mask
+
+
+class MemRange(HALBase):
+    def __init__(self, cs):
+        super(MemRange, self).__init__(cs)
+        self.helper = cs.helper
+
+    ####################################################################################
+    #
+    # Physical memory API using 64b Physical Address
+    # (Same functions as below just using 64b PA instead of High and Low 32b parts of PA)
+    #
+    ####################################################################################
+
+    # Reading physical memory
+
+    def read(self, phys_address: int, length: int) -> bytes:
+        self.logger.log_hal(f'[mem] 0x{phys_address:016X}')
+        return self.helper.read_phys_mem(phys_address, length)
+
+    
+    def write(self, phys_address: int, length: int, buf: bytes) -> int:
+        if self.logger.HAL:
+            self.logger.log(f'[mem] buffer len = 0x{length:X} to PA = 0x{phys_address:016X}')
+            print_buffer_bytes(buf)
+        return self.helper.write_phys_mem(phys_address, length, buf)
+    
+    def get_def(self, range_name: str) -> Dict[str, Any]:
+        '''Return address access of a MEM register'''
+        scope = self.cs.Cfg.get_scope(range_name)
+        vid, range, _, _ = self.cs.Cfg.convert_internal_scope(scope, range_name)
+        if vid in self.cs.Cfg.MEMORY_RANGES and range in self.cs.Cfg.MEMORY_RANGES[vid]:
+            return self.cs.Cfg.MEMORY_RANGES[vid][range]
+        return None
+
+
+haldata = {"arch":[HALBase.MfgIds.Any], 'name': ['MemRange']}

--- a/chipsec/hal/common/mmio.py
+++ b/chipsec/hal/common/mmio.py
@@ -207,10 +207,16 @@ class MMIO(hal_base.HALBase):
         size = 0
         mmioaddr = 0
 
-        if bar.register and pciobj is not None:
+        if bar.register:
+            
             preserve = True
-            bar_reg = self.cs.register.get_instance_by_name(bar.register, pciobj)
-            if bar_reg:
+            if pciobj is not None:
+                bar_reg_list = [self.cs.register.get_instance_by_name(bar.register, pciobj)]
+            else:
+                bar_reg_list = self.cs.register.get_list_by_name(bar.register)
+                
+            for bar_reg in bar_reg_list:
+            # if bar_reg:
                 if bar.reg_align:
                     preserve = False
                 if bar.base_field:
@@ -218,11 +224,14 @@ class MMIO(hal_base.HALBase):
                     try:
                         base = bar_reg.read_field(base_field, preserve)
                     except CSReadError:
-                        self.logger.log_hal('[mmio] Unable to determine MMIO Base register.  Using Base = 0x0')
+                        continue
+                        # self.logger.log_hal('[mmio] Unable to determine MMIO Base register.  Using Base = 0x0')
                     try:
                         reg_mask = bar_reg.get_field_mask(base_field, preserve)
                     except CSReadError:
-                        self.logger.log_hal('[mmio] Unable to determine MMIO Mask register.  Using Mask = 0xFFFF')
+                        continue
+                        # self.logger.log_hal('[mmio] Unable to determine MMIO Mask register.  Using Mask = 0xFFFF')
+                    break
             if not preserve:
                 base <<= bar.reg_align
                 reg_mask <<= bar.reg_align
@@ -286,6 +295,7 @@ class MMIO(hal_base.HALBase):
             size = DEFAULT_MMIO_BAR_SIZE
         self.logger.log_hal('[mmio] {}: 0x{:016X} (size = 0x{:X})'.format(bar_name, base, size))
         if base == 0:
+            breakpoint()
             self.logger.log_hal('[mmio] Base address was determined to be 0.')
             raise CSReadError('[mmio] Base address was determined to be 0')
 

--- a/chipsec/hal/common/physmem.py
+++ b/chipsec/hal/common/physmem.py
@@ -172,10 +172,9 @@ class Memory(HALBase):
     
     def get_def(self, range_name: str) -> Dict[str, Any]:
         '''Return address access of a MEM register'''
-        scope = self.cs.Cfg.get_scope(range_name)
-        vid, range, _, _ = self.cs.Cfg.convert_internal_scope(scope, range_name)
-        if vid in self.cs.Cfg.MEMORY_RANGES and range in self.cs.Cfg.MEMORY_RANGES[vid]:
-            return self.cs.Cfg.MEMORY_RANGES[vid][range]
+        ranges = self.cs.Cfg.get_objlist(self.cs.Cfg.MEMORY_RANGES, range_name)
+        if ranges:
+            return ranges[0]
         return None
 
 

--- a/chipsec/hal/common/spd.py
+++ b/chipsec/hal/common/spd.py
@@ -307,8 +307,8 @@ Base Configuration and DRAM Parameters
 ###############################################################################
 
 class SPD: #TODO: Refactor to derive from HALBase.
-    def __init__(self, smbus):
-        self.smbus = smbus
+    def __init__(self, cs):
+        self.smbus = cs.hals.SMBus
 
     def read_byte(self, offset: int, device: int = SPD_SMBUS_ADDRESS) -> int:
         return self.smbus.read_byte(device, offset)

--- a/chipsec/library/device.py
+++ b/chipsec/library/device.py
@@ -30,68 +30,78 @@ class Device:
         self.cs = cs
 
     def get_obj(self, device_name: str) -> PCIConfig:
-        scope = self.cs.Cfg.get_scope(device_name)
-        vid, device, _, _ = self.cs.Cfg.convert_internal_scope(scope, device_name)
-        if vid in self.cs.Cfg.CONFIG_PCI and device in self.cs.Cfg.CONFIG_PCI[vid]:
-            return self.cs.Cfg.CONFIG_PCI[vid][device]
-        else:
-            return None
+        devlist = self.get_objlist(device_name)
+        if devlist:
+            return devlist[0]
+        return None
+        
+    def get_objlist(self, device_name: str):
+        return self.cs.Cfg.get_objlist(self.cs.Cfg.CONFIG_PCI, device_name)
 
-    def get_first_bus(self, device: dict) -> int:
-        """Retrieves first value in bus list for PCI device"""
-        if 'bus' in device:
-            return self.get_first(device['bus'])
-        raise CSBusNotFoundError()
+    # def get_first_bus(self, device: dict) -> int:
+    #     """Retrieves first value in bus list for PCI device"""
+    #     if 'bus' in device:
+    #         return self.get_first(device['bus'])
+    #     raise CSBusNotFoundError()
 
-    def get_first(self, a_list: Union[list, int]) -> int:
-        """Returns received integer or first item from received list"""
-        if type(a_list) is int:
-            return a_list
-        if type(a_list) is list:
-            return a_list[0]
-        raise CSFirstNotFoundError()
+    # def get_first(self, a_list: Union[list, int]) -> int:
+    #     """Returns received integer or first item from received list"""
+    #     if type(a_list) is int:
+    #         return a_list
+    #     if type(a_list) is list:
+    #         return a_list[0]
+    #     raise CSFirstNotFoundError()
 
-    def get_BDF(self, device_name: str) -> Tuple[int, int, int]:
-        """Retrieves bus, device, and function values from PCI device"""
-        scope = self.cs.Cfg.get_scope(device_name)
-        vid, device, _, _ = self.cs.Cfg.convert_internal_scope(scope, device_name)
-        try:
-            device = self.cs.Cfg.CONFIG_PCI[vid][device]
-        except KeyError:
-            device = None
-        if device is None or device == {}:
-            raise DeviceNotFoundError(f'DeviceNotFound: {device_name}')
-        b = device['bus']
-        d = device['dev']
-        f = device['fun']
-        return (b, d, f)
+    # def get_BDF(self, device_name: str) -> Tuple[int, int, int]:
+    #     """Retrieves bus, device, and function values from PCI device"""
+    #     scope = self.cs.Cfg.get_scope(device_name)
+    #     vid, device, _, _ = self.cs.Cfg.convert_internal_scope(scope, device_name)
+    #     try:
+    #         device = self.cs.Cfg.CONFIG_PCI[vid][device]
+    #     except KeyError:
+    #         device = None
+    #     if device is None or device == {}:
+    #         raise DeviceNotFoundError(f'DeviceNotFound: {device_name}')
+    #     b = device['bus']
+    #     d = device['dev']
+    #     f = device['fun']
+    #     return (b, d, f)
 
-    def get_VendorID(self, device_name: str) -> Tuple[int, int]:
-        """Retrieves device ID and vendor ID from the PCI device"""
-        (b, d, f) = self.get_BDF(device_name)
-        return self.cs.hals.Pci.get_DIDVID(b, d, f)
+    # def get_VendorID(self, device_name: str) -> Tuple[int, int]:
+    #     """Retrieves device ID and vendor ID from the PCI device"""
+    #     (b, d, f) = self.get_BDF(device_name)
+    #     return self.cs.hals.Pci.get_DIDVID(b, d, f)
 
-    def is_enabled(self, device_name: str) -> bool:
-        """Checks if PCI device is enabled"""
-        if self.is_defined(device_name):
-            (b, d, f) = self.get_BDF(device_name)
-            return self.cs.hals.Pci.is_enabled(b, d, f)
-        return False
+    # def is_enabled(self, device_name: str) -> bool:
+    #     """Checks if PCI device is enabled"""
+    #     if self.is_defined(device_name):
+    #         (b, d, f) = self.get_BDF(device_name)
+    #         return self.cs.hals.Pci.is_enabled(b, d, f)
+    #     return False
 
     def is_defined(self, device_name: str) -> bool:
         """Checks if device is defined in the XML config"""
-        scope = self.cs.Cfg.get_scope(device_name)
-        vid, device, _, _ = self.cs.Cfg.convert_internal_scope(scope, device_name)
-        return self.cs.Cfg.CONFIG_PCI[vid].get(device, None) is not None
+        return self.get_obj(device_name) is not None
+        # scope = self.cs.Cfg.get_scope(device_name)
+        # vid, device, _, _ = self.cs.Cfg.convert_internal_scope(scope, device_name)
+        # return self.cs.Cfg.CONFIG_PCI[vid].get(device, None) is not None
 
     def get_bus(self, device_name: str) -> List[int]:
         """Retrieves bus value(s) from PCI device"""
-        scope = self.cs.Cfg.get_scope(device_name)
-        vid, device, _, _ = self.cs.Cfg.convert_internal_scope(scope, device_name)
-        if vid in self.cs.Cfg.CONFIG_PCI and device in self.cs.Cfg.CONFIG_PCI[vid]:
-            return self.cs.Cfg.CONFIG_PCI[vid][device].bus
-        else:
-            return []
+        dev_list = self.get_objlist(device_name)
+        buses = []
+        breakpoint()
+        for dev in dev_list:
+            for instance_key in dev.instances.keys():
+                buses.append(dev.instances[instance_key].bus)
+        return buses
+
+        # scope = self.cs.Cfg.get_scope(device_name)
+        # vid, device, _, _ = self.cs.Cfg.convert_internal_scope(scope, device_name)
+        # if vid in self.cs.Cfg.CONFIG_PCI and device in self.cs.Cfg.CONFIG_PCI[vid]:
+        #     return self.cs.Cfg.CONFIG_PCI[vid][device].bus
+        # else:
+        #     return []
 
         # buses = self.cs.Cfg.BUS.get(device_name, [])
         # if buses:

--- a/chipsec/library/device.py
+++ b/chipsec/library/device.py
@@ -21,6 +21,7 @@
 
 # from chipsec.library.logger import logger
 from typing import List, Optional, Tuple, Union
+from chipsec.cfg.parsers.ip.pci_device import PCIConfig
 from chipsec.library.exceptions import CSFirstNotFoundError, CSBusNotFoundError, DeviceNotFoundError
 
 
@@ -28,7 +29,7 @@ class Device:
     def __init__(self, cs) -> None:
         self.cs = cs
 
-    def get_obj(self, device_name: str):
+    def get_obj(self, device_name: str) -> PCIConfig:
         scope = self.cs.Cfg.get_scope(device_name)
         vid, device, _, _ = self.cs.Cfg.convert_internal_scope(scope, device_name)
         if vid in self.cs.Cfg.CONFIG_PCI and device in self.cs.Cfg.CONFIG_PCI[vid]:

--- a/chipsec/library/logger.py
+++ b/chipsec/library/logger.py
@@ -219,9 +219,9 @@ class Logger:
                 return False
         return True
 
-    def set_autolog_file(self):
+    def set_autolog_file(self, prefix: str="") -> None:
         if self.create_logs_folder():
-            log_file_name = f'{strftime("%a%b%d%y-%H%M%S")}.log'
+            log_file_name = f'{prefix}{"-" if prefix else ""}{strftime("%Y%b%d-%H%M%S")}.log'
             log_path = os.path.join(self.LOG_PATH, log_file_name)
             file_handler = logging.FileHandler(log_path)
             self.chipsecLogger.addHandler(file_handler)

--- a/chipsec/library/register.py
+++ b/chipsec/library/register.py
@@ -119,33 +119,26 @@ class Register:
 
     # rework any call to this function
     def get_list_by_name(self, reg_name: str) -> 'ObjList':
-        reg_def = ObjList()
-        scope = self.cs.Cfg.get_scope(reg_name)
-        vid, dev_name, register, _ = self.cs.Cfg.convert_internal_scope(scope, reg_name)
-        if vid in self.cs.Cfg.REGISTERS and dev_name in self.cs.Cfg.REGISTERS[vid] and register in self.cs.Cfg.REGISTERS[vid][dev_name]:
-            reg_def.extend(self.cs.Cfg.REGISTERS[vid][dev_name][register])
-        return reg_def
+        return self.cs.Cfg.get_objlist(self.cs.Cfg.REGISTERS, reg_name)
+    
+    def get_list_by_name_without_scope(self, reg_name: str) -> 'ObjList':
+        return self.cs.Cfg.get_objlist(self.cs.Cfg.REGISTERS, "*.*." + reg_name)
 
     def get_instance_by_name(self, reg_name: str, instance: Any):
-        scope = self.cs.Cfg.get_scope(reg_name)
-        vid, dev_name, register, _ = self.cs.Cfg.convert_internal_scope(scope, reg_name)
-        if vid in self.cs.Cfg.REGISTERS and dev_name in self.cs.Cfg.REGISTERS[vid] and register in self.cs.Cfg.REGISTERS[vid][dev_name]:
-            for reg_obj in self.cs.Cfg.REGISTERS[vid][dev_name][register]:
-                if reg_obj.instance == instance:
-                    return reg_obj
+        for reg_obj in self.cs.Cfg.get_objlist(self.cs.Cfg.REGISTERS, reg_name):
+            if reg_obj.instance == instance:
+                return reg_obj
         return None #TODO Change to null register object
 
     def has_field(self, reg_name: str, field_name: str) -> bool:
-        scope = self.cs.Cfg.get_scope(reg_name)
-        vid, device, register, _ = self.cs.Cfg.convert_internal_scope(scope, reg_name)
         """Checks if the register has specific field"""
-        scope = self.cs.Cfg.get_scope(reg_name)
-        vid, device, register, _ = self.cs.Cfg.convert_internal_scope(scope, reg_name)
-        try:
-            reg_def = self.cs.Cfg.REGISTERS[vid][device][register]
-        except KeyError:
-            return False
-        return field_name in reg_def[0].fields
+        reg_defs = self.cs.Cfg.get_objlist(self.cs.Cfg.REGISTERS, reg_name)
+        for reg_def in reg_defs:
+            try:
+                return field_name in reg_def.fields
+            except KeyError:
+                return False
+        return False
 
     def get_match(self, name: str):
         vid, device, register, field = self.cs.Cfg.convert_internal_scope("", name)

--- a/chipsec/modules/common/me_mfg_mode.py
+++ b/chipsec/modules/common/me_mfg_mode.py
@@ -102,12 +102,13 @@ class me_mfg_mode(BaseModule):
     def __init__(self):
         BaseModule.__init__(self)
         self.cs.set_scope({
-            "MEI1": "8086.MEI1",
-            "HFS": "8086.MEI1.HFS",
+            "MEI1": "8086", # TODO: Must not have .MEI1 at the end. The ending item must only be in the key.
+            "HFS": "8086.MEI1",
         })
 
     def is_supported(self) -> bool:
-        if self.cs.device.get_bus('MEI1') and self.cs.device.is_enabled('MEI1'):
+        self.mei1_dev = self.cs.device.get_obj('MEI1')
+        if self.mei1_dev.instances and self.mei1_dev.instances[0].bus is not None:
             return True
         else:
             self.logger.log_important('MEI1 not enabled.  Skipping module.')

--- a/chipsec/modules/common/remap.py
+++ b/chipsec/modules/common/remap.py
@@ -90,11 +90,11 @@ class remap(BaseModule):
     def check_remap_config(self) -> int:
         is_warning = False
 
-        remapbase = self.cs.register.read('PCI0.0.0_REMAPBASE')
-        remaplimit = self.cs.register.read('PCI0.0.0_REMAPLIMIT')
-        touud = self.cs.register.read('PCI0.0.0_TOUUD')
-        tolud = self.cs.register.read('PCI0.0.0_TOLUD')
-        tsegmb = self.cs.register.read('PCI0.0.0_TSEGMB')
+        remapbase = self.cs.register.read('REMAPBASE')
+        remaplimit = self.cs.register.read('REMAPLIMIT')
+        touud = self.cs.register.read('TOUUD')
+        tolud = self.cs.register.read('TOLUD')
+        tsegmb = self.cs.register.read('TSEGMB')
         self.logger.log('[*] Registers:')
         self.logger.log(f'[*]   TOUUD     : 0x{touud:016X}')
         self.logger.log(f'[*]   REMAPLIMIT: 0x{remaplimit:016X}')

--- a/chipsec/modules/common/spd_wd.py
+++ b/chipsec/modules/common/spd_wd.py
@@ -52,8 +52,6 @@ Examples:
 
 from chipsec.module_common import BaseModule
 from chipsec.library.returncode import ModuleResult
-from chipsec.hal.common.smbus import SMBus
-from chipsec.hal.common.spd import SPD
 from typing import List
 
 
@@ -62,11 +60,13 @@ class spd_wd(BaseModule):
     def __init__(self):
         BaseModule.__init__(self)
         self.cs.set_scope({
-            'SPD_WD': '8086.SMBUS.SPD_WD',
+            'SMBUS_HCFG': '8086.SMBUS',
+            'SMBUS': '8086',
         })
 
     def is_supported(self) -> bool:
-        if self.cs.device.is_enabled('SMBUS'):
+        smbdev = self.cs.device.get_obj('SMBUS')
+        if smbdev.get_enabled_instances():
             if self.cs.register.has_field('SMBUS_HCFG', 'SPD_WD'):
                 return True
             else:
@@ -77,8 +77,7 @@ class spd_wd(BaseModule):
 
     def check_spd_wd(self) -> int:
         try:
-            _smbus = SMBus(self.cs)
-            _spd = SPD(_smbus)
+            _spd = self.cs.hals.SPD
         except BaseException as msg:
             self.logger.log_error(msg)
             self.result.setStatusBit(self.result.status.INFORMATION)

--- a/chipsec/modules/common/spd_wd.py
+++ b/chipsec/modules/common/spd_wd.py
@@ -60,7 +60,7 @@ class spd_wd(BaseModule):
     def __init__(self):
         BaseModule.__init__(self)
         self.cs.set_scope({
-            'SMBUS_HCFG': '8086.SMBUS',
+            'SMBUS_HCFG': '8086.SMBUS*',
             'SMBUS': '8086',
         })
 
@@ -83,7 +83,6 @@ class spd_wd(BaseModule):
             self.result.setStatusBit(self.result.status.INFORMATION)
             self.res = self.result.getReturnCode(ModuleResult.ERROR)
             return self.res
-
         spd_wd_reg = self.cs.register.get_list_by_name('SMBUS_HCFG')
         spd_wd_reg.read_and_print()
         spd_wd_mask = spd_wd_reg[0].get_field_mask("SPD_WD", True)

--- a/chipsec/utilcmd/config_cmd.py
+++ b/chipsec/utilcmd/config_cmd.py
@@ -108,7 +108,12 @@ class CONFIGCommand(BaseCommand):
         return ret
 
     def pci_details(self, regi: Dict[str, Any]) -> str:
-        ret = f'bus: {regi["bus"]}, dev: {regi["dev"]}, func: {regi["fun"]}, vid: {regi["vid"]}, did: {regi["did"] if "did" in regi.keys() else None}'
+        if 'bus' in regi:
+            ret = f'bus: {regi["bus"]}, dev: {regi["dev"]}, func: {regi["fun"]}, vid: {regi["vid"]}, did: {regi["did"] if "did" in regi.keys() else None}'
+        elif 'component' in regi:
+            ret = f'Component: {regi["component"]}'
+        if 'config' in regi:
+            ret += f', Config: {regi["config"]}'
         return ret
 
     def mmio_details(self, regi: Dict[str, Any]) -> str:

--- a/chipsec/utilcmd/reg_cmd.py
+++ b/chipsec/utilcmd/reg_cmd.py
@@ -82,8 +82,11 @@ class RegisterCommand(BaseCommand):
 
     def reg_read(self):
         if self.field_name is not None:
-            value = self.cs.register.read_field(self.reg_name, self.field_name)
-            self.logger.log("[CHIPSEC] {}.{}=0x{:X}".format(self.reg_name, self.field_name, value))
+            reglist = self.cs.register.get_list_by_name(self.reg_name)
+            values = reglist.read_field(self.field_name)
+            # value = self.cs.register.read_field(self.reg_name, self.field_name)
+            for value in values:
+                self.logger.log(f"[CHIPSEC] {self.reg_name}.{self.field_name}=0x{value:X}")
         else:
             # value = self.cs.register.read(self.reg_name)
             reglist = self.cs.register.get_list_by_name(self.reg_name)

--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -359,7 +359,7 @@ class ChipsecMain:
             self.logger.set_log_file(self.log)
             self._autolog_disable = True
         if self._autolog_disable is False:
-            self.logger.set_autolog_file()
+            self.logger.set_autolog_file("main")
         if self._return_codes:
             self.logger.log_warning("Return codes feature is currently Work in Progress!!!")
             self._cs.using_return_codes = True

--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -135,7 +135,7 @@ class ChipsecUtil:
             self.logger.set_log_file(self.log)
             self._autolog_disable = True
         if self._autolog_disable is False:
-            self.logger.set_autolog_file()
+            self.logger.set_autolog_file("util")
         if self._return_codes:
             self.logger.log_warning("Return codes feature is currently Work in Progress!!!")
             self._cs.using_return_codes = True

--- a/tests/utilcmd/run_chipsec_util.py
+++ b/tests/utilcmd/run_chipsec_util.py
@@ -28,7 +28,6 @@ import chipsec.library.logger
 from chipsec_util import ChipsecUtil, parse_args
 
 
-
 def run_chipsec_util(csu: ChipsecUtil, util_replay_file: str) -> int:
     comm = csu.commands[csu._cmd](csu._cmd_args, cs=csu._cs)
     reqs = comm.requirements()


### PR DESCRIPTION
Update HALData to use manufacturer string instead of VID (Vendor ID)
Update to MMIO configuration definition. Able to define it as a `subcomponent` under a `pci` `device`. 
