### PR TITLE
fix for flake8 rule E275

### DIFF
--- a/chipsec/hal/psp.py
+++ b/chipsec/hal/psp.py
@@ -61,13 +61,13 @@ class PSP:
         # poll for mailbox ready
         start_time = time.time()
         timeout = False
-        while(True): 
+        while (True): 
             mbox_cmd_status_value = self.smu_read32(self.SMU_PSP_MBOX_CMD_STATUS)
             timeout = (time.time() - start_time > self.TIMEOUT)
-            if((mbox_cmd_status_value & 0x80000000) or timeout):
+            if ((mbox_cmd_status_value & 0x80000000) or timeout):
                 break
 
-        if(timeout):
+        if (timeout):
             logger().log_bad(f'Timeout polling for PSP Mailbox Ready (Idle)')
             return [0xbaddbadd]
 
@@ -85,13 +85,13 @@ class PSP:
         start_time = time.time()
         timeout = False
 
-        while(True): 
+        while (True): 
             mbox_cmd_status_value = self.smu_read32(self.SMU_PSP_MBOX_CMD_STATUS)
             timeout = (time.time() - start_time > self.TIMEOUT)
-            if((mbox_cmd_status_value & 0x80000000) or timeout):
+            if ((mbox_cmd_status_value & 0x80000000) or timeout):
                 break
 
-        if(timeout):
+        if (timeout):
             logger().log_bad(f'Timeout polling for PSP Mailbox Ready (Complete)')
             self.helper.free_phys_mem(buf_va)
             return [0xbaddbadd]
@@ -106,7 +106,7 @@ class PSP:
 
     def query_HSTI(self) -> int:
         hsti_buffer = self.psp_mbox_command(self.PSP_CMD_GET_HSTI_STATE)
-        if(len(hsti_buffer) > 1):
+        if (len(hsti_buffer) > 1):
             return hsti_buffer[2] 
         else:
             return 0 

--- a/chipsec/hal/psp.py
+++ b/chipsec/hal/psp.py
@@ -40,12 +40,12 @@ class PSP:
         self.helper = cs.helper
 
     def smu_read32(self, reg):
-        self.cs.pci.write_dword(0,0,0,self.SMN_INDEX_ADDR,reg)
-        return self.cs.pci.read_dword(0,0,0,self.SMN_DATA_ADDR)
+        self.cs.pci.write_dword(0, 0, 0, self.SMN_INDEX_ADDR, reg)
+        return self.cs.pci.read_dword(0, 0, 0, self.SMN_DATA_ADDR)
 
     def smu_write32(self, reg, val):
-        self.cs.pci.write_dword(0,0,0,self.SMN_INDEX_ADDR,reg)
-        return self.cs.pci.write_dword(0,0,0, self.SMN_DATA_ADDR,val)
+        self.cs.pci.write_dword(0, 0, 0, self.SMN_INDEX_ADDR, reg)
+        return self.cs.pci.write_dword(0, 0, 0, self.SMN_DATA_ADDR, val)
 
     def psp_mbox_command(self, cmd):
         #  Command ID (bits [23:16]), Status (bits [15:0]) fields and Ready flag (bit #31)
@@ -71,11 +71,11 @@ class PSP:
             logger().log_bad(f'Timeout polling for PSP Mailbox Ready (Idle)')
             return [0xbaddbadd]
 
-        (buf_va,buf_pa) = self.helper.alloc_phys_mem(buf_size,0x1000_0000_0000)
+        (buf_va, buf_pa) = self.helper.alloc_phys_mem(buf_size, 0x1000_0000_0000)
 
         # send physical address for msg buffer
-        self.smu_write32(self.SMU_PSP_MBOX_CMD_BUF_LO,buf_pa & 0xFFFFFFFF)
-        self.smu_write32(self.SMU_PSP_MBOX_CMD_BUF_HI,(buf_pa >> 32) & 0xFFFFFFFF)
+        self.smu_write32(self.SMU_PSP_MBOX_CMD_BUF_LO, buf_pa & 0xFFFFFFFF)
+        self.smu_write32(self.SMU_PSP_MBOX_CMD_BUF_HI, (buf_pa >> 32) & 0xFFFFFFFF)
 
         # send command
         mbox_cmd_status_value = (cmd << 16) & 0x00ff0000
@@ -97,8 +97,8 @@ class PSP:
             return [0xbaddbadd]
         
         buffer = []
-        for i in range(0,num_buf):
-            buffer.append(int.from_bytes(self.helper.read_phys_mem(buf_pa + (i * dword_size),dword_size),'little'))
+        for i in range(0, num_buf):
+            buffer.append(int.from_bytes(self.helper.read_phys_mem(buf_pa + (i * dword_size), dword_size), 'little'))
 
         self.helper.free_phys_mem(buf_va)
 

--- a/chipsec/hal/uefi_common.py
+++ b/chipsec/hal/uefi_common.py
@@ -217,7 +217,7 @@ def EFI_GUID_STR(guid: bytes) -> str:
     return str(guid_str).upper()
 
 
-def align(of:int, size: int) -> int:
+def align(of: int, size: int) -> int:
     of = (((of + size - 1) // size) * size)
     return of
 

--- a/chipsec/helper/efi/efihelper.py
+++ b/chipsec/helper/efi/efihelper.py
@@ -181,7 +181,7 @@ class EfiHelper(Helper):
         else:
             return edk2.readpci(bus, device, function, address, size)
 
-    def write_pci_reg(self, bus: int, device: int, function: int, address:int, value: int, size: int) -> int:
+    def write_pci_reg(self, bus: int, device: int, function: int, address: int, value: int, size: int) -> int:
         return edk2.writepci(bus, device, function, address, value, size)
 
     #

--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -393,7 +393,7 @@ class LinuxHelper(Helper):
         in_buf = struct.pack(f'3{self._pack}', phys_address, size, value)
         out_buf = self.ioctl(IOCTL_WRMMIO, in_buf)
 
-    def get_ACPI_table(self, table_name:str) -> Optional['Array']:
+    def get_ACPI_table(self, table_name: str) -> Optional['Array']:
         raise UnimplementedAPIError('get_ACPI_table')
 
     def enum_ACPI_tables(self) -> Optional['Array']:

--- a/chipsec/helper/record/recordhelper.py
+++ b/chipsec/helper/record/recordhelper.py
@@ -135,7 +135,7 @@ class RecordHelper(Helper):
     #
     # physical_address is 64 bit integer
     #
-    def read_phys_mem(self, phys_address:int, length:int) -> bytes:
+    def read_phys_mem(self, phys_address: int, length: int) -> bytes:
         return self._call_subhelper(phys_address, length)
 
     def write_phys_mem(self, phys_address: int, length: int, buf: bytes) -> int:

--- a/chipsec/library/register.py
+++ b/chipsec/library/register.py
@@ -550,7 +550,7 @@ class Register:
         rtype = reg['type']
         reg_str = ''
         reg_width = reg["size"] * 2
-        reg_val_str = f'0x{reg_val:0{reg_width: d}X}'
+        reg_val_str = f'0x{reg_val:0{reg_width:d}X}'
         if RegisterType.PCICFG == rtype or RegisterType.MMCFG == rtype:
             if bus is not None:
                 b = bus

--- a/chipsec/library/register.py
+++ b/chipsec/library/register.py
@@ -550,7 +550,7 @@ class Register:
         rtype = reg['type']
         reg_str = ''
         reg_width = reg["size"] * 2
-        reg_val_str = f'0x{reg_val:0{reg_width:d}X}'
+        reg_val_str = f'0x{reg_val:0{reg_width: d}X}'
         if RegisterType.PCICFG == rtype or RegisterType.MMCFG == rtype:
             if bus is not None:
                 b = bus

--- a/chipsec/modules/common/cpu/cpu_info.py
+++ b/chipsec/modules/common/cpu/cpu_info.py
@@ -130,7 +130,7 @@ class cpu_info(BaseModule):
             e_rdx = int("itne".encode('utf-8').hex(), 16)    #0x69746E65
             (_, r_rbx, r_rcx, r_rdx) = self.cs.cpu.cpuid(0x00, 0x00)
 
-            if not(e_rbx == r_rbx and e_rcx == r_rcx and e_rdx == r_rdx):
+            if not (e_rbx == r_rbx and e_rcx == r_rcx and e_rdx == r_rdx):
                 self.logger.log_failed("Not Authentic AMD")
                 self.res = ModuleResult.FAILED
                 return self.res

--- a/chipsec/modules/common/cpu/cpu_info.py
+++ b/chipsec/modules/common/cpu/cpu_info.py
@@ -107,7 +107,7 @@ class cpu_info(BaseModule):
         # Determine number of threads to check
         thread_count = 1
         if not self.cs.os_helper.is_efi():
-            (_, _, r_rcx, _) = self.cs.cpu.cpuid(0x80000008,0)
+            (_, _, r_rcx, _) = self.cs.cpu.cpuid(0x80000008, 0)
             thread_count = r_rcx & 0xff
 
         for thread in range(thread_count):
@@ -125,9 +125,9 @@ class cpu_info(BaseModule):
             self.logger.log(f'[*] Processor: {brand}')
 
             # "Authentic AMD"
-            e_rbx = int("htuA".encode('utf-8').hex(),16)    #0x68747541
-            e_rcx = int("DMAc".encode('utf-8').hex(),16)    #0x444D4163
-            e_rdx = int("itne".encode('utf-8').hex(),16)    #0x69746E65
+            e_rbx = int("htuA".encode('utf-8').hex(), 16)    #0x68747541
+            e_rcx = int("DMAc".encode('utf-8').hex(), 16)    #0x444D4163
+            e_rdx = int("itne".encode('utf-8').hex(), 16)    #0x69746E65
             (_, r_rbx, r_rcx, r_rdx) = self.cs.cpu.cpuid(0x00, 0x00)
 
             if not(e_rbx == r_rbx and e_rcx == r_rcx and e_rdx == r_rdx):

--- a/chipsec/modules/common/cpu/spectre_v2.py
+++ b/chipsec/modules/common/cpu/spectre_v2.py
@@ -295,7 +295,7 @@ class spectre_v2(BaseModule):
 
         elif self.cs.is_amd():
             res = ModuleResult.PASSED
-            fields = ['IBRS','STIBP','SSBD','PSFD']
+            fields = ['IBRS', 'STIBP', 'SSBD', 'PSFD']
             settings = {} 
             threads = {}
             fail = False
@@ -311,7 +311,7 @@ class spectre_v2(BaseModule):
             if fail:
                 self.logger.log_failed("Spectre V2 Mitigations Currently not enabled")
                 res = ModuleResult.PASSED
-                for t,s in threads.items():
+                for t, s in threads.items():
                     self.logger.log_warning(f"Thread[{t}]: {fields[0]}:{s[fields[0]]} {fields[1]}:{s[fields[1]]} {fields[2]}:{s[fields[2]]} {fields[3]}:{s[fields[3]]}")
             else:
                 self.logger.log_passed("Spectre V2 Mitigations Currently enabled")

--- a/chipsec/modules/common/cpu/spectre_v2.py
+++ b/chipsec/modules/common/cpu/spectre_v2.py
@@ -304,7 +304,7 @@ class spectre_v2(BaseModule):
                 spec_ctrl_msr = self.cs.register.read('SPEC_CTRL', tid)
                 for f in fields:
                     settings[f] = bool(self.cs.register.get_field('SPEC_CTRL', spec_ctrl_msr, f))
-                if not(settings[f]):
+                if not (settings[f]):
                     fail = True
                 threads[tid] = settings
 

--- a/chipsec/modules/common/rom_armor.py
+++ b/chipsec/modules/common/rom_armor.py
@@ -63,7 +63,7 @@ class rom_armor(BaseModule):
         # Confirm SPI Control Bass address is blocked
         spi_ctrl_bar = self.cs.pci.read_dword(0, 0x14, 3, 0xa0)
 
-        if(spi_ctrl_bar == 0xFFFFFFFF):
+        if (spi_ctrl_bar == 0xFFFFFFFF):
             self.logger.log_good("SPI BAR access from host is blocked")
         else:
             self.logger.log_bad("Host is able to access SPI Bar")
@@ -78,7 +78,7 @@ class rom_armor(BaseModule):
         self.logger.start_test("Rom Armor Verification")
         rom_armor_enabled = self.check_ROMAMOR()
         self.res = ModuleResult.FAILED
-        if(not(rom_armor_enabled)):
+        if (not (rom_armor_enabled)):
             self.logger.log_failed("Rom Armor is not enabled.")
             return self.res
         else:

--- a/chipsec/modules/common/rom_armor.py
+++ b/chipsec/modules/common/rom_armor.py
@@ -61,7 +61,7 @@ class rom_armor(BaseModule):
 
     def check_RA_Fencing(self) -> int:
         # Confirm SPI Control Bass address is blocked
-        spi_ctrl_bar = self.cs.pci.read_dword(0,0x14,3,0xa0)
+        spi_ctrl_bar = self.cs.pci.read_dword(0, 0x14, 3, 0xa0)
 
         if(spi_ctrl_bar == 0xFFFFFFFF):
             self.logger.log_good("SPI BAR access from host is blocked")

--- a/chipsec/modules/common/smm_close.py
+++ b/chipsec/modules/common/smm_close.py
@@ -59,7 +59,7 @@ class smm_close(BaseModule):
         TSegClose = bool(self.cs.register.get_field('SMMMASK', regval, 'TCLOSE'))
         ASegClose = bool(self.cs.register.get_field('SMMMASK', regval, 'ACLOSE'))
 
-        if(TSegClose or ASegClose):
+        if (TSegClose or ASegClose):
             self.logger.log_failed(f"TSeg Close {TSegClose}, Aseg Valid {ASegClose}")
             res = ModuleResult.FAILED
         else:

--- a/chipsec/modules/tools/vmm/common.py
+++ b/chipsec/modules/tools/vmm/common.py
@@ -56,7 +56,7 @@ class BaseModuleDebug(BaseModule):
             sys.stdout.write(f'[{self.prompt}]  {message}\n')
         return
 
-    def hex(self, title: str, data:str, w=16) -> None:
+    def hex(self, title: str, data: str, w=16) -> None:
         if title and data:
             title = f'{"-" * 6}{title}{"-" * w * 3}'
             sys.stdout.write(f'[{self.prompt}]  {title[:w * 3 + 15]}')

--- a/chipsec/utilcmd/deltas_cmd.py
+++ b/chipsec/utilcmd/deltas_cmd.py
@@ -44,8 +44,8 @@ class DeltasCommand(BaseCommand):
     def parse_arguments(self) -> None:
         options = Options()
         try:
-            default_format = options.get_section_data('Util_Config','log_output_deltas_format')
-            default_out_file =  options.get_section_data('Util_Config','deltas_output_file')
+            default_format = options.get_section_data('Util_Config', 'log_output_deltas_format')
+            default_out_file =  options.get_section_data('Util_Config', 'deltas_output_file')
         except Exception:
             default_format = 'JSON'
             default_out_file = 'log_output_deltas.json'

--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -89,7 +89,7 @@ def parse_args(argv: Sequence[str]) -> Optional[Dict[str, Any]]:
     adv_options.add_argument('-k', '--markdown', dest='_markdown_out', help='Specify filename for markdown output')
     adv_options.add_argument('-t', '--moduletype', dest='USER_MODULE_TAGS', type=str.upper, default=[], help='Run tests of a specific type (tag)')
     adv_options.add_argument('--list_tags', dest='_list_tags', action='store_true', help='List all the available options for -t,--moduletype')
-    adv_options.add_argument('-lm','--list_modules', dest='_list_modules', action='store_true', help='List all the available options for -m,--module/-mx,--module_exclude')
+    adv_options.add_argument('-lm', '--list_modules', dest='_list_modules', action='store_true', help='List all the available options for -m,--module/-mx,--module_exclude')
     adv_options.add_argument('-I', '--include', dest='IMPORT_PATHS', default=[], help='Specify additional path to load modules from')
     adv_options.add_argument('--failfast', help="Fail on any exception and exit (don't mask exceptions)", action='store_true')
     adv_options.add_argument('--no_time', help="Don't log timestamps", action='store_true')

--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,7 @@ if platform.system().lower() == 'windows':
 
 elif platform.system().lower() == 'linux':
     package_data['chipsec_tools.compression'] = ['*']
-    data_files = [(os.path.abspath(os.path.join(os.sep,'usr','share', 'doc','chipsec')), ['chipsec-manual.pdf'])]
+    data_files = [(os.path.abspath(os.path.join(os.sep, 'usr', 'share', 'doc', 'chipsec')), ['chipsec-manual.pdf'])]
     extra_kw = [
         Extension(
             'EfiCompressor',

--- a/tests/hal/test_smbus.py
+++ b/tests/hal/test_smbus.py
@@ -22,7 +22,7 @@ import unittest
 
 from unittest.mock import MagicMock, patch
 from chipsec.hal.smbus import SMBus, SMBUS_POLL_COUNT
-from chipsec.library.exceptions import IOBARNotFoundError,RegisterNotFoundError
+from chipsec.library.exceptions import IOBARNotFoundError, RegisterNotFoundError
 
 class TestSMBUS(unittest.TestCase):
     @patch("chipsec.hal.smbus.iobar")

--- a/tests/helpers/helper_utils.py
+++ b/tests/helpers/helper_utils.py
@@ -22,16 +22,16 @@ class packer():
         self.size_char = default_size_char
 
 
-    def custom_pack(self, num_of_chunks: int, expected_value: int, expected_value_index:int = 0) -> bytes:
+    def custom_pack(self, num_of_chunks: int, expected_value: int, expected_value_index: int = 0) -> bytes:
         input = [0] * num_of_chunks
         input[expected_value_index] = expected_value
-        return pack(f'{num_of_chunks}{self.size_char}',*input)
+        return pack(f'{num_of_chunks}{self.size_char}', *input)
 
     def pack_pci(self, expected_value: int) -> bytes:
         return self.custom_pack(5, expected_value, 4)
 
-    def pack_cpuinfo(self, expected_value:int) -> bytes:
+    def pack_cpuinfo(self, expected_value: int) -> bytes:
         return self.custom_pack(4, expected_value, 0)
 
-    def pack_ioport(self, expected_value:int) -> bytes:
+    def pack_ioport(self, expected_value: int) -> bytes:
         return self.custom_pack(3, expected_value, 2)

--- a/tests/helpers/test_linuxhelper.py
+++ b/tests/helpers/test_linuxhelper.py
@@ -84,7 +84,7 @@ class LinuxHelperTest(unittest.TestCase):
         (0xC0084314, b'E#\x01\x00\x00\x00\x00\x00'):
             b'\x00\x00\x00\x00\x00\x00\x00\x00',
         (0xc0084315, b'\x02\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'):
-            cpacker.custom_pack(5,0x200, 4),
+            cpacker.custom_pack(5, 0x200, 4),
         (0xc0084316, b'\x00\x00\x00\x16\x00\x00\x00\x00'):
             cpacker.custom_pack(1, 0x1, 0),
          }
@@ -109,7 +109,7 @@ class LinuxHelperTest(unittest.TestCase):
         mock_fcntl().ioctl.side_effect = LinuxHelperTest.ioctlret
         import chipsec.helper.linux.linuxhelper as lh
         unittest.TestCase.setUp(self)
-        with patch.dict(lh.os.__dict__, {'chown':lambda *args:None}):
+        with patch.dict(lh.os.__dict__, {'chown': lambda *args: None}):
             self.lhelper = lh.LinuxHelper()
             mock_open().return_value = True
             os_chmod().return_value = True
@@ -128,7 +128,7 @@ class LinuxHelperTest(unittest.TestCase):
         self.assertTrue(self.lhelper.delete())
         
     def test_map_io_space(self, _, lh_ioctl):
-        self.assertRaises(UnimplementedAPIError, self.lhelper.map_io_space, 0,0,0)
+        self.assertRaises(UnimplementedAPIError, self.lhelper.map_io_space, 0, 0, 0)
 
 
     def test_write_phys_mem(self, _, _1):
@@ -245,7 +245,7 @@ class LinuxHelperTest(unittest.TestCase):
 
     def test_write_mmio_reg(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
-        self.lhelper.write_mmio_reg(0x123,0x1, 0x22)
+        self.lhelper.write_mmio_reg(0x123, 0x1, 0x22)
 
     def test_get_ACPI_table(self, _, lh_ioctl):
         self.assertRaises(UnimplementedAPIError, self.lhelper.get_ACPI_table, "SDEV")

--- a/tests/helpers/test_recordhelper.py
+++ b/tests/helpers/test_recordhelper.py
@@ -43,22 +43,22 @@ class RecordHelperTest(unittest.TestCase):
         self.assertTrue(self.recordhelper.create())
         self.assertTrue(self.recordhelper.start())
 
-        pci_read_value = self.recordhelper.read_pci_reg(0,0,0,0,0x1)
+        pci_read_value = self.recordhelper.read_pci_reg(0, 0, 0, 0, 0x1)
         self.assertEqual(pci_read_value, 0x86)
 
-        pci_read_value = self.recordhelper.read_pci_reg(0,0,0,0,0x2)
+        pci_read_value = self.recordhelper.read_pci_reg(0, 0, 0, 0, 0x2)
         self.assertEqual(pci_read_value, 0x8086)
 
-        pci_read_value = self.recordhelper.read_pci_reg(0,0,0,0,0x4)
+        pci_read_value = self.recordhelper.read_pci_reg(0, 0, 0, 0, 0x4)
         self.assertEqual(pci_read_value, 0x59048086)
 
-        pci_read_value = self.recordhelper.read_pci_reg(0,0x1f,0,0,0x1)
+        pci_read_value = self.recordhelper.read_pci_reg(0, 0x1f, 0, 0, 0x1)
         self.assertEqual(pci_read_value, 0x86)
 
-        pci_read_value = self.recordhelper.read_pci_reg(0,0x1f,0,0,0x2)
+        pci_read_value = self.recordhelper.read_pci_reg(0, 0x1f, 0, 0, 0x2)
         self.assertEqual(pci_read_value, 0x8086)
 
-        pci_read_value = self.recordhelper.read_pci_reg(0,0x1f,0,0,0x4)
+        pci_read_value = self.recordhelper.read_pci_reg(0, 0x1f, 0, 0, 0x4)
         self.assertEqual(pci_read_value, 0x9D4E8086)
 
         thread_count = self.recordhelper.get_threads_count()
@@ -70,7 +70,7 @@ class RecordHelperTest(unittest.TestCase):
         mem_value = self.recordhelper.read_phys_mem(0x5001, 0x2)
         self.assertEqual(mem_value, b'\x99\xaa')
 
-        mem_value = self.recordhelper.read_phys_mem(0x5010,0x2)
+        mem_value = self.recordhelper.read_phys_mem(0x5010, 0x2)
         self.assertEqual(mem_value, b'\xf3\x99')
 
         cpuid_value = self.recordhelper.cpuid(1, 0)
@@ -79,18 +79,18 @@ class RecordHelperTest(unittest.TestCase):
         cpuid_value = self.recordhelper.cpuid(2, 0)
         self.assertEqual(cpuid_value, (1979933441, 15775231, 0, 12779520))
 
-        self.recordhelper.write_pci_reg(0,0x3,0,0x2D, 0x33, 0x1)
-        pci_read_value = self.recordhelper.read_pci_reg(0,0x3,0,0x2d,0x1)
+        self.recordhelper.write_pci_reg(0, 0x3, 0, 0x2D, 0x33, 0x1)
+        pci_read_value = self.recordhelper.read_pci_reg(0, 0x3, 0, 0x2d, 0x1)
         self.assertEqual(pci_read_value, 0xFF)
 
-        self.recordhelper.write_pci_reg(0,0x0,0,0x0, 0x44, 0x1)
-        pci_read_value = self.recordhelper.read_pci_reg(0,0x0,0,0x0,0x2)
+        self.recordhelper.write_pci_reg(0, 0x0, 0, 0x0, 0x44, 0x1)
+        pci_read_value = self.recordhelper.read_pci_reg(0, 0x0, 0, 0x0, 0x2)
         self.assertEqual(pci_read_value, 32902)
 
         mmio_read_value = self.recordhelper.read_mmio_reg(0xfed0, 0x3)
         self.assertEqual(mmio_read_value, 0xababab)
 
-        self.recordhelper.write_mmio_reg(0x123,0x1, 0x22)
+        self.recordhelper.write_mmio_reg(0x123, 0x1, 0x22)
         mmio_read_value = self.recordhelper.read_mmio_reg(0x123, 0x1)
         self.assertEqual(mmio_read_value, 0x22)
 

--- a/tests/helpers/test_replayhelper.py
+++ b/tests/helpers/test_replayhelper.py
@@ -38,27 +38,27 @@ class ReplayHelperTest(unittest.TestCase):
         self.assertTrue(self.replayhelper.delete())
 
     def test_cpu_read_pci_reg_one_byte(self):
-        pci_read_value = self.replayhelper.read_pci_reg(0,0,0,0,0x1)
+        pci_read_value = self.replayhelper.read_pci_reg(0, 0, 0, 0, 0x1)
         self.assertEqual(pci_read_value, 0x86)
         
     def test_cpu_read_pci_reg_two_bytes(self):
-        pci_read_value = self.replayhelper.read_pci_reg(0,0,0,0,0x2)
+        pci_read_value = self.replayhelper.read_pci_reg(0, 0, 0, 0, 0x2)
         self.assertEqual(pci_read_value, 0x8086)
         
     def test_cpu_read_pci_reg_four_bytes(self):
-        pci_read_value = self.replayhelper.read_pci_reg(0,0,0,0,0x4)
+        pci_read_value = self.replayhelper.read_pci_reg(0, 0, 0, 0, 0x4)
         self.assertEqual(pci_read_value, 0x59048086)
 
     def test_pch_read_pci_reg_one_byte(self):
-        pci_read_value = self.replayhelper.read_pci_reg(0,0x1f,0,0,0x1)
+        pci_read_value = self.replayhelper.read_pci_reg(0, 0x1f, 0, 0, 0x1)
         self.assertEqual(pci_read_value, 0x86)
 
     def test_pch_read_pci_reg_two_bytes(self):
-        pci_read_value = self.replayhelper.read_pci_reg(0,0x1f,0,0,0x2)
+        pci_read_value = self.replayhelper.read_pci_reg(0, 0x1f, 0, 0, 0x2)
         self.assertEqual(pci_read_value, 0x8086)
     
     def test_pch_read_pci_reg_four_bytes(self):
-        pci_read_value = self.replayhelper.read_pci_reg(0,0x1f,0,0,0x4)
+        pci_read_value = self.replayhelper.read_pci_reg(0, 0x1f, 0, 0, 0x4)
         self.assertEqual(pci_read_value, 0x9D4E8086)
 
     def test_get_thread_count(self):
@@ -74,7 +74,7 @@ class ReplayHelperTest(unittest.TestCase):
         self.assertEqual(mem_value, b'\x99\xaa')
 
     def test_read_phyis_mem_oob(self):
-        mem_value = self.replayhelper.read_phys_mem(0x5010,0x2)
+        mem_value = self.replayhelper.read_phys_mem(0x5010, 0x2)
         self.assertEqual(mem_value, b'\xf3\x99')
 
     def test_cpuid_one(self):
@@ -86,13 +86,13 @@ class ReplayHelperTest(unittest.TestCase):
         self.assertEqual(cpuid_value, (1979933441, 15775231, 0, 12779520))
 
     def test_write_pci_reg_new_location(self):
-        self.replayhelper.write_pci_reg(0,0x3,0,0x2D, 0x33, 0x1)
-        pci_read_value = self.replayhelper.read_pci_reg(0,0x3,0,0x2d,0x1)
+        self.replayhelper.write_pci_reg(0, 0x3, 0, 0x2D, 0x33, 0x1)
+        pci_read_value = self.replayhelper.read_pci_reg(0, 0x3, 0, 0x2d, 0x1)
         self.assertEqual(pci_read_value, 0xFF)
 
     def test_write_pci_reg_defined_location(self):
-        self.replayhelper.write_pci_reg(0,0x0,0,0x0, 0x44, 0x1)
-        pci_read_value = self.replayhelper.read_pci_reg(0,0x0,0,0x0,0x2)
+        self.replayhelper.write_pci_reg(0, 0x0, 0, 0x0, 0x44, 0x1)
+        pci_read_value = self.replayhelper.read_pci_reg(0, 0x0, 0, 0x0, 0x2)
         self.assertEqual(pci_read_value, 32902)
 
     def test_read_mmio_reg(self):
@@ -100,7 +100,7 @@ class ReplayHelperTest(unittest.TestCase):
         self.assertEqual(mmio_read_value, 0xababab)
 
     def test_write_mmio_reg(self):
-        self.replayhelper.write_mmio_reg(0x123,0x1, 0x22)
+        self.replayhelper.write_mmio_reg(0x123, 0x1, 0x22)
         mmio_read_value = self.replayhelper.read_mmio_reg(0x123, 0x1)
         self.assertEqual(mmio_read_value, 0x22)
         

--- a/tests/helpers/test_windowshelper.py
+++ b/tests/helpers/test_windowshelper.py
@@ -84,9 +84,9 @@ class WindowsHelperTest(unittest.TestCase):
         (0x22e04c, b'\x01\x00\x00\x00\x00\x00\x00\x00'):
             ipacker.pack_cpuinfo(0x406F1),
         (0x22e070, b'\x00\x00\x00\x00\x00\x00\x01\xfe\x04\x00\x00\x00'):
-            ipacker.custom_pack(1,0x7FF0200,0),
+            ipacker.custom_pack(1, 0x7FF0200, 0),
         (0x22e048, b'\x00\x00\x00\x00\x00\x10\x00\x00\x08\x00\x00\x00'):
-            qpacker.custom_pack(2,1,0),
+            qpacker.custom_pack(2, 1, 0),
         (0x22e064, b'\x00\x00\x00\x00\x00\x00'):
             b'3\x00\x05\x80\x00\x00\x00\x00',
         (0x22e060, b'\x00\x003\x00\x05\x80\x00\x00\x00\x00\x00\x00\x00\x00'):
@@ -137,12 +137,12 @@ class WindowsHelperTest(unittest.TestCase):
         wh.FILE_ATTRIBUTE_NORMAL = 0x80
         wh.FILE_FLAG_OVERLAPPED = 0x40000000
         wh.INVALID_HANDLE_VALUE = -1
-        wh.c_char = type('',(object,),{"__mul__": lambda self, other: Mock()})()
+        wh.c_char = type('', (object,), {"__mul__": lambda self, other: Mock()})()
         os_path_isfile().return_value = True
         mock_win32sservice.CreateService.return_value = DRIVER_HANDLE
         mock_win32sservice.CloseServiceHandle().return_value = None
         self.wh = wh
-        with patch.dict(wh.os.__dict__, {'chown':lambda *args:None}):
+        with patch.dict(wh.os.__dict__, {'chown': lambda *args: None}):
             self.whelper = wh.WindowsHelper()
             self.assertTrue(self.whelper.create())
             self.assertTrue(self.whelper.start())        
@@ -278,7 +278,7 @@ class WindowsHelperTest(unittest.TestCase):
 
     def test_write_mmio_reg(self, *mocks):
         self._assign_mocks(mocks)
-        self.whelper.write_mmio_reg(0x123,0x1, 0x22)
+        self.whelper.write_mmio_reg(0x123, 0x1, 0x22)
     
     # TODO def test_get_ACPI_SDT(self, *mocks):
         # self._assign_mocks(mocks)
@@ -337,7 +337,7 @@ class WindowsHelperTest(unittest.TestCase):
     @patch('chipsec.helper.windows.windowshelper.addressof')
     @patch('chipsec.helper.windows.windowshelper.c_uint32')
     def test_retpoline_enabled(self, mock_c_uint32, *_):
-        mock_c_uint32.return_value = type('',(object,),{"value": 0x4000})()
+        mock_c_uint32.return_value = type('', (object,), {"value": 0x4000})()
         self.assertEqual(self.whelper.retpoline_enabled(), True)
 
 # test_reg_get_control

--- a/tests/modules/test_tgl_modules.py
+++ b/tests/modules/test_tgl_modules.py
@@ -32,10 +32,10 @@ class TestTglModules(unittest.TestCase):
         self.folder_path = os.path.join(get_main_dir(), "tests", "modules", "tgl")
         self.init_replay_file = os.path.join(self.folder_path, "enumeration.json")
         
-    def derive_filename(self, module_name:str) -> str:
+    def derive_filename(self, module_name: str) -> str:
         return f"{module_name.replace('.', '-')}_test.json"
 
-    def run_and_test_module(self, module_name:str, expected_returncode:int) -> None:
+    def run_and_test_module(self, module_name: str, expected_returncode: int) -> None:
         test_recording = self.derive_filename(module_name)
         replay_file = os.path.join(self.folder_path, test_recording)
         retval = setup_run_destroy_module_with_mock_logger(self.init_replay_file, module_name, module_replay_file=replay_file)

--- a/tests/utilcmd/run_chipsec_util.py
+++ b/tests/utilcmd/run_chipsec_util.py
@@ -60,5 +60,5 @@ def setup_run_destroy_util_get_log_output(init_replay_file: str, util_name: str,
     return retval, " ".join([call.args[0] for call in logger_calls])
 
 def setup_run_destroy_util(init_replay_file: str, util_name: str, util_args: str = "", util_replay_file: str = "") -> int:
-    retval, _ = setup_run_destroy_util_get_log_output(init_replay_file,util_name, util_args, util_replay_file)    
+    retval, _ = setup_run_destroy_util_get_log_output(init_replay_file, util_name, util_args, util_replay_file)    
     return retval


### PR DESCRIPTION
This is one in a series of PRs to get the source compliant with our .flake8 configuration.

This commit fixes all the E275 errors. They were found by running "flake8 ." from the root directory. E275 is an error defined by "pycodestyle", and has no functional impact to the source. This is simply fixing whitespace as defined by CHIPSEC's .flake8 configuration.

background:
https://www.flake8rules.com/rules/E275.html

versions: flake8 v7.1.1, python v3.12.6