### PR TITLE
fix for flake8 rule E251

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -109,7 +109,7 @@ class Chipset:
         return _cpuid.get_proc_info()
 
     @classmethod
-    def basic_init_with_helper(cls, helper = None):
+    def basic_init_with_helper(cls, helper=None):
         _cs = cls()
         _cs.load_helper(helper)
         _cs.start_helper()

--- a/chipsec/hal/mmio.py
+++ b/chipsec/hal/mmio.py
@@ -208,7 +208,7 @@ class MMIO(hal_base.HALBase):
             if 'base_field' in bar:
                 base_field = bar['base_field']
                 try:
-                    bar_value = self.cs.register.read(bar_reg, bus = _bus)
+                    bar_value = self.cs.register.read(bar_reg, bus=_bus)
                     base = self.cs.register.get_field(bar_reg, bar_value, base_field, preserve)
                 except CSReadError:
                     base = 0

--- a/chipsec/modules/tools/vmm/cpuid_fuzz.py
+++ b/chipsec/modules/tools/vmm/cpuid_fuzz.py
@@ -88,7 +88,7 @@ class cpuid_fuzz (BaseModule):
     def __init__(self):
         BaseModule.__init__(self)
 
-    def fuzz_CPUID(self, eax_start, random_order = False):
+    def fuzz_CPUID(self, eax_start, random_order=False):
         eax_range = _NO_EAX_TO_FUZZ
         eax_end = eax_start + eax_range
         self.logger.log(f'[*] Fuzzing CPUID with EAX in range 0x{eax_start:08X}:0x{eax_end:08X}..')

--- a/tests/helpers/helper_utils.py
+++ b/tests/helpers/helper_utils.py
@@ -20,7 +20,7 @@ from struct import pack
 
 
 class packer():
-    def __init__(self, default_size_char = 'Q') -> None:
+    def __init__(self, default_size_char='Q') -> None:
         self.size_char = default_size_char
 
     def custom_pack(self, num_of_chunks: int, expected_value: int, expected_value_index: int = 0) -> bytes:


### PR DESCRIPTION
This commit fixes all the E251 errors.  They were found by running "flake8 ." from the root directory.  This is an error defined by "pycodestyle", and has no functional impact to the source.  This is simply fixing whitespace as defined by CHIPSEC's .flake8 configuration.

background:
https://www.flake8rules.com/rules/E251.html
https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes:~:text=tab%20after%20%E2%80%98%2C%E2%80%99-,E251,-unexpected%20spaces%20around

tool versions: flake8 v7.2.0, python v3.12.6