### PR TITLE
fix for flake8 rule E305

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -245,6 +245,7 @@ class Chipset:
         old_log_state = (logger().HAL, logger().DEBUG, logger().VERBOSE)
         return old_log_state
 
+
 _chipset = None
 
 

--- a/chipsec/hal/uefi_compression.py
+++ b/chipsec/hal/uefi_compression.py
@@ -29,6 +29,7 @@ def show_import_error(import_name: str) -> None:
     if platform.system().lower() in ('windows', 'linux', 'darwin'):
         logger().log_error(f'Failed to import compression module "{import_name}"')
 
+
 try:
     import brotli
 

--- a/chipsec/utilcmd/cmos_cmd.py
+++ b/chipsec/utilcmd/cmos_cmd.py
@@ -92,4 +92,5 @@ class CMOSCommand(BaseCommand):
         self.logger.log(f'[CHIPSEC] Writing CMOS high byte 0x{self.offset:X} <- 0x{self.value:X}')
         self._cmos.write_cmos_high(self.offset, self.value)
 
+
 commands = {'cmos': CMOSCommand}

--- a/chipsec/utilcmd/ec_cmd.py
+++ b/chipsec/utilcmd/ec_cmd.py
@@ -126,4 +126,5 @@ class ECCommand(BaseCommand):
             mem = [self._ec.read_idx(off) for off in range(0x10000)]
             print_buffer_bytes(mem)
 
+
 commands = {'ec': ECCommand}

--- a/chipsec/utilcmd/io_cmd.py
+++ b/chipsec/utilcmd/io_cmd.py
@@ -101,4 +101,5 @@ class PortIOCommand(BaseCommand):
             f'[CHIPSEC] OUT 0x{self._port:04X} <- 0x{self._value:08X} (size = 0x{self._width:02X})')
         return
 
+
 commands = {'io': PortIOCommand}

--- a/chipsec/utilcmd/mem_cmd.py
+++ b/chipsec/utilcmd/mem_cmd.py
@@ -208,4 +208,5 @@ class MemCommand(BaseCommand):
         elif 0x4 == width:
             self.cs.mem.write_physical_mem_dword(self.phys_address, self.write_data)
 
+
 commands = {'mem': MemCommand}

--- a/chipsec/utilcmd/mmcfg_base_cmd.py
+++ b/chipsec/utilcmd/mmcfg_base_cmd.py
@@ -52,4 +52,5 @@ class MMCfgBaseCommand(BaseCommand):
             self.logger.log(f'[CHIPSEC] Memory Mapped Config Size: 0x{pciexbar[1]:016X}')
             self.logger.log('')
 
+
 commands = {'mmcfg_base': MMCfgBaseCommand}

--- a/chipsec/utilcmd/mmio_cmd.py
+++ b/chipsec/utilcmd/mmio_cmd.py
@@ -169,4 +169,5 @@ class MMIOCommand(BaseCommand):
             self._mmio.write_MMIO_reg_dword(self.base, self.offset, self.value & 0xFFFFFFFF)
             self._mmio.write_MMIO_reg_dword(self.base, self.offset + 4, (self.value >> 32) & 0xFFFFFFFF)
 
+
 commands = {'mmio': MMIOCommand}

--- a/chipsec/utilcmd/module_id_cmd.py
+++ b/chipsec/utilcmd/module_id_cmd.py
@@ -71,4 +71,5 @@ class ModuleIdCommand(BaseCommand):
         except IndexError:
             self.logger.log(f'Could not find {self.module_id}\n')
 
+
 commands = {'id': ModuleIdCommand}

--- a/chipsec/utilcmd/reg_cmd.py
+++ b/chipsec/utilcmd/reg_cmd.py
@@ -121,4 +121,5 @@ class RegisterCommand(BaseCommand):
         else:
             self.logger.log_error("[CHIPSEC] Control '{}' isn't defined".format(self.control_name))
 
+
 commands = {'reg': RegisterCommand}

--- a/chipsec/utilcmd/spi_cmd.py
+++ b/chipsec/utilcmd/spi_cmd.py
@@ -174,4 +174,5 @@ class SPICommand(BaseCommand):
             else:
                 self.logger.log(' JEDEC ID command is not supported')
 
+
 commands = {'spi': SPICommand}

--- a/chipsec/utilcmd/tpm_cmd.py
+++ b/chipsec/utilcmd/tpm_cmd.py
@@ -103,4 +103,5 @@ class TPMCommand(BaseCommand):
         except Exception:
             self.ExitCode = ExitCode.ERROR
 
+
 commands = {'tpm': TPMCommand}

--- a/chipsec/utilcmd/txt_cmd.py
+++ b/chipsec/utilcmd/txt_cmd.py
@@ -171,4 +171,5 @@ class TXTCommand(BaseCommand):
         except Exception:
             self.ExitCode = ExitCode.ERROR
 
+
 commands = {'txt': TXTCommand}

--- a/tests/modules/test_cpu_info.py
+++ b/tests/modules/test_cpu_info.py
@@ -40,5 +40,6 @@ class TestCpuInfo(unittest.TestCase):
         result = cpu_info.is_supported(mock_self)
         self.assertTrue(result)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/modules/test_tgl_modules.py
+++ b/tests/modules/test_tgl_modules.py
@@ -121,5 +121,6 @@ class TestTglModules(unittest.TestCase):
     def test_tgl_module_uefi_s3bootscript(self):
         self.run_and_test_module("common.uefi.s3bootscript", ExitCode.WARNING)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/acpi_cmd/test_acpi_cmd.py
+++ b/tests/utilcmd/acpi_cmd/test_acpi_cmd.py
@@ -250,5 +250,6 @@ class TestACPIChipsecUtil(util.TestChipsecUtil):
         self.assertIn(b"OEMSS2", self.log)
         self.assertIn(b"OEMSS3", self.log)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/chipset_cmd/test_chipset_cmd.py
+++ b/tests/utilcmd/chipset_cmd/test_chipset_cmd.py
@@ -37,5 +37,6 @@ class TestChipsetUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "platform", util_replay_file=chipset_dump_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/cmos_cmd/test_cmos_cmd.py
+++ b/tests/utilcmd/cmos_cmd/test_cmos_cmd.py
@@ -61,5 +61,6 @@ class TestCmosUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "cmos", "writeh 0x0 0xCC", util_replay_file=cmos_writeh_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/config_cmd/test_config_cmd.py
+++ b/tests/utilcmd/config_cmd/test_config_cmd.py
@@ -43,5 +43,6 @@ class TestConfigUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "config", "show MMIO_BARS", util_replay_file=config_cmd_show_all_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/cpu_cmd/test_cpu_cmd.py
+++ b/tests/utilcmd/cpu_cmd/test_cpu_cmd.py
@@ -44,5 +44,6 @@ class TestCpuUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "cpu", "info", util_replay_file=cpu_info_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/desc_cmd/test_desc_cmd.py
+++ b/tests/utilcmd/desc_cmd/test_desc_cmd.py
@@ -43,5 +43,6 @@ class TestDescUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "idt", "0", util_replay_file=desc_idt_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/igd_cmd/test_igd_cmd.py
+++ b/tests/utilcmd/igd_cmd/test_igd_cmd.py
@@ -43,5 +43,6 @@ class TestIgdUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "igd", "dmawrite 0x2217F1000 0x4 deadbeef", util_replay_file=igd_dump_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/interrupts_cmd/test_interrupts_cmd.py
+++ b/tests/utilcmd/interrupts_cmd/test_interrupts_cmd.py
@@ -55,5 +55,6 @@ class TestInterruptsUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "nmi", "", util_replay_file=interrupts_dump_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/io_cmd/test_io_cmd.py
+++ b/tests/utilcmd/io_cmd/test_io_cmd.py
@@ -49,5 +49,6 @@ class TestIoUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "io", "write 0x430 1 0x0", util_replay_file=io_dump_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/iommu_cmd/test_iommu_cmd.py
+++ b/tests/utilcmd/iommu_cmd/test_iommu_cmd.py
@@ -67,5 +67,6 @@ class TestIommuUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "iommu", "status GFXVTD", util_replay_file=iommu_dump_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/mmcfg_base_cmd/test_mmcfg_base_cmd.py
+++ b/tests/utilcmd/mmcfg_base_cmd/test_mmcfg_base_cmd.py
@@ -37,5 +37,6 @@ class TestMmcfgBaseUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "mmcfg", "base", util_replay_file=mmcfg_base_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/mmcfg_cmd/test_mmcfg_cmd.py
+++ b/tests/utilcmd/mmcfg_cmd/test_mmcfg_cmd.py
@@ -55,5 +55,6 @@ class TestMmcfgUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "mmcfg", "write 0 0 0 0x200 1 0x1A", util_replay_file=mmcfg_write_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/msr_cmd/test_msr_cmd.py
+++ b/tests/utilcmd/msr_cmd/test_msr_cmd.py
@@ -49,5 +49,6 @@ class TestMsrUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "msr", "0x8B 0x0 0x0 0x0", util_replay_file=msr_write_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/test_template_cmd.py
+++ b/tests/utilcmd/test_template_cmd.py
@@ -38,5 +38,6 @@ class TestTemplateUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "template", "command", util_replay_file=template_dump_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utilcmd/txt_cmd/test_txt_cmd.py
+++ b/tests/utilcmd/txt_cmd/test_txt_cmd.py
@@ -43,5 +43,6 @@ class TestTxtUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "txt", "state", util_replay_file=txt_state_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit fixes all the E305 errors.  They were found by running "flake8 ." from the root directory.  This is an error defined by "pycodestyle", and has no functional impact to the source.  This is simply fixing whitespace as defined by CHIPSEC's .flake8 configuration.

background:
https://www.flake8rules.com/rules/E305.html
https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes:~:text=after%20function%20decorator-,E305,-expected%202%20blank

versions: flake8 v7.2.0, python v3.12.6