### PR TITLE
fix for flake8 rule W293

### DIFF
--- a/chipsec/command.py
+++ b/chipsec/command.py
@@ -49,16 +49,16 @@ class BaseCommand:
 
     def set_up(self) -> None:
         pass
-    
+
     def tear_down(self) -> None:
         pass
 
     def parse_arguments(self) -> None:
         raise NotImplementedError('sub class should overwrite the parse_arguments() method')
-    
+
     def requirements(self) -> 'toLoad':
         raise NotImplementedError('sub class should overwrite the requirements() method')
-    
+
 class toLoad(Enum):
     Nil = 0
     Config = 1

--- a/chipsec/hal/psp.py
+++ b/chipsec/hal/psp.py
@@ -28,7 +28,7 @@ class PSP:
     SMN_INDEX_ADDR = 0xb8
     SMN_DATA_ADDR = 0xbc
     SMU_PSP_SMN_BASE = 0x3800000
-    SMU_PSP_MBOX_CMD_STATUS = SMU_PSP_SMN_BASE + 0x00010970 
+    SMU_PSP_MBOX_CMD_STATUS = SMU_PSP_SMN_BASE + 0x00010970
     SMU_PSP_MBOX_CMD_BUF_LO = SMU_PSP_SMN_BASE + 0x00010974
     SMU_PSP_MBOX_CMD_BUF_HI = SMU_PSP_SMN_BASE + 0x00010978
     PSP_CMD_GET_CAPABILITIES = 0x27
@@ -61,7 +61,7 @@ class PSP:
         # poll for mailbox ready
         start_time = time.time()
         timeout = False
-        while (True): 
+        while (True):
             mbox_cmd_status_value = self.smu_read32(self.SMU_PSP_MBOX_CMD_STATUS)
             timeout = (time.time() - start_time > self.TIMEOUT)
             if ((mbox_cmd_status_value & 0x80000000) or timeout):
@@ -85,7 +85,7 @@ class PSP:
         start_time = time.time()
         timeout = False
 
-        while (True): 
+        while (True):
             mbox_cmd_status_value = self.smu_read32(self.SMU_PSP_MBOX_CMD_STATUS)
             timeout = (time.time() - start_time > self.TIMEOUT)
             if ((mbox_cmd_status_value & 0x80000000) or timeout):
@@ -95,7 +95,7 @@ class PSP:
             logger().log_bad(f'Timeout polling for PSP Mailbox Ready (Complete)')
             self.helper.free_phys_mem(buf_va)
             return [0xbaddbadd]
-        
+
         buffer = []
         for i in range(0, num_buf):
             buffer.append(int.from_bytes(self.helper.read_phys_mem(buf_pa + (i * dword_size), dword_size), 'little'))
@@ -107,6 +107,6 @@ class PSP:
     def query_HSTI(self) -> int:
         hsti_buffer = self.psp_mbox_command(self.PSP_CMD_GET_HSTI_STATE)
         if (len(hsti_buffer) > 1):
-            return hsti_buffer[2] 
+            return hsti_buffer[2]
         else:
-            return 0 
+            return 0

--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -483,7 +483,7 @@ class UEFI(hal_base.HALBase):
     def list_EFI_variables(self) -> Optional[Dict[str, List[Tuple[int, bytes, int, bytes, str, int]]]]:
         varlist = self.helper.list_EFI_variables()
         return varlist
-    
+
     def list_EFI_variables_spi(self, filename: str = None) -> Optional[Dict[str, List[Tuple[int, bytes, int, bytes, str, int]]]]:
         if filename:
             varlist = self.read_EFI_variables_from_file(filename)

--- a/chipsec/helper/dal/dalhelper.py
+++ b/chipsec/helper/dal/dalhelper.py
@@ -375,7 +375,7 @@ class DALHelper(Helper):
     #
     def get_ACPI_table(self, table_name: str) -> Optional['Array']:
         raise UnimplementedAPIError('get_ACPI_table')
-    
+
     def enum_ACPI_tables(self) -> Optional['Array']:
         raise UnimplementedAPIError('enum_ACPI_table')
 

--- a/chipsec/helper/efi/efihelper.py
+++ b/chipsec/helper/efi/efihelper.py
@@ -370,7 +370,7 @@ class EfiHelper(Helper):
 
     def get_ACPI_table(self, table_name: str) -> Optional['Array']:
         raise UnimplementedAPIError('get_ACPI_table')
-    
+
     def enum_ACPI_tables(self) -> Optional['Array']:
         raise UnimplementedAPIError('enum_ACPI_table')
 

--- a/chipsec/helper/linuxnative/linuxnativehelper.py
+++ b/chipsec/helper/linuxnative/linuxnativehelper.py
@@ -392,7 +392,7 @@ class LinuxNativeHelper(Helper):
 
     def get_ACPI_table(self, table_name: str) -> Optional['Array']:
         raise NotImplementedError()
-    
+
     def enum_ACPI_tables(self) -> Optional['Array']:
         raise NotImplementedError()
 

--- a/chipsec/helper/nonehelper.py
+++ b/chipsec/helper/nonehelper.py
@@ -159,7 +159,7 @@ class NoneHelper(Helper):
 
     def get_ACPI_table(self, table_name: str) -> Optional['Array']:
         raise UnimplementedAPIError('NoneHelper')
-    
+
     def enum_ACPI_tables(self) -> Optional['Array']:
         raise UnimplementedAPIError('NoneHelper')
 

--- a/chipsec/helper/record/recordhelper.py
+++ b/chipsec/helper/record/recordhelper.py
@@ -39,7 +39,7 @@ class RecordHelper(Helper):
         self.driver_created = False
         self.driver_loaded = False
         self.name = "FileHelper"
-        
+
         dtstr = datetime.now().strftime("%Y%m%d%H%M%S")
         self.default_file_name = f"recording{dtstr}.json"
         self.default_file_location = os.path.join("chipsec", "helper", "record")
@@ -118,7 +118,7 @@ class RecordHelper(Helper):
         self.driver_created = False
         return self._subhelper.delete()
 
-    
+
 
     def read_pci_reg(self, bus: int, device: int, function: int, offset: int, size: int) -> int:
         return self._call_subhelper(bus, device, function, offset, size)
@@ -128,10 +128,10 @@ class RecordHelper(Helper):
 
     def read_mmio_reg(self, phys_address: int, size: int) -> int:
         return self._call_subhelper(phys_address, size)
-    
+
     def write_mmio_reg(self, phys_address: int, size: int, value: int) -> int:
         return self._call_subhelper(phys_address, size, value)
-        
+
     #
     # physical_address is 64 bit integer
     #
@@ -152,7 +152,7 @@ class RecordHelper(Helper):
 
     def map_io_space(self, physical_address: int, length: int, cache_type: int) -> int:
         return self._call_subhelper(physical_address, length, cache_type)
-        
+
     #
     # Read/Write I/O port
     #
@@ -161,7 +161,7 @@ class RecordHelper(Helper):
 
     def write_io_port(self, io_port: int, value: int, size: int) -> int:
         return self._call_subhelper(io_port, value, size)
-        
+
     #
     # Read/Write CR registers
     #
@@ -274,4 +274,3 @@ class RecordHelper(Helper):
 def get_helper():
     return RecordHelper()
 
-            

--- a/chipsec/helper/replay/replayhelper.py
+++ b/chipsec/helper/replay/replayhelper.py
@@ -47,7 +47,7 @@ class ReplayHelper(Helper):
             else:
                 raise FileNotFoundError("Cannot find a recorded file to load")
         self._data = {}
-        
+
 
     def create(self) -> bool:
         return True
@@ -61,7 +61,7 @@ class ReplayHelper(Helper):
 
     def delete(self) -> bool:
         return True
-    
+
     def _get_element_eval(self, cmd: str, args: Tuple) -> Optional[Any]:
         element = self._get_element(cmd, args)
         if type(element) is str:
@@ -94,7 +94,7 @@ class ReplayHelper(Helper):
                     raise err
         logger().log_error(f"Missing entry for {str(cmd)} {targs}")
         return None
-    
+
     def _load(self) -> None:
         file_data = read_file(self.config_file)
         if file_data == 0:
@@ -113,10 +113,10 @@ class ReplayHelper(Helper):
 
     def read_mmio_reg(self, phys_address: int, size: int) -> int:
         return self._get_element_eval("read_mmio_reg", (phys_address, size))
-    
+
     def write_mmio_reg(self, phys_address: int, size: int, value: int) -> int:
         return self._get_element_eval("write_mmio_reg", (phys_address, size, value))
-        
+
     #
     # physical_address is 64 bit integer
     #
@@ -201,7 +201,7 @@ class ReplayHelper(Helper):
 
     def get_ACPI_table(self, table_name: str) -> Optional['Array']:
         return self._get_element_eval("get_ACPI_table", (table_name, ))
-    
+
     def enum_ACPI_tables(self) -> Optional['Array']:
         return self._get_element_eval("enum_ACPI_tables", ())
 

--- a/chipsec/helper/windows/__init__.py
+++ b/chipsec/helper/windows/__init__.py
@@ -26,7 +26,7 @@
 ##################################################################################
 
 import platform
-    
+
 if "windows" == platform.system().lower():
     __all__ = ["windowshelper"]
 else:

--- a/chipsec/library/logger.py
+++ b/chipsec/library/logger.py
@@ -110,7 +110,7 @@ class chipsecStreamFormatter(logging.Formatter):
             'YELLOW': '\033[93m',
             'BLUE': '\033[94m',
             'PURPLE': '\033[95m',
-            'CYAN': '\033[96m', 
+            'CYAN': '\033[96m',
             'WHITE': '\033[97m',
             'END': '\033[0m'}
     else:
@@ -228,17 +228,17 @@ class Logger:
             file_handler.setFormatter(self.logFormatter)
         else:
             self.log('Unable to autolog')
-    
+
     def get_terminators(self) -> List[str]:
         terms = []
         for clhandler in self.chipsecLogger.handlers:
             terms.append(clhandler.terminator)
         return terms
-    
+
     def set_terminators(self, term: str) -> None:
         for clhandler in self.chipsecLogger.handlers:
             clhandler.terminator = term
-    
+
     def log_inline(self, msg: str) -> None:
         """Logs a plain message without a newline charater at the end"""
         orig_term = self.get_terminators().pop()

--- a/chipsec/modules/common/cpu/cpu_info.py
+++ b/chipsec/modules/common/cpu/cpu_info.py
@@ -101,7 +101,7 @@ class cpu_info(BaseModule):
             self.logger.log('[*]')
 
         self.logger.log_information('Processor information displayed')
-        
+
         self.result.setStatusBit(self.result.status.INFORMATION)
         return self.result.getReturnCode(ModuleResult.INFORMATION)
 
@@ -154,9 +154,9 @@ class cpu_info(BaseModule):
             self.logger.log(f'[*]            Microcode: {microcode_rev:08X}')
             self.logger.log('[*]')
         self.logger.log_information('Processor information displayed')
-        
+
         self.res = ModuleResult.INFORMATION
-        return self.res 
+        return self.res
 
     def run(self, module_argv: List[str]) -> int:
         # Log the start of the test

--- a/chipsec/modules/common/cpu/ia_untrusted.py
+++ b/chipsec/modules/common/cpu/ia_untrusted.py
@@ -86,5 +86,5 @@ class ia_untrusted(BaseModule):
             self.logger.log_passed('IA_UNTRUSTED set on all threads')
         elif self.res == ModuleResult.FAILED:
             self.logger.log_failed('IA_UNTRUSTED not set on all threads')
-        
+
         return self.result.getReturnCode(self.res)

--- a/chipsec/modules/common/cpu/spectre_v2.py
+++ b/chipsec/modules/common/cpu/spectre_v2.py
@@ -145,7 +145,7 @@ class spectre_v2(BaseModule):
             if self.cs.register.is_defined('IA32_ARCH_CAPABILITIES'):
                 if self.cs.register.is_defined('IA32_SPEC_CTRL'):
                     return True
-                
+
                 self.logger.log_important('IA32_SPEC_CTRL register not defined for platform.  Skipping module.')
             else:
                 self.logger.log_important('IA32_ARCH_CAPABILITIES register not defined for platform.  Skipping module.')
@@ -297,7 +297,7 @@ class spectre_v2(BaseModule):
         elif self.cs.is_amd():
             res = ModuleResult.PASSED
             fields = ['IBRS', 'STIBP', 'SSBD', 'PSFD']
-            settings = {} 
+            settings = {}
             threads = {}
             fail = False
 

--- a/chipsec/modules/common/remap.py
+++ b/chipsec/modules/common/remap.py
@@ -90,14 +90,14 @@ class remap(BaseModule):
         else:
             self.logger.log_verbose('IBECC is not defined!')
         return False
-    
+
     def get_remap_registers(self, base_reg: str, limit_reg: str) -> Tuple[int, int]:
         if self.cs.register.is_defined(base_reg) and self.cs.register.is_defined(limit_reg):
             base = self.cs.register.read(base_reg)
             limit = self.cs.register.read(limit_reg)
             return base, limit
         raise RegisterNotFoundError('Required register definitions not defined for platform.')
-    
+
     def check_remap_config(self) -> int:
         is_warning = False
         remapMC0Found = True
@@ -112,7 +112,7 @@ class remap(BaseModule):
             remapbasemc1, remaplimitmc1 = self.get_remap_registers('PCI0.0.0_REMAPBASEMC1', 'PCI0.0.0_REMAPLIMITMC1')
         except RegisterNotFoundError:
             remapMC1Found = False
-        
+
         touud = self.cs.register.read('PCI0.0.0_TOUUD')
         tolud = self.cs.register.read('PCI0.0.0_TOLUD')
         tsegmb = self.cs.register.read('PCI0.0.0_TSEGMB')

--- a/chipsec/modules/common/rom_armor.py
+++ b/chipsec/modules/common/rom_armor.py
@@ -85,5 +85,5 @@ class rom_armor(BaseModule):
         else:
             self.logger.log_good("Rom Armor enabled.")
         self.res = self.check_RA_Fencing()
-        
+
         return self.res

--- a/chipsec/modules/common/sgx_check_sidekick.py
+++ b/chipsec/modules/common/sgx_check_sidekick.py
@@ -22,11 +22,10 @@ class SGX_Check_Sidekick():
     def __init__(self, cs):
         self.cs = cs
         self.sgx_global_en_defined = self.cs.register.has_field('IA32_FEATURE_CONTROL', 'SGX_GLOBAL_EN')
-    
+
     def check_valid(self, tid) -> bool:
         if self.sgx_global_en_defined:
             sgx_global_en = self.cs.register.read_field('IA32_FEATURE_CONTROL', 'SGX_GLOBAL_EN', tid)
         else:
             sgx_global_en = True
         return sgx_global_en
-    

--- a/chipsec/modules/common/smm_addr.py
+++ b/chipsec/modules/common/smm_addr.py
@@ -166,7 +166,7 @@ class smm_addr(BaseModule):
         else:
             res = ModuleResult.PASSED
             self.logger.log_passed("SMMask protection against cache attack is properly configured")
-        
+
         res = ModuleResult.PASSED
 
         return self.result.getReturnCode(res)

--- a/chipsec/modules/common/smrr.py
+++ b/chipsec/modules/common/smrr.py
@@ -81,7 +81,7 @@ class smrr(BaseModule):
             self.logger.log_not_applicable('CPU does not support SMRR range protection of SMRAM')
             self.result.setStatusBit(self.result.status.NOT_APPLICABLE)
             self.res = self.result.getReturnCode(ModuleResult.NOTAPPLICABLE)
-        
+
         smrr_ok = True
 
         self.logger.log('')

--- a/chipsec/modules/tools/cpu/sinkhole.py
+++ b/chipsec/modules/tools/cpu/sinkhole.py
@@ -121,5 +121,5 @@ class sinkhole(BaseModule):
             self.logger.log_important('CPU does not support SMRR range protection of SMRAM.  Skipping module.')
             self.result.setStatusBit(self.result.status.NOT_APPLICABLE)
             self.res = self.result.getReturnCode(ModuleResult.NOTAPPLICABLE)
-        
+
         return self.res

--- a/chipsec/modules/tools/smm/rogue_mmio_bar.py
+++ b/chipsec/modules/tools/smm/rogue_mmio_bar.py
@@ -103,7 +103,7 @@ class rogue_mmio_bar(BaseModule):
             if self.cs.os_helper.is_windows():
                 self.logger.log_important('Try running in Linux for better coverage.')
             return False
-        
+
         if self.logger.VERBOSE:
             self.cs.mmio.dump_MMIO(base, size)
             write_file('mmio_mem.orig', orig_mmio)

--- a/chipsec/modules/tools/uefi/s3script_modify.py
+++ b/chipsec/modules/tools/uefi/s3script_modify.py
@@ -427,7 +427,7 @@ class s3script_modify(BaseModule):
             self.logger.log(examples_str)
             self.result.setStatusBit(self.result.status.UNSUPPORTED_FEATURE)
             return self.result.getReturnCode(ModuleResult.ERROR)
-        
+
         self.result.setStatusBit(self.result.status.VERIFY)
 
         if sts:
@@ -435,5 +435,5 @@ class s3script_modify(BaseModule):
             self.res = ModuleResult.PASSED
         else:
             self.res = ModuleResult.FAILED
-        
+
         return self.result.getReturnCode(self.res)

--- a/chipsec/modules/tools/vmm/ept_finder.py
+++ b/chipsec/modules/tools/vmm/ept_finder.py
@@ -255,7 +255,7 @@ class ept_finder(BaseModule):
             if not ept.failure:
                 ept.save_configuration(self.path + f'ept_{eptp:08x}.py')
             count += 1
-            
+
         for (_, _, source_fp) in self.par:
             if source_fp:
                 source_fp.close()

--- a/chipsec/modules/tools/vmm/hv/synth_kbd.py
+++ b/chipsec/modules/tools/vmm/hv/synth_kbd.py
@@ -151,7 +151,7 @@ class synth_kbd(BaseModule):
             self.logger.log('\n\n')
             self.logger.log_bad(traceback.format_exc())
             self.logger.log('\n\n')
-            
+
         finally:
             vb.vmbus_close(relid)
             vb.vmbus_teardown_gpadl(relid, vb.ringbuffers[relid].gpadl)

--- a/chipsec/testcase.py
+++ b/chipsec/testcase.py
@@ -113,7 +113,7 @@ class ChipsecResults:
 
     def get_return_code(self):
         pass
-        
+
     def order_summary(self):
         return {}
 
@@ -228,18 +228,18 @@ class ChipsecResults:
             # Category as header level 1
             ret_string += f'\n# {result:s}:{len(destination[result]):d}\n'
             ret_string += ''.join(destination[result])
-        return ret_string   
+        return ret_string
 
 class LegacyResults(ChipsecResults):
     def print_summary(self, runtime: Optional[float] = None) -> None:
         summary = self.order_summary()
         filler = '*' * 27
         logger().log(f'\n[CHIPSEC] {filler}  SUMMARY  {filler}')
-        print_dictionary = {'failed to run': logger().log_error, 
-                            'passed': logger().log_passed, 
+        print_dictionary = {'failed to run': logger().log_error,
+                            'passed': logger().log_passed,
                             'information': logger().log_information,
-                            'archived': logger().log_information, 
-                            'failed': logger().log_failed, 
+                            'archived': logger().log_information,
+                            'failed': logger().log_failed,
                             'not applicable': logger().log_not_applicable}
         if runtime is not None:
             logger().log(f'[CHIPSEC] Time elapsed            {runtime:.3f}')
@@ -306,7 +306,7 @@ class LegacyResults(ChipsecResults):
             if len(summary[result]) != 0:
                 return destination[result]
         return ExitCode.OK
-        
+
 class ReturnCodeResults(ChipsecResults):
     def print_summary(self, runtime: Optional[float] = None) -> None:
         summary = self.order_summary()

--- a/chipsec/utilcmd/chipset_cmd.py
+++ b/chipsec/utilcmd/chipset_cmd.py
@@ -41,7 +41,7 @@ class PlatformCommand(BaseCommand):
 
     def requirements(self) -> toLoad:
         return toLoad.All
-    
+
     def parse_arguments(self) -> None:
         pass
 

--- a/chipsec/utilcmd/config_cmd.py
+++ b/chipsec/utilcmd/config_cmd.py
@@ -37,7 +37,7 @@ class CONFIGCommand(BaseCommand):
 
     def requirements(self) -> toLoad:
         return toLoad.All
-    
+
     def parse_arguments(self) -> None:
         parser = ArgumentParser(usage=__doc__)
 

--- a/chipsec/utilcmd/cpu_cmd.py
+++ b/chipsec/utilcmd/cpu_cmd.py
@@ -48,7 +48,7 @@ from typing import Dict, List, Optional, Union
 
 
 class CPUCommand(BaseCommand):
-    
+
     def requirements(self) -> toLoad:
         return toLoad.All
 

--- a/chipsec/utilcmd/decode_cmd.py
+++ b/chipsec/utilcmd/decode_cmd.py
@@ -59,13 +59,13 @@ class DecodeCommand(BaseCommand):
 
     def requirements(self) -> toLoad:
         return toLoad.Nil
-    
+
     def parse_arguments(self) -> None:
         parser = ArgumentParser(usage=__doc__)
         parser.add_argument('_rom', metavar='<rom>', help='file to decode')
         parser.add_argument('_fwtype', metavar='fw_type', nargs='?', help='firmware type', default=None)
         parser.parse_args(self.argv, namespace=self)
-        
+
         if self._rom.lower() == 'types':
             self.func = self.decode_types
         else:

--- a/chipsec/utilcmd/desc_cmd.py
+++ b/chipsec/utilcmd/desc_cmd.py
@@ -68,7 +68,7 @@ class IDTCommand(BaseCommand):
 
     def requirements(self) -> toLoad:
         return toLoad.Driver
-    
+
     def parse_arguments(self) -> None:
         parser = ArgumentParser(usage=IDTCommand.__doc__)
         parser.add_argument('_thread', metavar='thread', type=lambda x: int(x, 0), nargs='?', default=None, help="thread")
@@ -96,7 +96,7 @@ class GDTCommand(BaseCommand):
 
     def requirements(self) -> toLoad:
         return toLoad.Driver
-    
+
     def parse_arguments(self) -> None:
         parser = ArgumentParser(usage=GDTCommand.__doc__)
         parser.add_argument('_thread', metavar='thread', type=lambda x: int(x, 0), nargs='?', default=None, help="thread")
@@ -124,7 +124,7 @@ class LDTCommand(BaseCommand):
 
     def requirements(self) -> toLoad:
         return toLoad.Nil
-    
+
     def parse_arguments(self) -> None:
         return
 

--- a/chipsec/utilcmd/ec_cmd.py
+++ b/chipsec/utilcmd/ec_cmd.py
@@ -83,7 +83,7 @@ class ECCommand(BaseCommand):
         parser_index.set_defaults(func=self.index)
 
         parser.parse_args(self.argv, namespace=self)
-        
+
     def set_up(self) -> None:
         self._ec = EC(self.cs)
 

--- a/chipsec/utilcmd/igd_cmd.py
+++ b/chipsec/utilcmd/igd_cmd.py
@@ -63,7 +63,7 @@ class IgdCommand(BaseCommand):
         parser_write.set_defaults(func=self.write_dma)
 
         parser.parse_args(self.argv, namespace=self)
-        
+
 
     def read_dma(self) -> None:
         self.logger.log(f'[CHIPSEC] Reading buffer from memory: PA = 0x{self.address:016X}, len = 0x{self.width:X}..')

--- a/chipsec/utilcmd/lock_check_cmd.py
+++ b/chipsec/utilcmd/lock_check_cmd.py
@@ -33,7 +33,7 @@ Examples:
 KEY:
     Lock Name - Name of Lock within configuration file
     State     - Lock Configuration
-    
+
         Undefined - Lock is not defined within configuration
         Undoc     - Lock is missing configuration information
         Hidden    - Lock is in a disabled or hidden state (unable to read the lock)
@@ -86,7 +86,7 @@ class LOCKCHECKCommand(BaseCommand):
             self.cs.consistency_checking = True
         self.logger.set_always_flush(True)
         self._locks = locks(self.cs)
-    
+
     def tear_down(self) -> None:
         self.logger.set_always_flush(False)
         if self.flip_consistency_checking:

--- a/chipsec/utilcmd/module_id_cmd.py
+++ b/chipsec/utilcmd/module_id_cmd.py
@@ -37,7 +37,7 @@ from argparse import ArgumentParser
 
 
 class ModuleIdCommand(BaseCommand):
-    
+
     def requirements(self) -> toLoad:
         return toLoad.Nil
 

--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -292,7 +292,7 @@ class ChipsecMain:
             self.logger.log_error(f'Exception occurred during {modx.get_name()}.run(): \'{str(msg)}\'')
             raise msg
         return result
-    
+
     def run_loaded_modules(self):
         results = ReturnCodeResults() if self._return_codes else LegacyResults()
         results.add_properties(self.properties())

--- a/chipsec_util.py
+++ b/chipsec_util.py
@@ -158,7 +158,7 @@ class ChipsecUtil:
         if reqs.load_driver() and self._no_driver:
             self.logger.log("Cannot run command without a driver loaded.", level.ERROR)
             return ExitCode.ERROR
-            
+
         if reqs.load_config() and not self._load_config:
             self.logger.log("Cannot run command without a config loaded. Please run with -p and/or --pch if needed.", level.ERROR)
             return ExitCode.ERROR
@@ -179,18 +179,18 @@ class ChipsecUtil:
             print_banner_properties(self._cs, os_version())
 
         self.logger.log(f"[CHIPSEC] Executing command '{self._cmd}' with args {self._cmd_args}\n")
-        
+
         try:
             comm.set_up()
         except Exception as msg:
             self.logger.log_error(msg)
             return
-        
+
         t = time()
         if comm.prerun():
             comm.run()
         self.logger.log(f"[CHIPSEC] Time elapsed {time()-t:.3f}")
-        
+
         comm.tear_down()
         if reqs.load_driver() and not self._no_driver:
             self._cs.destroy_helper()

--- a/tests/hal/test_smbus.py
+++ b/tests/hal/test_smbus.py
@@ -83,7 +83,7 @@ class TestSMBUS(unittest.TestCase):
         smbus_hal = SMBus(mock_cs)
         mock_cs.device.get_VendorID.return_value = (did, vid)
         self.assertTrue(smbus_hal.is_SMBus_supported())
-        
+
     def test_is_SMBus_supported_invalid(self):
         did = 1234
         vid = 0x5678
@@ -101,7 +101,7 @@ class TestSMBUS(unittest.TestCase):
         mock_cs.register.get_field.return_value = hst_en
         smbus_hal = SMBus(mock_cs)
         self.assertEqual(smbus_hal.is_SMBus_host_controller_enabled(), hst_en)
-    
+
     @patch("chipsec.hal.smbus.iobar")
     def test_enable_SMBus_host_controller(self, mock_iobar):
         base_address = 123456
@@ -113,21 +113,21 @@ class TestSMBUS(unittest.TestCase):
         smbus_hal.enable_SMBus_host_controller()
         self.assertEqual(smbus_hal.cs.register.write.call_count, 2)
         self.assertEqual(smbus_hal.cs.register.read.call_count, 2)
-    
+
     def test_reset_SMBus_controller_valid(self):
         mock_cs = MagicMock()
         smbus_hal = SMBus(mock_cs)
         mock_cs.register.read.side_effect = [321, 0x8, 0]
         self.assertTrue(smbus_hal.reset_SMBus_controller())
         self.assertEqual(smbus_hal.cs.register.read.call_count, 3)
-    
+
     def test_reset_SMBus_controller_invalid(self):
         mock_cs = MagicMock()
         smbus_hal = SMBus(mock_cs)
         mock_cs.register.read.return_value = 0x8
         self.assertFalse(smbus_hal.reset_SMBus_controller())
         self.assertEqual(smbus_hal.cs.register.read.call_count, SMBUS_POLL_COUNT + 1)
-    
+
     def test__is_smbus_ready_valid(self):
         mock_cs = MagicMock()
         smbus_hal = SMBus(mock_cs)
@@ -216,4 +216,3 @@ class TestSMBUS(unittest.TestCase):
         mock_cs.register.read_field.return_value = 1
         buffer = bytes([1])
         self.assertTrue(smbus_hal.write_range(1, 2, buffer))
-        

--- a/tests/helpers/test_linuxhelper.py
+++ b/tests/helpers/test_linuxhelper.py
@@ -32,14 +32,14 @@ from tests.helpers.helper_utils import packer
 
 
 @patch('chipsec.helper.linux.linuxhelper.fcntl.ioctl')
-@patch('chipsec.helper.linux.linuxhelper.fcntl')  
+@patch('chipsec.helper.linux.linuxhelper.fcntl')
 class LinuxHelperTest(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         # Set up mock modules
         cls._mocked_modules = ['fcntl', 'resource', 'pywintypes', 'win32service',
-                               'winerror', 'win32file', 'win32api', 'win32process', 
+                               'winerror', 'win32file', 'win32api', 'win32process',
                                'win32security', 'win32serviceutil']
         for mod in cls._mocked_modules:
             sys.modules[mod] = Mock()
@@ -55,7 +55,7 @@ class LinuxHelperTest(unittest.TestCase):
             cpacker.pack_ioport(0x1),
         (0xc0084302, b'\xb8\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00U\x00\x00\x00\x00\x00\x00\x00'):
             0x01,
-        (0xC0084303, b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'): 
+        (0xC0084303, b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'):
             cpacker.pack_pci(0x86),
         (0xC0084303, b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'):
             cpacker.pack_pci(0x8086),
@@ -88,7 +88,7 @@ class LinuxHelperTest(unittest.TestCase):
         (0xc0084316, b'\x00\x00\x00\x16\x00\x00\x00\x00'):
             cpacker.custom_pack(1, 0x1, 0),
          }
-    
+
     def ioctlret(*arg):
         for i in arg:
             if type(i) is int:
@@ -98,7 +98,7 @@ class LinuxHelperTest(unittest.TestCase):
         if arg[1:] in LinuxHelperTest.ioctldict:
             return LinuxHelperTest.ioctldict[arg[1:]]
         return b'\xab'*40
-    
+
     @patch('chipsec.helper.linux.linuxhelper.open')
     @patch('chipsec.helper.linux.linuxhelper.subprocess.call')
     @patch('chipsec.helper.linux.linuxhelper.subprocess.check_output')
@@ -121,12 +121,12 @@ class LinuxHelperTest(unittest.TestCase):
             self.assertTrue(self.lhelper.start())
             # breakpoint()
             pass
-        
+
 
     def tearDown(self):
         unittest.TestCase.tearDown(self)
         self.assertTrue(self.lhelper.delete())
-        
+
     def test_map_io_space(self, _, lh_ioctl):
         self.assertRaises(UnimplementedAPIError, self.lhelper.map_io_space, 0, 0, 0)
 
@@ -143,30 +143,30 @@ class LinuxHelperTest(unittest.TestCase):
         self.lhelper.dev_fh = Mock()
         self.lhelper.dev_fh.seek.return_value = 0
         self.lhelper.dev_fh.read.return_value = b'\xac\xdc'
-        
+
         mem_value = self.lhelper.read_phys_mem(0x5000, 0x2)
         self.assertEqual(mem_value, b'\xac\xdc')
-    
-   
-   
-   
+
+
+
+
     def test_va2pa(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         pa = self.lhelper.va2pa(0x12345)
         self.assertEqual(pa, (0, 0))
-        
-        
+
+
 
     def test_read_pci_reg_cpu_one_byte(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         pci_read_value = self.lhelper.read_pci_reg(0, 0, 0, 0, 0x1)
         self.assertEqual(pci_read_value, 0x86)
-  
+
     def test_read_pci_reg_cpu_two_bytes(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         pci_read_value = self.lhelper.read_pci_reg(0, 0, 0, 0, 0x2)
         self.assertEqual(pci_read_value, 0x8086)
-        
+
     def test_read_pci_reg_cpu_four_bytes(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         pci_read_value = self.lhelper.read_pci_reg(0, 0, 0, 0, 0x4)
@@ -181,23 +181,23 @@ class LinuxHelperTest(unittest.TestCase):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         pci_read_value = self.lhelper.read_pci_reg(0, 0x1f, 0, 0, 0x2)
         self.assertEqual(pci_read_value, 0x8086)
-    
+
     def test_read_pci_reg_pch_four_bytes(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         pci_read_value = self.lhelper.read_pci_reg(0, 0x1f, 0, 0, 0x4)
         self.assertEqual(pci_read_value, 0xA0828086)
-        
+
     def test_write_pci_reg_cpu_one_byte(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         pci_write_return = self.lhelper.write_pci_reg(0, 0, 0, 0, 0x1, 0xab)
         self.assertEqual(pci_write_return, 0x1)
-    
-    # TODO Test: load_ucode_update() - Has error in implementation. 
+
+    # TODO Test: load_ucode_update() - Has error in implementation.
     # def test_load_ucode_update(self, _, lh_ioctl):
     #     lh_ioctl.side_effect = LinuxHelperTest.ioctlret
     #     load_ucode_update_return = self.lhelper.load_ucode_update(0, b'\x55')
     #     self.assertTrue(load_ucode_update_return)
-    
+
     def test_read_io_port(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         ioport_read_value = self.lhelper.read_io_port(0xB8, 4)
@@ -207,32 +207,32 @@ class LinuxHelperTest(unittest.TestCase):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         ioport_write_return = self.lhelper.write_io_port(0xB8, 0x55, 4)
         self.assertEqual(ioport_write_return, 0x1)
-    
+
     # TODO Test: read_cr
-    
+
     # TODO Test: write_cr
-    
+
     # TODO Test: read_msr
-    
+
     # TODO Test: write_msr
-    
+
     # TODO Test: get_descriptor_table
 
     def test_cpuid_one(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         cpuid_value = self.lhelper.cpuid(1, 0)
         self.assertEqual(cpuid_value, (0x406F1, 0, 0, 0))
-    
+
     def test_cpuid_two(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         cpuid_value = self.lhelper.cpuid(2, 0)
         self.assertEqual(cpuid_value, (0xFFFFF, 0, 0, 0))
-        
+
     def test_alloc_phys_mem(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         alloc_return = self.lhelper.alloc_phys_mem(0x8, 0x1000_0000_0000)
         self.assertEqual(alloc_return, (0x1, 0x0))
-    
+
     def test_free_phys_mem(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         free_return = self.lhelper.free_phys_mem(0x1600_0000)
@@ -254,35 +254,35 @@ class LinuxHelperTest(unittest.TestCase):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         msg_s_r_m = self.lhelper.msgbus_send_read_message(0x1, 0x2)
         self.assertEqual(msg_s_r_m, 0x200)
-    
+
     def test_msgbus_send_write_message(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         msg_s_r_m = self.lhelper.msgbus_send_write_message(0x1, 0x2, 0x3)
         self.assertIsNone(msg_s_r_m)
-    
+
     # TODO Test: get_affinity
-    
+
     # TODO Test: set_affinity
-    
+
     # TODO Test: EFI_supported
-    
+
     # TODO Test: delete_EFI_variable
-    
+
     # TODO Test: list_EFI_variables
-    
+
     # TODO Test: get_EFI_variable
-    
+
     # TODO Test: set_EFI_variable
-    
+
     # TODO Test: hypercall
-    
+
     # TODO Test: send_sw_smi
-    
+
     # TODO Test: get_tool_info
 
     def test_get_threads_count(self, _, _1):
         thread_count = self.lhelper.get_threads_count()
         self.assertEqual(thread_count, cpu_count())
-        
+
     def test_retpoline_enabled(self, _, lh_ioctl):
         self.assertRaises(NotImplementedError, self.lhelper.retpoline_enabled)

--- a/tests/helpers/test_replayhelper.py
+++ b/tests/helpers/test_replayhelper.py
@@ -40,11 +40,11 @@ class ReplayHelperTest(unittest.TestCase):
     def test_cpu_read_pci_reg_one_byte(self):
         pci_read_value = self.replayhelper.read_pci_reg(0, 0, 0, 0, 0x1)
         self.assertEqual(pci_read_value, 0x86)
-        
+
     def test_cpu_read_pci_reg_two_bytes(self):
         pci_read_value = self.replayhelper.read_pci_reg(0, 0, 0, 0, 0x2)
         self.assertEqual(pci_read_value, 0x8086)
-        
+
     def test_cpu_read_pci_reg_four_bytes(self):
         pci_read_value = self.replayhelper.read_pci_reg(0, 0, 0, 0, 0x4)
         self.assertEqual(pci_read_value, 0x59048086)
@@ -56,7 +56,7 @@ class ReplayHelperTest(unittest.TestCase):
     def test_pch_read_pci_reg_two_bytes(self):
         pci_read_value = self.replayhelper.read_pci_reg(0, 0x1f, 0, 0, 0x2)
         self.assertEqual(pci_read_value, 0x8086)
-    
+
     def test_pch_read_pci_reg_four_bytes(self):
         pci_read_value = self.replayhelper.read_pci_reg(0, 0x1f, 0, 0, 0x4)
         self.assertEqual(pci_read_value, 0x9D4E8086)
@@ -68,7 +68,7 @@ class ReplayHelperTest(unittest.TestCase):
     def test_read_phyis_mem_align(self):
         mem_value = self.replayhelper.read_phys_mem(0x5000, 0x2)
         self.assertEqual(mem_value, b'\xd1\x99')
-        
+
     def test_read_phyis_mem_unaligned(self):
         mem_value = self.replayhelper.read_phys_mem(0x5001, 0x2)
         self.assertEqual(mem_value, b'\x99\xaa')
@@ -80,7 +80,7 @@ class ReplayHelperTest(unittest.TestCase):
     def test_cpuid_one(self):
         cpuid_value = self.replayhelper.cpuid(1, 0)
         self.assertEqual(cpuid_value, (526057, 51382272, 2147154879, 3219913727))
-    
+
     def test_cpuid_two(self):
         cpuid_value = self.replayhelper.cpuid(2, 0)
         self.assertEqual(cpuid_value, (1979933441, 15775231, 0, 12779520))
@@ -103,4 +103,3 @@ class ReplayHelperTest(unittest.TestCase):
         self.replayhelper.write_mmio_reg(0x123, 0x1, 0x22)
         mmio_read_value = self.replayhelper.read_mmio_reg(0x123, 0x1)
         self.assertEqual(mmio_read_value, 0x22)
-        

--- a/tests/helpers/test_windowshelper.py
+++ b/tests/helpers/test_windowshelper.py
@@ -44,12 +44,12 @@ def print_args(args):
 @patch('chipsec.helper.windows.windowshelper.win32file.CreateFile')
 @patch('chipsec.helper.windows.windowshelper.win32file.DeviceIoControl')
 class WindowsHelperTest(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         # Set up mock modules
         cls._mocked_modules = ['pywintypes', 'win32service', 'windll',
-                               'winerror', 'win32file', 'win32api', 'win32process', 
+                               'winerror', 'win32file', 'win32api', 'win32process',
                                'win32security', 'win32serviceutil', 'ctypes', 'win32.lib']
         for mod in cls._mocked_modules:
             sys.modules[mod] = Mock()
@@ -92,22 +92,22 @@ class WindowsHelperTest(unittest.TestCase):
         (0x22e060, b'\x00\x003\x00\x05\x80\x00\x00\x00\x00\x00\x00\x00\x00'):
             b'',
         (0x22e034, b'\x00\x00\x00\x00:\x00\x00\x00'):
-            b'\x01\x00\x00\x00\x00\x00\x00\x00',  
+            b'\x01\x00\x00\x00\x00\x00\x00\x00',
         (0x22e030, b'\x00\x00\x00\x00:\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00' ):
             b'',
         (0x22e040, b'\x00\x00\x00\x00\x01'):
             b'W\x00\xb0\x1f\xeav\x04\xf8\xff\xff\xb0\xbf0\x03\x00\x00\x00\x00',
     }
 
-    
-    
+
+
     def ioctlret(*args):
         if DEBUG:
             print_args(args)
         if args[1:3] in WindowsHelperTest.ioctl_dict:
             return WindowsHelperTest.ioctl_dict[args[1:3]]
         return b'\xab'*40
-                
+
     @patch('chipsec.helper.windows.windowshelper.windll.ntdll.NtQuerySystemInformation')
     @patch('chipsec.helper.windows.windowshelper.logger')
     @patch('chipsec.helper.windows.windowshelper.win32file')
@@ -145,14 +145,14 @@ class WindowsHelperTest(unittest.TestCase):
         with patch.dict(wh.os.__dict__, {'chown': lambda *args: None}):
             self.whelper = wh.WindowsHelper()
             self.assertTrue(self.whelper.create())
-            self.assertTrue(self.whelper.start())        
+            self.assertTrue(self.whelper.start())
 
     @patch('chipsec.helper.windows.windowshelper.win32api.CloseHandle')
     def tearDown(self, _):
         unittest.TestCase.tearDown(self)
         self.assertTrue(self.whelper.delete())
         self.whelper.__del__()
-        
+
     # TODO def test_map_io_space(self, _):
 
     def _assign_mocks(self, mocks):
@@ -160,7 +160,7 @@ class WindowsHelperTest(unittest.TestCase):
         mock_createfile = mocks[1]
         mock_ioctl.side_effect = WindowsHelperTest.ioctlret
         mock_createfile.return_value = DRIVER_HANDLE
-        
+
     def test_write_phys_mem(self, *mocks):
         self._assign_mocks(mocks)
         retval = self.whelper.write_phys_mem(0x1234, 0x8, "abc")
@@ -182,14 +182,14 @@ class WindowsHelperTest(unittest.TestCase):
         pci_bdf.side_effect = pcibdf_sideeffect
         pci_read_value = self.whelper.read_pci_reg(0, 0, 0, 0, 0x1)
         self.assertEqual(pci_read_value, 0x86)
-    
+
     @patch('chipsec.helper.windows.windowshelper.PCI_BDF')
     def test_read_pci_reg_cpu_two_bytes(self, pci_bdf, *mocks):
         self._assign_mocks(mocks)
         pci_bdf.side_effect = pcibdf_sideeffect
         pci_read_value = self.whelper.read_pci_reg(0, 0, 0, 0, 0x2)
         self.assertEqual(pci_read_value, 0x8086)
-    
+
     @patch('chipsec.helper.windows.windowshelper.PCI_BDF')
     def test_read_pci_reg_cpu_four_bytes(self, pci_bdf, *mocks):
         self._assign_mocks(mocks)
@@ -228,27 +228,27 @@ class WindowsHelperTest(unittest.TestCase):
         self._assign_mocks(mocks)
         ioport_write_return = self.whelper.write_io_port(0xB8, 0x55, 4)
         self.assertTrue(ioport_write_return)
-  
+
     def test_read_cr(self, *mocks):
         self._assign_mocks(mocks)
         read_cr_return = self.whelper.read_cr(0, 0)
         self.assertEqual(read_cr_return, 0x80050033)
-  
+
     def test_write_cr(self, *mocks):
         self._assign_mocks(mocks)
         write_cr_return = self.whelper.write_cr(0, 0, 0x80050033)
         self.assertTrue(write_cr_return)
-  
+
     def test_read_msr(self, *mocks):
         self._assign_mocks(mocks)
         read_msr_return = self.whelper.read_msr(0, 0x3A)
         self.assertEqual(read_msr_return, (1, 0))
-  
+
     def test_write_msr(self, *mocks):
         self._assign_mocks(mocks)
         write_msr_return = self.whelper.write_msr(0, 0x3a, 1, 0)
         self.assertTrue(write_msr_return)
-  
+
 
     def test_get_descriptor_table(self, *mocks):
         self._assign_mocks(mocks)
@@ -260,12 +260,12 @@ class WindowsHelperTest(unittest.TestCase):
         cpuid_value = self.whelper.cpuid(1, 0)
         self.assertEqual(cpuid_value, (0x406F1, 0, 0, 0))
 
-        
+
     def test_alloc_phys_mem(self, *mocks):
         self._assign_mocks(mocks)
         alloc_return = self.whelper.alloc_phys_mem(0x8, 0x1000_0000_0000)
         self.assertEqual(alloc_return, (0x1, 0x0))
-    
+
     def test_free_phys_mem(self, *mocks):
         self._assign_mocks(mocks)
         free_return = self.whelper.free_phys_mem(0x1600_0000)
@@ -279,19 +279,19 @@ class WindowsHelperTest(unittest.TestCase):
     def test_write_mmio_reg(self, *mocks):
         self._assign_mocks(mocks)
         self.whelper.write_mmio_reg(0x123, 0x1, 0x22)
-    
+
     # TODO def test_get_ACPI_SDT(self, *mocks):
         # self._assign_mocks(mocks)
 
     # TODO def test_get_ACPI_table(self, *mocks):
         # self._assign_mocks(mocks)
-    
+
     def test_msgbus_send_read_message(self, *_):
         self.assertRaises(UnimplementedAPIError, self.whelper.msgbus_send_read_message, 0x1, 0x2)
-    
+
     def test_msgbus_send_write_message(self, *_):
         self.assertRaises(UnimplementedAPIError, self.whelper.msgbus_send_write_message, 0x1, 0x2, 3)
-    
+
     def test_msgbus_send_message(self, *_):
         self.assertRaises(UnimplementedAPIError, self.whelper.msgbus_send_message, 0x1, 0x2, 3)
 

--- a/tests/modules/test_tgl_modules.py
+++ b/tests/modules/test_tgl_modules.py
@@ -31,7 +31,7 @@ class TestTglModules(unittest.TestCase):
     def setUp(self) -> None:
         self.folder_path = os.path.join(get_main_dir(), "tests", "modules", "tgl")
         self.init_replay_file = os.path.join(self.folder_path, "enumeration.json")
-        
+
     def derive_filename(self, module_name: str) -> str:
         return f"{module_name.replace('.', '-')}_test.json"
 
@@ -40,86 +40,86 @@ class TestTglModules(unittest.TestCase):
         replay_file = os.path.join(self.folder_path, test_recording)
         retval = setup_run_destroy_module_with_mock_logger(self.init_replay_file, module_name, module_replay_file=replay_file)
         self.assertEqual(retval, expected_returncode, f"Expected: {expected_returncode} but got: {retval}")
-                   
+
     def test_tgl_module_bios_smi(self):
         self.run_and_test_module("common.bios_smi", ExitCode.OK)
-    
+
     def test_tgl_module_bios_ts(self):
         self.run_and_test_module("common.bios_ts", ExitCode.OK)
-    
+
     def test_tgl_module_bios_wp(self):
         self.run_and_test_module("common.bios_wp", ExitCode.OK)
-        
+
     def test_tgl_module_cpu_cpu_info(self):
         self.run_and_test_module("common.cpu.cpu_info", ExitCode.INFORMATION)
-    
+
     def test_tgl_module_cpu_ia_untrusted(self):
         self.run_and_test_module("common.cpu.ia_untrusted", ExitCode.OK)
-        
+
     def test_tgl_module_cpu_spectre_v2(self):
         self.run_and_test_module("common.cpu.spectre_v2", ExitCode.OK)
-        
+
     def test_tgl_module_debugenabled(self):
         self.run_and_test_module("common.debugenabled", ExitCode.OK)
-        
+
     def test_tgl_module_ia32cfg(self):
         self.run_and_test_module("common.ia32cfg", ExitCode.OK)
-        
+
     def test_tgl_module_memconfig(self):
         self.run_and_test_module("common.memconfig", ExitCode.OK)
-        
+
     def test_tgl_module_memlock(self):
         self.run_and_test_module("common.memlock", ExitCode.NOTAPPLICABLE)
-    
+
     def test_tgl_module_me_mfg_mode(self):
         self.run_and_test_module("common.me_mfg_mode", ExitCode.OK)
-    
+
     def test_tgl_module_remap(self):
         self.run_and_test_module("common.remap", ExitCode.OK)
 
     def test_tgl_module_rtclock(self):
         self.run_and_test_module("common.rtclock", ExitCode.WARNING)
-        
+
     def test_tgl_module_secureboot_variables(self):
         self.run_and_test_module("common.secureboot.variables", ExitCode.OK)
-        
+
     def test_tgl_module_sgx_check(self):
         self.run_and_test_module("common.sgx_check", ExitCode.NOTAPPLICABLE)
-        
+
     def test_tgl_module_smm_code_chk(self):
         self.run_and_test_module("common.smm_code_chk", ExitCode.OK)
-    
+
     def test_tgl_module_smm_dma(self):
         self.run_and_test_module("common.smm_dma", ExitCode.OK)
-    
+
     def test_tgl_module_smm(self):
         self.run_and_test_module("common.smm", ExitCode.NOTAPPLICABLE)
-    
+
     def test_tgl_module_smrr(self):
         self.run_and_test_module("common.smrr", ExitCode.OK)
-    
+
     def test_tgl_module_spd_wd(self):
         self.run_and_test_module("common.spd_wd", ExitCode.OK)
-    
+
     def test_tgl_module_spi_access(self):
         self.run_and_test_module("common.spi_access", ExitCode.FAIL)
-    
+
     def test_tgl_module_spi_desc(self):
         self.run_and_test_module("common.spi_desc", ExitCode.OK)
-    
+
     def test_tgl_module_spi_fdopss(self):
         self.run_and_test_module("common.spi_fdopss", ExitCode.OK)
-    
+
     def test_tgl_module_spi_lock(self):
         self.run_and_test_module("common.spi_lock", ExitCode.OK)
-    
+
     def test_tgl_module_uefi_access_uefispec(self):
         self.run_and_test_module("common.uefi.access_uefispec", ExitCode.OK)
 
     @unittest.skip("S3bootscript module was archived")
     def test_tgl_module_uefi_s3bootscript(self):
         self.run_and_test_module("common.uefi.s3bootscript", ExitCode.WARNING)
-        
+
 
 
 if __name__ == '__main__':

--- a/tests/software/mock_helper.py
+++ b/tests/software/mock_helper.py
@@ -151,7 +151,7 @@ class TestHelper(Helper):
 
     def get_ACPI_table(self, table_name: str) -> Optional['Array']:
         raise UnimplementedAPIError('get_ACPI_table')
-    
+
     def enum_ACPI_tables(self) -> Optional['Array']:
         raise UnimplementedAPIError('enum_ACPI_table')
 

--- a/tests/utilcmd/cmos_cmd/test_cmos_cmd.py
+++ b/tests/utilcmd/cmos_cmd/test_cmos_cmd.py
@@ -40,8 +40,8 @@ class TestCmosUtilcmd(unittest.TestCase):
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")
         cmos_readl_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "cmos_cmd", "cmos_cmd_readl_1.json")
         retval = setup_run_destroy_util(init_replay_file, "cmos", "readl 0x0", util_replay_file=cmos_readl_replay_file)
-        self.assertEqual(retval, ExitCode.OK) 
-        
+        self.assertEqual(retval, ExitCode.OK)
+
     def test_writel(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")
         cmos_writel_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "cmos_cmd", "cmos_cmd_writel_1.json")

--- a/tests/utilcmd/tpm_cmd/test_tpm_cmd.py
+++ b/tests/utilcmd/tpm_cmd/test_tpm_cmd.py
@@ -34,8 +34,8 @@ class TestTpmUtilcmd(unittest.TestCase):
         pass
 
     def test_command_pcrread(self) -> None:
-        pass 
-        
+        pass
+
     def test_command_nvread(self) -> None:
         pass
 


### PR DESCRIPTION
This commit fixes all the W293 errors.  They were found by running "flake8 ." from the root directory.  W293 is an error defined by "pycodestyle", and has no functional impact to the source.  This is simply fixing whitespace as defined by CHIPSEC's .flake8 configuration.

background:
https://www.flake8rules.com/rules/W293.html
https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes:~:text=end%20of%20file-,W293,-blank%20line%20contains

versions: flake8 v7.1.1, python v3.12.6