### PR TITLE
dev/chipsec2 - cfg platform object structure usage update

### DIFF
--- a/chipsec/config.py
+++ b/chipsec/config.py
@@ -518,10 +518,23 @@ class Cfg:
             sname = name
         return scope_name(*(sname.split('.', 3)))
     
-    def get_objlist(self, objdict:dict, name:str):
+    def convert_platform_scope(self, scope, name):
+        if scope:
+            sname = scope + '.' + name
+        else:
+            sname = name
+        return sname.split('.')
+
+    
+    def get_objlist(self, name:str):
         scope = self.get_scope(name)
-        fullscope = self.convert_internal_scope(scope, name)
-        return self.get_objlist_from_scope(objdict, fullscope)
+        fullscope = self.convert_platform_scope(scope, name)
+        return self.platform.get_matches_from_scope(fullscope)
+    
+    def get_reglist(self, name:str):
+        scope = self.get_scope(name)
+        fullscope = self.convert_platform_scope(scope, name)
+        return self.platform.get_register_matches_from_scope(fullscope)
 
     def __add_obj_to_regdef(self, reg_def, obj):
         if isinstance(obj, Iterable):

--- a/chipsec/hal/common/memrange.py
+++ b/chipsec/hal/common/memrange.py
@@ -62,7 +62,7 @@ class MemRange(HALBase):
     
     def get_def(self, range_name: str) -> Dict[str, Any]:
         '''Return address access of a MEM register'''
-        ranges = self.cs.Cfg.get_objlist(self.cs.Cfg.MEMORY_RANGES, range_name)
+        ranges = self.cs.Cfg.get_objlist(range_name)
         if ranges:
             return ranges[0]
         return None

--- a/chipsec/hal/common/physmem.py
+++ b/chipsec/hal/common/physmem.py
@@ -172,7 +172,7 @@ class Memory(HALBase):
     
     def get_def(self, range_name: str) -> Dict[str, Any]:
         '''Return address access of a MEM register'''
-        ranges = self.cs.Cfg.get_objlist(self.cs.Cfg.MEMORY_RANGES, range_name)
+        ranges = self.cs.Cfg.get_objlist(range_name)
         if ranges:
             return ranges[0]
         return None

--- a/chipsec/library/device.py
+++ b/chipsec/library/device.py
@@ -37,7 +37,7 @@ class Device:
         return None
         
     def get_list_by_name(self, device_name: str):
-        return self.cs.Cfg.platform.get_matches_from_scope(device_name)
+        return [ip.obj for ip in self.cs.Cfg.platform.get_matches_from_scope(device_name)]
 
     # def get_first_bus(self, device: dict) -> int:
     #     """Retrieves first value in bus list for PCI device"""
@@ -122,12 +122,12 @@ class Device:
         #         logger().log_important(f"No bus value defined for device '{device_name}'")
         # return buses
 
-    def switch_def(self, target_device: str, source_device: str) -> None:
-        """Changes bus, device, and function values of PCI device"""
-        (b, d, f) = self.get_BDF(source_device)
-        self.cs.Cfg.CONFIG_PCI[target_device]['bus'] = b
-        self.cs.Cfg.CONFIG_PCI[target_device]['dev'] = d
-        self.cs.Cfg.CONFIG_PCI[target_device]['fun'] = f
+    # def switch_def(self, target_device: str, source_device: str) -> None:
+    #     """Changes bus, device, and function values of PCI device"""
+    #     (b, d, f) = self.get_BDF(source_device)
+    #     self.cs.Cfg.CONFIG_PCI[target_device]['bus'] = b
+    #     self.cs.Cfg.CONFIG_PCI[target_device]['dev'] = d
+    #     self.cs.Cfg.CONFIG_PCI[target_device]['fun'] = f
 
     def get_IO_space(self, io_name: str) -> Tuple[Optional[int], Optional[int]]:
         """Retrieves BAR values for given IO range"""

--- a/chipsec/library/device.py
+++ b/chipsec/library/device.py
@@ -37,7 +37,7 @@ class Device:
         return None
         
     def get_list_by_name(self, device_name: str):
-        return self.cs.Cfg.get_objlist(self.cs.Cfg.CONFIG_PCI, device_name)
+        return self.cs.Cfg.platform.get_matches_from_scope(device_name)
 
     # def get_first_bus(self, device: dict) -> int:
     #     """Retrieves first value in bus list for PCI device"""

--- a/chipsec/library/exceptions.py
+++ b/chipsec/library/exceptions.py
@@ -116,11 +116,12 @@ class PortIORuntimeError (RuntimeError):
 class IOBARRuntimeError (RuntimeError):
     pass
 
-
-class IOBARNotFoundError (RuntimeError):
+class BARNotFoundError (RuntimeError):
+    pass
+class IOBARNotFoundError (BARNotFoundError):
     pass
 
-class MMIOBARNotFoundError (RuntimeError):
+class MMIOBARNotFoundError (BARNotFoundError):
     pass
 
 class IOMMUError (RuntimeError):

--- a/chipsec/library/register.py
+++ b/chipsec/library/register.py
@@ -67,7 +67,7 @@ class Register:
 
     def is_defined(self, reg_name: str) -> bool:
         """Checks if register is defined in the XML config"""
-        return len(self.cs.Cfg.get_objlist(self.cs.Cfg.REGISTERS, reg_name)) > 0
+        return len(self.cs.Cfg.get_reglist(reg_name)) > 0
 
     def _get_pci_def(
         self, reg_def: Dict[str, Any], vid: str, dev_name: str
@@ -125,20 +125,20 @@ class Register:
 
     # rework any call to this function
     def get_list_by_name(self, reg_name: str) -> 'ObjList':
-        return self.cs.Cfg.get_objlist(self.cs.Cfg.REGISTERS, reg_name)
+        return self.cs.Cfg.get_reglist(reg_name)
 
-    def get_list_by_name_without_scope(self, reg_name: str) -> 'ObjList':
-        return self.cs.Cfg.get_objlist(self.cs.Cfg.REGISTERS, '*.*.' + reg_name)
+    def get_list_by_name_without_scope(self, reg_name: str) -> 'ObjList': # TODO: rewrite so that it looks at all registers in platform structure. Should use a new function in platform. 
+        return self.cs.Cfg.get_reglist('*.*.' + reg_name)
 
     def get_instance_by_name(self, reg_name: str, instance: 'PCIObj'):
-        for reg_obj in self.cs.Cfg.get_objlist(self.cs.Cfg.REGISTERS, reg_name):
+        for reg_obj in self.cs.Cfg.get_reglist(reg_name):
             if reg_obj.get_instance() == instance:
                 return reg_obj
         return None  # TODO Change to null register object
 
     def has_field(self, reg_name: str, field_name: str) -> bool:
         """Checks if the register has specific field"""
-        reg_defs = self.cs.Cfg.get_objlist(self.cs.Cfg.REGISTERS, reg_name)
+        reg_defs = self.cs.Cfg.get_reglist(reg_name)
         for reg_def in reg_defs:
             try:
                 return field_name in reg_def.fields
@@ -223,6 +223,7 @@ class BaseConfigRegisterHelper(BaseConfigHelper):
     def __init__(self, cfg_obj):
         super(BaseConfigRegisterHelper, self).__init__(cfg_obj)
         self.name = cfg_obj['name']
+        # self.full_name = cfg_obj['full_name']
         self.instance = cfg_obj['instance'] if 'instance' in cfg_obj else None
         self.value = None
         self.desc = cfg_obj['desc']

--- a/chipsec/library/register.py
+++ b/chipsec/library/register.py
@@ -27,7 +27,7 @@ from typing import Any, Dict, List, Optional
 from chipsec.parsers import BaseConfigHelper
 from chipsec.library.logger import logger
 from chipsec.library.bits import set_bits, get_bits, make_mask
-from chipsec.library.exceptions import CSReadError, UninitializedRegisterError
+from chipsec.library.exceptions import CSReadError, RegisterNotFoundError, UninitializedRegisterError
 from chipsec.library.registers.io import IO
 from chipsec.library.registers.iobar import IOBar
 from chipsec.library.registers.memory import Memory
@@ -131,9 +131,12 @@ class Register:
         return self.cs.Cfg.get_reglist('*.*.' + reg_name)
 
     def get_instance_by_name(self, reg_name: str, instance: 'PCIObj'):
-        for reg_obj in self.cs.Cfg.get_reglist(reg_name):
-            if reg_obj.get_instance() == instance:
-                return reg_obj
+        try:
+            for reg_obj in self.cs.Cfg.get_reglist(reg_name):
+                if reg_obj.get_instance() == instance:
+                    return reg_obj
+        except RegisterNotFoundError:
+            logger().log_error(f'Register {reg_name} not found')
         return None  # TODO Change to null register object
 
     def has_field(self, reg_name: str, field_name: str) -> bool:

--- a/chipsec/modules/common/cpu/cpu_info.py
+++ b/chipsec/modules/common/cpu/cpu_info.py
@@ -55,7 +55,7 @@ class cpu_info(BaseModule):
     def __init__(self):
         super(cpu_info, self).__init__()
         self.cs.set_scope({
-            "IA32_BIOS_SIGN_ID": "8086.MSR.IA32_BIOS_SIGN_ID",
+            "IA32_BIOS_SIGN_ID": "8086.MSR",
         })
         self.result.url = 'https://chipsec.github.io/modules/chipsec.modules.common.cpu.cpu_info.html'
 

--- a/chipsec/modules/common/debugenabled.py
+++ b/chipsec/modules/common/debugenabled.py
@@ -56,8 +56,8 @@ class debugenabled(BaseModule):
     def __init__(self):
         BaseModule.__init__(self)
         self.cs.set_scope({
-            "ECTRL": "8086.DCI.ECTRL",
-            "IA32_DEBUG_INTERFACE": "8086.MSR.IA32_DEBUG_INTERFACE"
+            "ECTRL": "8086.DCI",
+            "IA32_DEBUG_INTERFACE": "8086.MSR"
         })
         self.is_enable_set = False
         self.is_debug_set = False

--- a/chipsec/modules/common/remap.py
+++ b/chipsec/modules/common/remap.py
@@ -66,8 +66,8 @@ class remap(BaseModule):
             'MSR_BIOS_DONE': "8086.MSR",
             'IA_UNTRUSTED': "8086.MSR",
             'IBECC_ACTIVATE': "8086.HOSTCTL*",
-            'REMAPBASE': "8086.HOSTCTL*",
-            'REMAPLIMIT': "8086.HOSTCTL*"
+            'REMAPBASE': "8086.HOSTCTL.MCHBAR*",
+            'REMAPLIMIT': "8086.HOSTCTL.MCHBAR*"
         })
 
     def is_supported(self) -> bool:
@@ -103,7 +103,8 @@ class remap(BaseModule):
         # tmp = self.cs.Cfg.platform.get_matches_from_scope('8086.HOSTCTL.MCHBAR*')
         # tmp2 = ObjList(tmp[0].REMAPBASE + tmp[1].REMAPBASE)
         # tmp3 = self.cs.Cfg.platform.get_matches_from_scope('8086.HOSTCTL.MCHBAR*.REMAPBASE')
-        # tmp4 = self.cs.Cfg.platform.get_register_matches_from_scope('8086.HOSTCTL.MCHBAR*.REMAPBASE')
+        # tmp4 = self.cs.Cfg.get_objlist('8086.HOSTCTL.MCHBAR*.REMAPBASE')
+        # tmp5 = self.cs.Cfg.get_reglist('8086.HOSTCTL.MCHBAR*.REMAPBASE')
         remapbase_reg = self.cs.register.get_list_by_name('REMAPBASE')[0]
         remapbase = remapbase_reg.read()
         remaplimit_reg = self.cs.register.get_list_by_name('REMAPLIMIT')[0]

--- a/chipsec/modules/common/rtclock.py
+++ b/chipsec/modules/common/rtclock.py
@@ -59,7 +59,7 @@ class rtclock(BaseModule):
         self.test_offset = 0x38
         self.test_value = 0xAA
         self.cs.set_scope({
-            "RC": "8086.RTC.RC",
+            "RC": "8086.RTC",
         })
 
     def is_supported(self) -> bool:

--- a/chipsec/modules/common/smrr.py
+++ b/chipsec/modules/common/smrr.py
@@ -64,9 +64,9 @@ class smrr(BaseModule):
     def __init__(self):
         BaseModule.__init__(self)
         self.cs.set_scope({
-            'MTRRCAP': '8086.MSR.MTRRCAP',
-            'IA32_SMRR_PHYSBASE': '8086.MSR.IA32_SMRR_PHYSBASE',
-            'IA32_SMRR_PHYSMASK': '8086.MSR.IA32_SMRR_PHYSMASK',
+            'MTRRCAP': '8086.MSR',
+            'IA32_SMRR_PHYSBASE': '8086.MSR',
+            'IA32_SMRR_PHYSMASK': '8086.MSR',
         })
 
     def is_supported(self) -> bool:

--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -277,6 +277,7 @@ class ChipsecMain:
             run_it, is_archived = self.verify_module_tags(modx)
             if run_it:
                 result = modx.run(module_argv)
+                self._cs.clear_scope()
             else:
                 modx.get_module_object()
                 if is_archived:
@@ -285,6 +286,7 @@ class ChipsecMain:
                 else:
                     modx.mod_obj.result.setStatusBit(modx.mod_obj.result.status.NOT_APPLICABLE)
                     res = ModuleResult.NOTAPPLICABLE
+                self._cs.clear_scope()
                 return modx.mod_obj.result.getReturnCode(res, False)
         except BaseException as msg:
             if self.logger.DEBUG:


### PR DESCRIPTION
Note: with how the registers are retrieved now, if the scope has eg `"BC": "8086.SPI.BC"` it will fail because it will be looking for `"8086.SPI.BC.BC"` which doesn't exist. So it will need to be `"BC": "8086.SPI"`

Also note, the scopes are now cleared after each module is executed.