### PR TITLE
Fix for Flake8 rule E303

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -187,7 +187,6 @@ class Chipset:
                 error_no = msg.errorcode
             raise OsHelperError(f'Message: "{msg}"', error_no)
 
-
     def switch_helper(self, helper_name):
         oldName = self.helper.name
         self.destroy_helper()

--- a/chipsec/hal/acpi.py
+++ b/chipsec/hal/acpi.py
@@ -357,8 +357,6 @@ class ACPI(HALBase):
         sdt.parse(sdt_contents)
         return (is_xsdt, sdt_pa, sdt, sdt_header)
 
-
-
     def get_ACPI_SDT(self) -> Tuple[Optional['Array'], bool]:
         sdt = self.cs.helper.get_acpi_table('XSDT')  # FirmwareTableID_XSDT
         xsdt = sdt is not None

--- a/chipsec/hal/acpi_tables.py
+++ b/chipsec/hal/acpi_tables.py
@@ -1013,7 +1013,7 @@ Generic Error Status Block
         return f"""
 ------------------------------------------------------------------
   Boot Region Length                                : {self.BootRegionLen:d}
-  Boot Region Address	                            : 0x{self.BootRegionAddr:016X}
+  Boot Region Address                               : 0x{self.BootRegionAddr:016X}
   Boot Region - {self.BootRegion}
 """
 
@@ -1407,7 +1407,7 @@ class HEST (ACPI_TABLE):
 
         self.resultsStr += f"""
     {title}
-    Source ID         				  : 0x{sourceID:04X}
+    Source ID                                     : 0x{sourceID:04X}
     Reserved                                      : 0x{reserved1:04X}
     Flags                                         : 0x{flags:02X}{flags_str}
       FIRMWARE_FIRST                              : {firmware_first} - {firmware_first_str}
@@ -2266,8 +2266,6 @@ FIXED_COMM_BUFFERS                  : {self.fixed_comm_buffers}
 COMM_BUFFER_NESTED_PTR_PROTECTION   : {self.comm_buffer_nested_ptr_protection}
 SYSTEM_RESOURCE_PROTECTION          : {self.system_resource_protection}
     """
-
-
 
 ########################################################################################################
 #

--- a/chipsec/hal/msr.py
+++ b/chipsec/hal/msr.py
@@ -85,7 +85,6 @@ class Msr:
 #
 ##########################################################################################################
 
-
     def read_msr(self, cpu_thread_id: int, msr_addr: int) -> Tuple[int, int]:
         (eax, edx) = self.helper.read_msr(cpu_thread_id, msr_addr)
         logger().log_hal(f'[cpu{cpu_thread_id:d}] RDMSR( 0x{msr_addr:x} ): EAX = 0x{eax:08X}, EDX = 0x{edx:08X}')
@@ -130,7 +129,6 @@ class Msr:
 # Dump CPU Descriptor Tables (IDT, GDT, LDT..)
 #
 ##########################################################################################################
-
 
     def dump_Descriptor_Table(self, cpu_thread_id: int, code: int, num_entries: Optional[int] = None) -> Tuple[int, int]:
         (limit, _, pa) = self.helper.get_descriptor_table(cpu_thread_id, code)

--- a/chipsec/hal/psp.py
+++ b/chipsec/hal/psp.py
@@ -55,7 +55,6 @@ class PSP:
         buf_size = num_buf * dword_size  # TODO: Build a table for each command
         cmd = self.PSP_CMD_GET_HSTI_STATE
 
-
         # Todo: Add Reset and Recovery checks
 
         # poll for mailbox ready

--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -41,8 +41,6 @@ from chipsec.library.file import write_file, read_file
 from chipsec.library.defines import bytestostring
 from chipsec.helper.oshelper import OsHelperError
 
-
-
 ########################################################################################################
 #
 # S3 Resume Boot-Script Parsing Functionality

--- a/chipsec/helper/dal/dalhelper.py
+++ b/chipsec/helper/dal/dalhelper.py
@@ -397,11 +397,8 @@ class DALHelper(Helper):
     def get_tool_info(self, tool_type: str) -> Tuple[str, str]:
         return ('', '')
 
-
     def hypercall(self, rcx, rdx, r8, r9, r10, r11, rax, rbx, rdi, rsi, xmm_buffer):
         raise UnimplementedAPIError('hypercall')
-
-
 
 def get_helper() -> DALHelper:
     return DALHelper()

--- a/chipsec/helper/record/recordhelper.py
+++ b/chipsec/helper/record/recordhelper.py
@@ -118,8 +118,6 @@ class RecordHelper(Helper):
         self.driver_created = False
         return self._subhelper.delete()
 
-
-
     def read_pci_reg(self, bus: int, device: int, function: int, offset: int, size: int) -> int:
         return self._call_subhelper(bus, device, function, offset, size)
 

--- a/chipsec/helper/replay/replayhelper.py
+++ b/chipsec/helper/replay/replayhelper.py
@@ -48,7 +48,6 @@ class ReplayHelper(Helper):
                 raise FileNotFoundError("Cannot find a recorded file to load")
         self._data = {}
 
-
     def create(self) -> bool:
         return True
 
@@ -103,7 +102,6 @@ class ReplayHelper(Helper):
             self._data = loads(file_data)
         except Exception:
             raise OsHelperError(f'Unable to load JSON File: {self.config_file}', EFAULT)
-
 
     def read_pci_reg(self, bus: int, device: int, function: int, offset: int, size: int) -> int:
         return self._get_element_eval("read_pci_reg", (bus, device, function, offset, size))

--- a/chipsec/helper/windows/windowshelper.py
+++ b/chipsec/helper/windows/windowshelper.py
@@ -330,7 +330,6 @@ class WindowsHelper(Helper):
 # Driver/service management functions
 ###############################################################################################
 
-
     def show_warning(self) -> None:
         logger().log("")
         logger().log_warning("*******************************************************************")

--- a/chipsec/library/returncode.py
+++ b/chipsec/library/returncode.py
@@ -107,8 +107,6 @@ class ReturnCode:
         self.resetReturnCodeValues()
         return ret_value
 
-
-
 def get_module_ids_dictionary() -> Dict[str, str]:
     with open(os.path.join(get_main_dir(), 'chipsec', 'library', 'module_ids.json'), 'r') as module_ids_file:
         module_ids = json.loads(module_ids_file.read())
@@ -167,7 +165,7 @@ def getModuleResultName(res, using_return_codes) -> str:
         result_mask = 0xFFFFFFFF00000000
         status = [ReturnCode.status.SUCCESS.value[0], ReturnCode.status.INFORMATION.value[0], ReturnCode.status.NOT_APPLICABLE.value[0]]
         if ((res & result_mask) >> 32) in status:
-            resultName = 'Passed' 
+            resultName = 'Passed'
         elif ((res & result_mask) >> 32) == ReturnCode.status.ARCHIVED.value[0]:
             resultName = 'Archived'
         else:

--- a/chipsec/modules/common/cpu/cpu_info.py
+++ b/chipsec/modules/common/cpu/cpu_info.py
@@ -148,7 +148,6 @@ class cpu_info(BaseModule):
             model = (extModel << 4) & baseModel
             self.logger.log(f'[*]            Family: {family:02X} Model: {model:02X} Stepping: {stepping:01X}')
 
-
             # Get microcode revision
             microcode_rev = self.cs.register.read_field('PATCH_LEVEL', 'PatchLevel', cpu_thread=thread)
             self.logger.log(f'[*]            Microcode: {microcode_rev:08X}')

--- a/chipsec/modules/common/smm_addr.py
+++ b/chipsec/modules/common/smm_addr.py
@@ -22,7 +22,7 @@
 """
 CPU SMM Addr
 
-This module checks to see that SMMMask has Tseg and Aseg programmed correctly.  It also verifies that CPU access to SMM 
+This module checks to see that SMMMask has Tseg and Aseg programmed correctly.  It also verifies that CPU access to SMM
 is blocked while not in SMM.
 
 Usage:
@@ -88,7 +88,6 @@ class smm_addr(BaseModule):
         self.cs.register.print('SMMMASK', cpu0_smmmask)
         tseg_type = self.cs.register.get_field('SMMMASK', cpu0_smmmask, 'TMTYPEDRAM')
         aseg_type = self.cs.register.get_field('SMMMASK', cpu0_smmmask, 'AMTYPEDRAM')
-
 
         if tseg_type in MemType:
             self.logger.log(f"[*] TSEG range memory type is {MemType[tseg_type]}")

--- a/chipsec/modules/common/uefi/s3bootscript.py
+++ b/chipsec/modules/common/uefi/s3bootscript.py
@@ -151,7 +151,6 @@ class s3bootscript(BaseModule):
                 self.result.setStatusBit(self.result.status.VERIFY)
                 return ModuleResult.WARNING
 
-
             self.logger.log_important(f'Found {len(bootscript_PAs):d} S3 boot-script(s) in EFI variables')
 
         for bootscript_pa in bootscript_PAs:

--- a/chipsec/modules/tools/vmm/iofuzz.py
+++ b/chipsec/modules/tools/vmm/iofuzz.py
@@ -136,7 +136,6 @@ class iofuzz(BaseModule):
         self.result.setStatusBit(self.result.status.VERIFY)
         return self.result.getReturnCode(ModuleResult.WARNING)
 
-
     def run(self, module_argv):
         self.logger.start_test('I/O port fuzzer')
 

--- a/chipsec/testcase.py
+++ b/chipsec/testcase.py
@@ -120,7 +120,6 @@ class ChipsecResults:
     def print_summary(self):
         pass
 
-
     def set_time(self, pTime: Optional[float] = None) -> None:
         """Sets the time"""
         if pTime is not None:

--- a/chipsec/utilcmd/config_cmd.py
+++ b/chipsec/utilcmd/config_cmd.py
@@ -51,7 +51,6 @@ class CONFIGCommand(BaseCommand):
 
         parser.parse_args(self.argv, namespace=self)
 
-
     def show(self) -> None:
         if self.config == "ALL":
             config = ['CONFIG_PCI', 'REGISTERS', 'MMIO_BARS', 'IO_BARS', 'MEMORY_RANGES', 'CONTROLS', 'BUS', 'LOCKS']

--- a/chipsec/utilcmd/decode_cmd.py
+++ b/chipsec/utilcmd/decode_cmd.py
@@ -71,7 +71,6 @@ class DecodeCommand(BaseCommand):
         else:
             self.func = self.decode_rom
 
-
     def decode_types(self) -> None:
         self.logger.log(f'\n<fw_type> should be in [ {" | ".join([f"{t}" for t in uefi_platform.fw_types])} ]\n')
 

--- a/chipsec/utilcmd/ec_cmd.py
+++ b/chipsec/utilcmd/ec_cmd.py
@@ -126,6 +126,4 @@ class ECCommand(BaseCommand):
             mem = [self._ec.read_idx(off) for off in range(0x10000)]
             print_buffer_bytes(mem)
 
-
-
 commands = {'ec': ECCommand}

--- a/chipsec/utilcmd/igd_cmd.py
+++ b/chipsec/utilcmd/igd_cmd.py
@@ -64,7 +64,6 @@ class IgdCommand(BaseCommand):
 
         parser.parse_args(self.argv, namespace=self)
 
-
     def read_dma(self) -> None:
         self.logger.log(f'[CHIPSEC] Reading buffer from memory: PA = 0x{self.address:016X}, len = 0x{self.width:X}..')
         buffer = self.cs.igd.gfx_aperture_dma_read_write(self.address, self.width)

--- a/chipsec/utilcmd/mem_cmd.py
+++ b/chipsec/utilcmd/mem_cmd.py
@@ -102,7 +102,6 @@ class MemCommand(BaseCommand):
         parser_search.set_defaults(func=self.mem_search)
         parser.parse_args(self.argv, namespace=self)
 
-
     def dump_region_to_path(self, path: str, pa_start: int, pa_end: int) -> None:
         if pa_start >= pa_end:
             return

--- a/chipsec/utilcmd/mmcfg_base_cmd.py
+++ b/chipsec/utilcmd/mmcfg_base_cmd.py
@@ -52,6 +52,4 @@ class MMCfgBaseCommand(BaseCommand):
             self.logger.log(f'[CHIPSEC] Memory Mapped Config Size: 0x{pciexbar[1]:016X}')
             self.logger.log('')
 
-
-
 commands = {'mmcfg_base': MMCfgBaseCommand}

--- a/chipsec/utilcmd/mmio_cmd.py
+++ b/chipsec/utilcmd/mmio_cmd.py
@@ -169,6 +169,4 @@ class MMIOCommand(BaseCommand):
             self._mmio.write_MMIO_reg_dword(self.base, self.offset, self.value & 0xFFFFFFFF)
             self._mmio.write_MMIO_reg_dword(self.base, self.offset + 4, (self.value >> 32) & 0xFFFFFFFF)
 
-
-
 commands = {'mmio': MMIOCommand}

--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -382,7 +382,6 @@ class ChipsecMain:
             self.logger.log_warning("Most results cannot be trusted.")
             self.logger.log_warning("Unless a platform independent module is being run, do not file issues against this run.")
 
-
     def properties(self):
         ret = OrderedDict()
         ret["OS"] = f'{self._cs.helper.os_system} {self._cs.helper.os_release} {self._cs.helper.os_version} {self._cs.helper.os_machine}'

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ from setuptools.command.build_ext import build_ext as _build_ext
 
 NO_DRIVER_MARKER_FILE = 'README.NO_KERNEL_DRIVER'
 
-
-
 def long_description():
     return open('README').read()
 

--- a/tests/helpers/helper_utils.py
+++ b/tests/helpers/helper_utils.py
@@ -21,7 +21,6 @@ class packer():
     def __init__(self, default_size_char = 'Q') -> None:
         self.size_char = default_size_char
 
-
     def custom_pack(self, num_of_chunks: int, expected_value: int, expected_value_index: int = 0) -> bytes:
         input = [0] * num_of_chunks
         input[expected_value_index] = expected_value

--- a/tests/helpers/test_linuxhelper.py
+++ b/tests/helpers/test_linuxhelper.py
@@ -29,8 +29,6 @@ from tests.helpers.helper_utils import packer
 
 # assuming 64 bit system. Will break on 32bit system. (would need to swap Q > I in pack())
 
-
-
 @patch('chipsec.helper.linux.linuxhelper.fcntl.ioctl')
 @patch('chipsec.helper.linux.linuxhelper.fcntl')
 class LinuxHelperTest(unittest.TestCase):
@@ -122,7 +120,6 @@ class LinuxHelperTest(unittest.TestCase):
             # breakpoint()
             pass
 
-
     def tearDown(self):
         unittest.TestCase.tearDown(self)
         self.assertTrue(self.lhelper.delete())
@@ -130,14 +127,12 @@ class LinuxHelperTest(unittest.TestCase):
     def test_map_io_space(self, _, lh_ioctl):
         self.assertRaises(UnimplementedAPIError, self.lhelper.map_io_space, 0, 0, 0)
 
-
     def test_write_phys_mem(self, _, _1):
         self.lhelper.dev_fh = Mock()
         self.lhelper.dev_fh.seek.return_value = 0
         self.lhelper.dev_fh.write.return_value = 2
         write_return = self.lhelper.write_phys_mem(0x5000, 0x2, b'\xab\xab')
         self.assertEqual(write_return, 2)
-
 
     def test_read_phyis_mem(self, _, _1):
         self.lhelper.dev_fh = Mock()
@@ -147,15 +142,10 @@ class LinuxHelperTest(unittest.TestCase):
         mem_value = self.lhelper.read_phys_mem(0x5000, 0x2)
         self.assertEqual(mem_value, b'\xac\xdc')
 
-
-
-
     def test_va2pa(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret
         pa = self.lhelper.va2pa(0x12345)
         self.assertEqual(pa, (0, 0))
-
-
 
     def test_read_pci_reg_cpu_one_byte(self, _, lh_ioctl):
         lh_ioctl.side_effect = LinuxHelperTest.ioctlret

--- a/tests/helpers/test_replayhelper.py
+++ b/tests/helpers/test_replayhelper.py
@@ -31,7 +31,6 @@ class ReplayHelperTest(unittest.TestCase):
         self.assertTrue(self.replayhelper.create())
         self.assertTrue(self.replayhelper.start())
 
-
     def tearDown(self):
         unittest.TestCase.tearDown(self)
         self.assertTrue(self.replayhelper.stop())

--- a/tests/helpers/test_windowshelper.py
+++ b/tests/helpers/test_windowshelper.py
@@ -99,8 +99,6 @@ class WindowsHelperTest(unittest.TestCase):
             b'W\x00\xb0\x1f\xeav\x04\xf8\xff\xff\xb0\xbf0\x03\x00\x00\x00\x00',
     }
 
-
-
     def ioctlret(*args):
         if DEBUG:
             print_args(args)
@@ -249,7 +247,6 @@ class WindowsHelperTest(unittest.TestCase):
         write_msr_return = self.whelper.write_msr(0, 0x3a, 1, 0)
         self.assertTrue(write_msr_return)
 
-
     def test_get_descriptor_table(self, *mocks):
         self._assign_mocks(mocks)
         get_des_table_return = self.whelper.get_descriptor_table(0, 1)
@@ -259,7 +256,6 @@ class WindowsHelperTest(unittest.TestCase):
         self._assign_mocks(mocks)
         cpuid_value = self.whelper.cpuid(1, 0)
         self.assertEqual(cpuid_value, (0x406F1, 0, 0, 0))
-
 
     def test_alloc_phys_mem(self, *mocks):
         self._assign_mocks(mocks)

--- a/tests/modules/test_cpu_info.py
+++ b/tests/modules/test_cpu_info.py
@@ -40,7 +40,5 @@ class TestCpuInfo(unittest.TestCase):
         result = cpu_info.is_supported(mock_self)
         self.assertTrue(result)
 
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/modules/test_tgl_modules.py
+++ b/tests/modules/test_tgl_modules.py
@@ -120,7 +120,5 @@ class TestTglModules(unittest.TestCase):
     def test_tgl_module_uefi_s3bootscript(self):
         self.run_and_test_module("common.uefi.s3bootscript", ExitCode.WARNING)
 
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/software/mock_helper.py
+++ b/tests/software/mock_helper.py
@@ -182,8 +182,6 @@ class TestHelper(Helper):
     def retpoline_enabled(self) -> bool:
         return False
 
-
-
 class ACPIHelper(TestHelper):
     """Generic ACPI emulation
 

--- a/tests/utilcmd/run_chipsec_util.py
+++ b/tests/utilcmd/run_chipsec_util.py
@@ -25,13 +25,11 @@ import chipsec.helper.replay.replayhelper as rph
 from chipsec_util import ChipsecUtil, parse_args
 import chipsec.library.logger
 
-
-
 def run_chipsec_util(csu: ChipsecUtil, util_replay_file: str) -> int:
     csu._cs.init(csu._platform, csu._pch, csu._helper, not csu._no_driver, csu._load_config, csu._ignore_platform)
     if util_replay_file:
         csu._helper.config_file = util_replay_file
-        csu._helper._load()  
+        csu._helper._load()
     comm = csu.commands[csu._cmd](csu._cmd_args, cs=csu._cs)
     comm.parse_arguments()
     comm.set_up()
@@ -60,5 +58,5 @@ def setup_run_destroy_util_get_log_output(init_replay_file: str, util_name: str,
     return retval, " ".join([call.args[0] for call in logger_calls])
 
 def setup_run_destroy_util(init_replay_file: str, util_name: str, util_args: str = "", util_replay_file: str = "") -> int:
-    retval, _ = setup_run_destroy_util_get_log_output(init_replay_file, util_name, util_args, util_replay_file)    
+    retval, _ = setup_run_destroy_util_get_log_output(init_replay_file, util_name, util_args, util_replay_file)
     return retval

--- a/tests/utilcmd/tpm_cmd/test_tpm_cmd.py
+++ b/tests/utilcmd/tpm_cmd/test_tpm_cmd.py
@@ -45,7 +45,6 @@ class TestTpmUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "tpm", "command startup 1", util_replay_file=tpm_command_startup_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
-
     def test_command_continueselftest(self) -> None:
         pass
 


### PR DESCRIPTION
This commit fixes all the E303 errors.  They were found by running "flake8 ." from the root directory.  E303 is an error defined by "pycodestyle", and has no functional impact to the source.  This is simply fixing whitespace as defined by CHIPSEC's .flake8 configuration.

background:
https://www.flake8rules.com/rules/E303.html
https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes:~:text=lines%2C%20found%200-,E303,-too%20many%20blank

versions: flake8 v7.1.2, python v3.12.6