### PR TITLE
fix for flake8 rule E302

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -247,6 +247,7 @@ class Chipset:
 
 _chipset = None
 
+
 def cs():
     global _chipset
 

--- a/chipsec/command.py
+++ b/chipsec/command.py
@@ -24,6 +24,7 @@ from chipsec.library.logger import logger
 from chipsec.library.defines import CHIPSET_CODE_UNKNOWN
 from chipsec.testcase import ExitCode
 
+
 class BaseCommand:
 
     def __init__(self, argv, cs=None):
@@ -58,6 +59,7 @@ class BaseCommand:
 
     def requirements(self) -> 'toLoad':
         raise NotImplementedError('sub class should overwrite the requirements() method')
+
 
 class toLoad(Enum):
     Nil = 0

--- a/chipsec/config.py
+++ b/chipsec/config.py
@@ -33,6 +33,7 @@ LOAD_COMMON = True
 
 PROC_FAMILY = {}
 
+
 class Cfg:
     def __init__(self):
         self.logger = logger()

--- a/chipsec/hal/paging.py
+++ b/chipsec/hal/paging.py
@@ -41,6 +41,7 @@ ADDR_1GB = 0xFFFFFFFFC0000000 & MAXPHYADDR
 
 TranslationType = Dict[int, Dict[str, Any]]  # TODO: TypedDict (PEP589)
 
+
 class c_translation:
 
     def __init__(self):

--- a/chipsec/hal/psp.py
+++ b/chipsec/hal/psp.py
@@ -24,6 +24,7 @@
 import time
 from chipsec.library.logger import logger
 
+
 class PSP:
     SMN_INDEX_ADDR = 0xb8
     SMN_DATA_ADDR = 0xbc

--- a/chipsec/hal/spi_jedec_ids.py
+++ b/chipsec/hal/spi_jedec_ids.py
@@ -24,6 +24,7 @@ JEDED ID : Manufacturers and Device IDs
 
 from typing import Dict
 
+
 class JEDEC_ID:
 
     MANUFACTURER: Dict[int, str] = {0xEF: 'Winbond',

--- a/chipsec/hal/tpm_eventlog.py
+++ b/chipsec/hal/tpm_eventlog.py
@@ -33,6 +33,7 @@ from chipsec.library.logger import logger
 
 EventType = TypeVar('EventType', bound='TcgPcrEvent')
 
+
 class TcgPcrEvent:
     """An Event (TPM 1.2 format) as recorded in the SML."""
 

--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -47,6 +47,7 @@ from chipsec.helper.oshelper import OsHelperError
 #
 ########################################################################################################
 
+
 def parse_script(script: bytes, log_script: bool = False) -> List['S3BOOTSCRIPT_ENTRY']:
     off = 0
     entry_type = 0
@@ -162,6 +163,7 @@ def get_attr_string(attr: int) -> str:
     if IS_VARIABLE_ATTRIBUTE(attr, EFI_VARIABLE_APPEND_WRITE):
         attr_str = f'{attr_str}AW+'
     return attr_str[:-1].lstrip()
+
 
 def print_efi_variable(offset: int, var_buf: bytes, var_header: 'EfiTableType', var_name: str, var_data: bytes, var_guid: str, var_attrib: int) -> None:
     logger().log('\n--------------------------------')

--- a/chipsec/hal/uefi_compression.py
+++ b/chipsec/hal/uefi_compression.py
@@ -24,6 +24,7 @@ from typing import List, Any
 
 from chipsec.library.logger import logger
 
+
 def show_import_error(import_name: str) -> None:
     if platform.system().lower() in ('windows', 'linux', 'darwin'):
         logger().log_error(f'Failed to import compression module "{import_name}"')

--- a/chipsec/hal/uefi_platform.py
+++ b/chipsec/hal/uefi_platform.py
@@ -110,6 +110,7 @@ VAR_IN_DELETED_TRANSITION = 0xfe  # Variable is in obsolete transition
 VAR_DELETED = 0xfd  # Variable is obsolete
 VAR_ADDED = 0x7f  # Variable has been completely added
 
+
 def IS_VARIABLE_STATE(_c: int, _Mask: int) -> bool:
     return ((((~_c) & 0xFF) & ((~_Mask) & 0xFF)) != 0)
 
@@ -165,6 +166,7 @@ VARIABLE_STORE_FORMATTED = 0x5a
 VARIABLE_STORE_HEALTHY = 0xfe
 
 NvStore = Tuple[int, int, None]
+
 
 def _getNVstore_EFI(nvram_buf: bytes, efi_type: str) -> NvStore:
     l = (-1, -1, None)
@@ -565,6 +567,7 @@ DataSize   : 0x{self.DataSize:08X}
 Unknown    : 0x{self.unknown:08X}
 """
 
+
 def _getNVstore_VSS(nvram_buf: bytes, vss_type) -> Tuple[int, int, Union[VARIABLE_STORE_HEADER_VSS, VARIABLE_STORE_HEADER_VSS2, None]]:
     if vss_type == FWType.EFI_FW_TYPE_VSS2:
         sign = VARIABLE_STORE_SIGNATURE_VSS2
@@ -782,6 +785,7 @@ def getNVstore_EVSA(nvram_buf: bytes) -> NvStore:
                 l = (fv.Offset + nvram_start, fv.Size - nvram_start, None)
         fv = NextFwVolume(nvram_buf, fv.Offset, fv.Size)
     return l
+
 
 def EFIvar_EVSA(nvram_buf: bytes) -> Dict[str, List[EfiVariableType]]:
     image_size = len(nvram_buf)

--- a/chipsec/helper/dal/dalhelper.py
+++ b/chipsec/helper/dal/dalhelper.py
@@ -400,6 +400,7 @@ class DALHelper(Helper):
     def hypercall(self, rcx, rdx, r8, r9, r10, r11, rax, rbx, rdi, rsi, xmm_buffer):
         raise UnimplementedAPIError('hypercall')
 
+
 def get_helper() -> DALHelper:
     return DALHelper()
 

--- a/chipsec/helper/efi/efihelper.py
+++ b/chipsec/helper/efi/efihelper.py
@@ -47,6 +47,7 @@ from chipsec.library.exceptions import UnimplementedAPIError
 _tools = {
 }
 
+
 class EfiHelper(Helper):
 
     def __init__(self):
@@ -382,6 +383,7 @@ class EfiHelper(Helper):
 
     def retpoline_enabled(self) -> bool:
         return False
+
 
 def get_helper() -> EfiHelper:
     return EfiHelper()

--- a/chipsec/helper/record/recordhelper.py
+++ b/chipsec/helper/record/recordhelper.py
@@ -269,6 +269,7 @@ class RecordHelper(Helper):
     def retpoline_enabled(self) -> bool:
         return self._call_subhelper()
 
+
 def get_helper():
     return RecordHelper()
 

--- a/chipsec/helper/replay/replayhelper.py
+++ b/chipsec/helper/replay/replayhelper.py
@@ -254,5 +254,6 @@ class ReplayHelper(Helper):
     def retpoline_enabled(self) -> bool:
         return self._get_element_eval("retpoline_enabled", ())
 
+
 def get_helper():
     return ReplayHelper()

--- a/chipsec/library/returncode.py
+++ b/chipsec/library/returncode.py
@@ -107,10 +107,12 @@ class ReturnCode:
         self.resetReturnCodeValues()
         return ret_value
 
+
 def get_module_ids_dictionary() -> Dict[str, str]:
     with open(os.path.join(get_main_dir(), 'chipsec', 'library', 'module_ids.json'), 'r') as module_ids_file:
         module_ids = json.loads(module_ids_file.read())
     return module_ids
+
 
 def generate_hash_id(className: str) -> int:
     generated_id = sha256(className.encode("utf-8")).hexdigest()[:7]

--- a/chipsec/modules/common/cpu/cpu_info.py
+++ b/chipsec/modules/common/cpu/cpu_info.py
@@ -51,6 +51,7 @@ from typing import List
 TAGS = [CPU]
 METADATA_TAGS = ['OPENSOURCE', 'IA', 'COMMON', 'CPU', 'CPU_INFO']
 
+
 class cpu_info(BaseModule):
     def __init__(self):
         super(cpu_info, self).__init__()

--- a/chipsec/modules/common/rom_armor.py
+++ b/chipsec/modules/common/rom_armor.py
@@ -43,6 +43,7 @@ METADATA_TAGS = ['OPENSOURCE', 'IA', 'COMMON', 'ROM_ARMOR']
 SMU_PSP_SMN_BASE = 0x3800000
 SMU_PSP_MBOX_CMD_STATUS = 0x00010970
 
+
 class rom_armor(BaseModule):
 
     def __init__(self):

--- a/chipsec/testcase.py
+++ b/chipsec/testcase.py
@@ -55,6 +55,7 @@ class ExitCode:
 
 """
 
+
 class TestCase:
     def __init__(self, name: str) -> None:
         self.name = name
@@ -229,6 +230,7 @@ class ChipsecResults:
             ret_string += ''.join(destination[result])
         return ret_string
 
+
 class LegacyResults(ChipsecResults):
     def print_summary(self, runtime: Optional[float] = None) -> None:
         summary = self.order_summary()
@@ -305,6 +307,7 @@ class LegacyResults(ChipsecResults):
             if len(summary[result]) != 0:
                 return destination[result]
         return ExitCode.OK
+
 
 class ReturnCodeResults(ChipsecResults):
     def print_summary(self, runtime: Optional[float] = None) -> None:

--- a/chipsec/utilcmd/config_cmd.py
+++ b/chipsec/utilcmd/config_cmd.py
@@ -33,6 +33,7 @@ from argparse import ArgumentParser
 from chipsec.command import BaseCommand, toLoad
 from typing import Any, Dict
 
+
 class CONFIGCommand(BaseCommand):
 
     def requirements(self) -> toLoad:

--- a/chipsec/utilcmd/deltas_cmd.py
+++ b/chipsec/utilcmd/deltas_cmd.py
@@ -36,6 +36,7 @@ from chipsec.command import BaseCommand, toLoad
 import chipsec.library.result_deltas
 from chipsec.library.options import Options
 
+
 class DeltasCommand(BaseCommand):
 
     def requirements(self) -> toLoad:

--- a/chipsec/utilcmd/smbios_cmd.py
+++ b/chipsec/utilcmd/smbios_cmd.py
@@ -34,6 +34,7 @@ from chipsec.hal.smbios import SMBIOS
 from chipsec.library.logger import print_buffer_bytes
 from chipsec.library.options import Options
 
+
 class smbios_cmd(BaseCommand):
 
     def requirements(self) -> toLoad:

--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -452,11 +452,13 @@ class ChipsecMain:
         self.logger.disable()
         return self.main_return
 
+
 def run(cli_cmd: str = '') -> int:
     cli_cmds = []
     if cli_cmd:
         cli_cmds = cli_cmd.strip().split(' ')
     return main(cli_cmds)
+
 
 def main(argv: Sequence[str] = sys.argv[1:]) -> int:
     par = parse_args(argv)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ from setuptools.command.build_ext import build_ext as _build_ext
 
 NO_DRIVER_MARKER_FILE = 'README.NO_KERNEL_DRIVER'
 
+
 def long_description():
     return open('README').read()
 

--- a/tests/hal/test_acpi.py
+++ b/tests/hal/test_acpi.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 from chipsec.hal.acpi_tables import RSDP
 from chipsec.hal.acpi import ACPI
 
+
 class TestACPI(unittest.TestCase):
     def test_apci_read_rsdp(self):
         mock_cs = MagicMock()

--- a/tests/hal/test_smbus.py
+++ b/tests/hal/test_smbus.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock, patch
 from chipsec.hal.smbus import SMBus, SMBUS_POLL_COUNT
 from chipsec.library.exceptions import IOBARNotFoundError, RegisterNotFoundError
 
+
 class TestSMBUS(unittest.TestCase):
     @patch("chipsec.hal.smbus.iobar")
     def test_get_SMBus_Base_Address_valid_base(self, mock_iobar):

--- a/tests/helpers/helper_utils.py
+++ b/tests/helpers/helper_utils.py
@@ -17,6 +17,8 @@
 #
 
 from struct import pack
+
+
 class packer():
     def __init__(self, default_size_char = 'Q') -> None:
         self.size_char = default_size_char

--- a/tests/helpers/test_linuxhelper.py
+++ b/tests/helpers/test_linuxhelper.py
@@ -29,6 +29,7 @@ from tests.helpers.helper_utils import packer
 
 # assuming 64 bit system. Will break on 32bit system. (would need to swap Q > I in pack())
 
+
 @patch('chipsec.helper.linux.linuxhelper.fcntl.ioctl')
 @patch('chipsec.helper.linux.linuxhelper.fcntl')
 class LinuxHelperTest(unittest.TestCase):

--- a/tests/helpers/test_windowshelper.py
+++ b/tests/helpers/test_windowshelper.py
@@ -27,6 +27,8 @@ from tests.helpers.helper_utils import packer
 
 DEBUG = False  # Set to True to print the args passed to the driver
 DRIVER_HANDLE = '12345'
+
+
 class pcibdf_sideeffect():
     def __init__(self, b, d, f, o) -> None:
         self.BUS = b
@@ -34,12 +36,14 @@ class pcibdf_sideeffect():
         self.FUNC = f
         self.OFF = o
 
+
 def print_args(args):
     for i in args:
         if type(i) is int:
             print(hex(i))
         else:
             print(i)
+
 
 @patch('chipsec.helper.windows.windowshelper.win32file.CreateFile')
 @patch('chipsec.helper.windows.windowshelper.win32file.DeviceIoControl')

--- a/tests/modules/run_chipsec_module.py
+++ b/tests/modules/run_chipsec_module.py
@@ -36,6 +36,7 @@ def run_chipsec_module(csm: ChipsecMain, module_replay_file: str) -> int:
     ret = csm.run_loaded_modules()
     return ret
 
+
 def setup_run_destroy_module_with_mock_logger(init_replay_file: str, module_str: str, module_args: str = "", module_replay_file: str = "") -> int:
     chipsec.library.logger._logger.remove_chipsec_logger()
     chipsec.library.logger._logger = Mock()
@@ -45,6 +46,7 @@ def setup_run_destroy_module_with_mock_logger(init_replay_file: str, module_str:
     retval = setup_run_destroy_module(init_replay_file, module_str, module_args, module_replay_file)
     chipsec.library.logger._logger = chipsec.library.logger.Logger()
     return retval
+
 
 def setup_run_destroy_module(init_replay_file: str, module_str: str, module_args: str = "", module_replay_file: str = "") -> int:
     arg_str = f" {module_args}" if module_args else ""

--- a/tests/modules/test_sgx_check.py
+++ b/tests/modules/test_sgx_check.py
@@ -27,6 +27,7 @@ from chipsec.library.returncode import ModuleResult
 from chipsec.library.file import get_main_dir
 from tests.modules.run_chipsec_module import setup_run_destroy_module
 
+
 class TestSgxCheck(unittest.TestCase):
     def test_sgx_check_warning(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "modules", "adlenumerate.json")

--- a/tests/modules/test_tgl_modules.py
+++ b/tests/modules/test_tgl_modules.py
@@ -27,6 +27,7 @@ from chipsec.library.file import get_main_dir
 from chipsec.testcase import ExitCode
 from tests.modules.run_chipsec_module import setup_run_destroy_module_with_mock_logger
 
+
 class TestTglModules(unittest.TestCase):
     def setUp(self) -> None:
         self.folder_path = os.path.join(get_main_dir(), "tests", "modules", "tgl")

--- a/tests/software/mock_helper.py
+++ b/tests/software/mock_helper.py
@@ -182,6 +182,7 @@ class TestHelper(Helper):
     def retpoline_enabled(self) -> bool:
         return False
 
+
 class ACPIHelper(TestHelper):
     """Generic ACPI emulation
 
@@ -430,6 +431,7 @@ class InvalidChipsetHelper(TestHelper):
 
     def cpuid(self, eax, ecx):
         return 0xfffff, 0, 0, 0
+
 
 class InvalidPchHelper(TestHelper):
     def read_pci_reg(self, bus, device, function, address, size):

--- a/tests/utilcmd/acpi_cmd/test_acpi_cmd.py
+++ b/tests/utilcmd/acpi_cmd/test_acpi_cmd.py
@@ -31,6 +31,7 @@ from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 from tests.software import mock_helper, util
 
+
 class TestAcpiUtilcmd(unittest.TestCase):
     def test_list(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/chipset_cmd/test_chipset_cmd.py
+++ b/tests/utilcmd/chipset_cmd/test_chipset_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestChipsetUtilcmd(unittest.TestCase):
     def test_platform(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/cmos_cmd/test_cmos_cmd.py
+++ b/tests/utilcmd/cmos_cmd/test_cmos_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from chipsec.testcase import ExitCode
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 
+
 class TestCmosUtilcmd(unittest.TestCase):
     def test_dump(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/config_cmd/test_config_cmd.py
+++ b/tests/utilcmd/config_cmd/test_config_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestConfigUtilcmd(unittest.TestCase):
     def test_show_all(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/cpu_cmd/test_cpu_cmd.py
+++ b/tests/utilcmd/cpu_cmd/test_cpu_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestCpuUtilcmd(unittest.TestCase):
     def test_cr_read(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/desc_cmd/test_desc_cmd.py
+++ b/tests/utilcmd/desc_cmd/test_desc_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestDescUtilcmd(unittest.TestCase):
     def test_gdt(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/ec_cmd/test_ec_cmd.py
+++ b/tests/utilcmd/ec_cmd/test_ec_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestEcUtilcmd(unittest.TestCase):
     def test_dump(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/igd_cmd/test_igd_cmd.py
+++ b/tests/utilcmd/igd_cmd/test_igd_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestIgdUtilcmd(unittest.TestCase):
     def test_dmaread(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/interrupts_cmd/test_interrupts_cmd.py
+++ b/tests/utilcmd/interrupts_cmd/test_interrupts_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestInterruptsUtilcmd(unittest.TestCase):
     def test_count(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/io_cmd/test_io_cmd.py
+++ b/tests/utilcmd/io_cmd/test_io_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestIoUtilcmd(unittest.TestCase):
     def test_list(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/iommu_cmd/test_iommu_cmd.py
+++ b/tests/utilcmd/iommu_cmd/test_iommu_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestIommuUtilcmd(unittest.TestCase):
     def test_list(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/mem_cmd/test_mem_cmd.py
+++ b/tests/utilcmd/mem_cmd/test_mem_cmd.py
@@ -30,6 +30,7 @@ from unittest.mock import patch
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestMemUtilCmd(unittest.TestCase):
     def test_readval(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/mmcfg_base_cmd/test_mmcfg_base_cmd.py
+++ b/tests/utilcmd/mmcfg_base_cmd/test_mmcfg_base_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestMmcfgBaseUtilcmd(unittest.TestCase):
     def test_base(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/mmcfg_cmd/test_mmcfg_cmd.py
+++ b/tests/utilcmd/mmcfg_cmd/test_mmcfg_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestMmcfgUtilcmd(unittest.TestCase):
     def test_base(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/msr_cmd/test_msr_cmd.py
+++ b/tests/utilcmd/msr_cmd/test_msr_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestMsrUtilcmd(unittest.TestCase):
     def test_read(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/run_chipsec_util.py
+++ b/tests/utilcmd/run_chipsec_util.py
@@ -25,6 +25,7 @@ import chipsec.helper.replay.replayhelper as rph
 from chipsec_util import ChipsecUtil, parse_args
 import chipsec.library.logger
 
+
 def run_chipsec_util(csu: ChipsecUtil, util_replay_file: str) -> int:
     csu._cs.init(csu._platform, csu._pch, csu._helper, not csu._no_driver, csu._load_config, csu._ignore_platform)
     if util_replay_file:
@@ -36,6 +37,7 @@ def run_chipsec_util(csu: ChipsecUtil, util_replay_file: str) -> int:
     comm.run()
     comm.tear_down()
     return comm.ExitCode
+
 
 def setup_run_destroy_util_get_log_output(init_replay_file: str, util_name: str, util_args: str = "", util_replay_file: str = "", logging_fucntions_to_capture: List = ['log']) -> Tuple[int, str]:
     chipsec.library.logger._logger.remove_chipsec_logger()
@@ -56,6 +58,7 @@ def setup_run_destroy_util_get_log_output(init_replay_file: str, util_name: str,
             logger_calls += getattr(chipsec.library.logger._logger, func).mock_calls
     chipsec.library.logger._logger = chipsec.library.logger.Logger()
     return retval, " ".join([call.args[0] for call in logger_calls])
+
 
 def setup_run_destroy_util(init_replay_file: str, util_name: str, util_args: str = "", util_replay_file: str = "") -> int:
     retval, _ = setup_run_destroy_util_get_log_output(init_replay_file, util_name, util_args, util_replay_file)

--- a/tests/utilcmd/test_template_cmd.py
+++ b/tests/utilcmd/test_template_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestTemplateUtilcmd(unittest.TestCase):
     @unittest.skip("Template, not an actual test")
     def test_command(self) -> None:

--- a/tests/utilcmd/tpm_cmd/test_tpm_cmd.py
+++ b/tests/utilcmd/tpm_cmd/test_tpm_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from chipsec.testcase import ExitCode
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 
+
 class TestTpmUtilcmd(unittest.TestCase):
     def test_parse_log(self) -> None:
         pass

--- a/tests/utilcmd/txt_cmd/test_txt_cmd.py
+++ b/tests/utilcmd/txt_cmd/test_txt_cmd.py
@@ -29,6 +29,7 @@ from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 from chipsec.testcase import ExitCode
 
+
 class TestTxtUtilcmd(unittest.TestCase):
     def test_dump(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")

--- a/tests/utilcmd/vmem_cmd/test_vmem_cmd.py
+++ b/tests/utilcmd/vmem_cmd/test_vmem_cmd.py
@@ -29,6 +29,7 @@ from unittest.mock import patch
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util_get_log_output
 from chipsec.testcase import ExitCode
 
+
 class TestVmemUtilCmd(unittest.TestCase):
     def test_readval(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")


### PR DESCRIPTION
This commit fixes all the E302 errors.  They were found by running "flake8 ." from the root directory.  This is an error defined by "pycodestyle", and has no functional impact to the source.  This is simply fixing whitespace as defined by CHIPSEC's .flake8 configuration.

background:
https://www.flake8rules.com/rules/E302.html
https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes:~:text=line%2C%20found%200-,E302,-expected%202%20blank

versions: flake8 v7.2.0, python v3.12.6