### PR TITLE
fix for flake8 rule E111

### DIFF
--- a/chipsec/modules/tools/smm/smm_ptr.py
+++ b/chipsec/modules/tools/smm/smm_ptr.py
@@ -232,14 +232,14 @@ class smi_stats:
     # Combines the statistics of the two data sets using parallel variance computation
     #
     def combine(self, partial):
-         self.outliers += partial.outliers
-         total_count = self.count + partial.count
-         difference = partial.mean - self.mean
-         self.mean = (self.mean * self.count + partial.mean * partial.count) / total_count
-         self.m2 += partial.m2 + difference**2 * self.count * partial.count / total_count
-         self.count = total_count
-         variance = self.m2 / self.count
-         self.stdev = math.sqrt(variance)
+        self.outliers += partial.outliers
+        total_count = self.count + partial.count
+        difference = partial.mean - self.mean
+        self.mean = (self.mean * self.count + partial.mean * partial.count) / total_count
+        self.m2 += partial.m2 + difference**2 * self.count * partial.count / total_count
+        self.count = total_count
+        variance = self.m2 / self.count
+        self.stdev = math.sqrt(variance)
 
 
 class scan_track:


### PR DESCRIPTION
This commit fixes all the E111 errors.  They were found by running "flake8 ." from the root directory.  This is an error defined by "pycodestyle", and has no functional impact to the source.  This is simply fixing whitespace as defined by CHIPSEC's .flake8 configuration.

background:
https://www.flake8rules.com/rules/E111.html
https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes:~:text=spaces%20and%20tabs-,E111,-indentation%20is%20not

versions: flake8 v7.2.0, python v3.12.6