### PR TITLE
remove unused local var "scriptInsideSMRAM"

### DIFF
--- a/chipsec/modules/common/uefi/s3bootscript.py
+++ b/chipsec/modules/common/uefi/s3bootscript.py
@@ -139,7 +139,6 @@ class s3bootscript(BaseModule):
 
     def check_s3_bootscripts(self, bsaddress=None) -> int:
         res = 0
-        scriptInsideSMRAM = False
 
         if bsaddress:
             bootscript_PAs = [bsaddress]


### PR DESCRIPTION
The function check_s3_bootscripts() declares a local variable scriptInsideSMRAM, but then never uses it.  According to Python's LEGB rule, this variable has scope type "Local", which means it is only accessible within that function.  Therefore, safe to delete this unused local variable.