### PR TITLE
fix for flake8 rule E201

### DIFF
--- a/chipsec/helper/windows/windowshelper.py
+++ b/chipsec/helper/windows/windowshelper.py
@@ -882,7 +882,7 @@ class WindowsHelper(Helper):
     def msgbus_send_read_message(self, mcr, mcrx):
         raise UnimplementedAPIError("msgbus_send_read_message")
 
-    def msgbus_send_write_message( self, mcr, mcrx, mdr):
+    def msgbus_send_write_message(self, mcr, mcrx, mdr):
         raise UnimplementedAPIError("msgbus_send_write_message")
 
     def msgbus_send_message(self, mcr, mcrx, mdr):

--- a/chipsec/utilcmd/uefi_cmd.py
+++ b/chipsec/utilcmd/uefi_cmd.py
@@ -296,9 +296,9 @@ class UEFICommand(BaseCommand):
             return
 
         _orig_logname = self.logger.LOG_FILE_NAME
-        self.logger.set_log_file( (self.romfilename + '.nv.lst'), False)
-        parse_EFI_variables( self.romfilename, rom, authvars, self.fwtype )
-        self.logger.set_log_file( _orig_logname )
+        self.logger.set_log_file((self.romfilename + '.nv.lst'), False)
+        parse_EFI_variables(self.romfilename, rom, authvars, self.fwtype )
+        self.logger.set_log_file(_orig_logname )
 
     def nvram_auth(self):
         authvars = 1
@@ -313,9 +313,9 @@ class UEFICommand(BaseCommand):
             return
 
         _orig_logname = self.logger.LOG_FILE_NAME
-        self.logger.set_log_file( (self.romfilename + '.nv.lst'), False)
-        parse_EFI_variables( self.romfilename, rom, authvars, self.fwtype )
-        self.logger.set_log_file( _orig_logname )
+        self.logger.set_log_file((self.romfilename + '.nv.lst'), False)
+        parse_EFI_variables(self.romfilename, rom, authvars, self.fwtype )
+        self.logger.set_log_file(_orig_logname )
 
     def decode(self):
         if not os.path.exists(self.filename):
@@ -335,7 +335,7 @@ class UEFICommand(BaseCommand):
                         ftypes.append(inv_filetypes[mtype])
                     break
         decode_uefi_region(cur_dir, self.filename, self.fwtype, ftypes)
-        self.logger.set_log_file( _orig_logname )
+        self.logger.set_log_file(_orig_logname )
 
     def keys(self):
         if not os.path.exists(self.filename):


### PR DESCRIPTION
This commit fixes all the E201 errors.  They were found by running "flake8 ." from the root directory.  This is an error defined by "pycodestyle", and has no functional impact to the source.  This is simply fixing whitespace as defined by CHIPSEC's .flake8 configuration.

background:
https://www.flake8rules.com/rules/E201.html
https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes:~:text=Whitespace-,E201,-whitespace%20after%20%E2%80%98(%E2%80%99

versions: flake8 v7.2.0, python v3.12.6