### PR TITLE
Fix for Flake8 rule E261

### DIFF
--- a/chipsec/hal/psp.py
+++ b/chipsec/hal/psp.py
@@ -51,7 +51,7 @@ class PSP:
         #  Command ID (bits [23:16]), Status (bits [15:0]) fields and Ready flag (bit #31)
         mbox_cmd_status_value = 0
         dword_size = 4
-        num_buf = 4 # TODO: Build a table for each command
+        num_buf = 4  # TODO: Build a table for each command
         buf_size = num_buf * dword_size  # TODO: Build a table for each command
         cmd = self.PSP_CMD_GET_HSTI_STATE
 

--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -230,7 +230,7 @@ def decode_EFI_variables(efi_vars: Dict[str, List['EfiVariableType']], nvram_pth
         data: bytes
         guid: str
         attrs: int
-        for (_, _, _, data, guid, attrs) in efi_vars[name]: # Type: EfiVariableType
+        for (_, _, _, data, guid, attrs) in efi_vars[name]:  # Type: EfiVariableType
             attr_str = get_attr_string(attrs)
             var_fname = os.path.join(nvram_pth, f'{name}_{guid}_{attr_str.strip()}_{n:d}.bin')
             write_file(var_fname, data)

--- a/chipsec/helper/record/recordhelper.py
+++ b/chipsec/helper/record/recordhelper.py
@@ -87,7 +87,7 @@ class RecordHelper(Helper):
                 self._data = {}
 
     def _call_subhelper(self, *myargs):
-        fname= stack()[1][3] # gets the name of the function that called _call_subhelper
+        fname= stack()[1][3]  # gets the name of the function that called _call_subhelper
         func = getattr(self._subhelper, fname)
         err = None
         try:
@@ -105,7 +105,7 @@ class RecordHelper(Helper):
         return self._subhelper.create()
 
     def start(self) -> bool:
-        self._load() # Load file if it exists
+        self._load()  # Load file if it exists
         self.driver_loaded = True
         return self._subhelper.start()
 

--- a/chipsec/utilcmd/acpi_cmd.py
+++ b/chipsec/utilcmd/acpi_cmd.py
@@ -48,7 +48,7 @@ from chipsec.command import BaseCommand, toLoad
 class ACPICommand(BaseCommand):
     def requirements(self) -> toLoad:
         if self.func == self.acpi_table and self._file:
-            return toLoad.Nil # TODO: Fix this case. Need to update ACPI HAL to not try to auto-populate tables.
+            return toLoad.Nil  # TODO: Fix this case. Need to update ACPI HAL to not try to auto-populate tables.
         return toLoad.All
 
     def parse_arguments(self) -> None:

--- a/tests/helpers/test_windowshelper.py
+++ b/tests/helpers/test_windowshelper.py
@@ -25,7 +25,7 @@ import sys
 from chipsec.library.exceptions import UnimplementedAPIError
 from tests.helpers.helper_utils import packer
 
-DEBUG = False # Set to True to print the args passed to the driver
+DEBUG = False  # Set to True to print the args passed to the driver
 DRIVER_HANDLE = '12345'
 class pcibdf_sideeffect():
     def __init__(self, b, d, f, o) -> None:


### PR DESCRIPTION
This commit fixes all the E261 errors. They were found by running "flake8 ." from the root directory. E261 is an error defined by "pycodestyle", and has no functional impact to the source. This is simply fixing whitespace as defined by CHIPSEC's .flake8 configuration.

background:
https://www.flake8rules.com/rules/E261.html
https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes:~:text=keyword%20/%20parameter%20equals-,E261,-at%20least%20two

versions: flake8 v7.1.2, python v3.12.6