### PR TITLE
Added validation of EFI compressed data before attempting Tiano/UEFI decompression

### DIFF
--- a/chipsec/hal/uefi_compression.py
+++ b/chipsec/hal/uefi_compression.py
@@ -95,6 +95,20 @@ class UEFICompression:
     def rotate_list(self, rot_list: List[Any], n: int) -> List[Any]:
         return rot_list[n:] + rot_list[:n]
 
+    @staticmethod
+    def is_efi_compressed(efi_data: bytes) -> bool:
+        """ Check if data is EFI compressed """
+
+        size_compressed: int = int.from_bytes(efi_data[0:4], byteorder='little')
+
+        size_decompressed: int = int.from_bytes(efi_data[4:8], byteorder='little')
+
+        check_size: bool = 0 < size_compressed < size_decompressed
+
+        check_data: bool = size_compressed + 8 == len(efi_data)
+
+        return check_size and check_data
+
     def decompress_EFI_binary(self, compressed_data: bytes, compression_type: int) -> bytes:
         if compression_type in COMPRESSION_TYPES:
             if compression_type == COMPRESSION_TYPE_UNKNOWN:
@@ -105,12 +119,18 @@ class UEFICompression:
                 data = compressed_data
             elif compression_type == COMPRESSION_TYPE_TIANO and has_eficomp:
                 try:
-                    data = EfiCompressor.TianoDecompress(compressed_data)
+                    if self.is_efi_compressed(efi_data=compressed_data):
+                        data = EfiCompressor.TianoDecompress(compressed_data)
+                    else:
+                        data = b''
                 except Exception:
                     data = b''
             elif compression_type == COMPRESSION_TYPE_UEFI and has_eficomp:
                 try:
-                    data = EfiCompressor.UefiDecompress(compressed_data)
+                    if self.is_efi_compressed(efi_data=compressed_data):
+                        data = EfiCompressor.UefiDecompress(compressed_data)
+                    else:
+                        data = b''
                 except Exception:
                     data = b''
             elif compression_type in [COMPRESSION_TYPE_LZMA, COMPRESSION_TYPE_LZMAF86] and has_lzma:


### PR DESCRIPTION
At HAL, when attempting to decompress blobs using the Tiano (EFI 1.0) and/or UEFI (EFI 1.1) compression, it is possible for Chipsec to hang for a prolonged period of time with excessive memory consumption. The root of the issue appears to be the EfiCompressor module, which does not perform basic validations of the input data stream and may end up taking a lot of time, while consuming GBs of memory and producing huge garbage output files.

Since EFI compressed data streams do have a small 8-byte header at the start, which consists of 2 unsigned dwords (compressed size, decompressed size), we can validate them a bit before attempting EFI decompression via EfiCompressor module. That will avoid the vast majority of false positive detections and/or garbage decompression attempts.

In terms of sample, this UEFI image from Fujitsu causes an OOMKill error as Chipsec (i.e. EfiCompressor) consumes more than 8GB of RAM and produces a (garbage) ~3.5GB file as the result of a (false positive) ~130KB compressed EFI data stream.
- [Fujitsu_7195974de29f85c907869e39a9eca4533369d576.zip](https://github.com/user-attachments/files/19708379/Fujitsu_7195974de29f85c907869e39a9eca4533369d576.zip)