### PR TITLE
fix for flake8 rule E222

### DIFF
--- a/chipsec/hal/paging.py
+++ b/chipsec/hal/paging.py
@@ -136,7 +136,7 @@ class c_reverse_translation:
                 self.reverse_translation[phys] = []
             self.reverse_translation[phys].append({'addr': virt, 'size': size, 'attr': attr})
 
-    def get_reverse_translation(self, addr: int) ->  List[Dict[str, Any]]:
+    def get_reverse_translation(self, addr: int) -> List[Dict[str, Any]]:
         ADDR_4KB = 0xFFFFFFFFFFFFF000
         addr &= ADDR_4KB
         return self.reverse_translation[addr] if addr in self.reverse_translation else []
@@ -492,7 +492,7 @@ class c_extended_page_tables(c_4level_page_tables):
         self.BIGPAGE = {'mask': 0x1, 'offset': 7}
         self.canonical_msb = 63
 
-    def is_present(self, entry: int) ->  bool:
+    def is_present(self, entry: int) -> bool:
         return self.get_field(entry, self.XWR) != 0
 
     def is_bigpage(self, entry: int) -> bool:

--- a/chipsec/hal/uefi.py
+++ b/chipsec/hal/uefi.py
@@ -183,7 +183,7 @@ def print_efi_variable(offset: int, var_buf: bytes, var_header: 'EfiTableType', 
             if uefi_platform.IS_VARIABLE_STATE(state, uefi_platform.VAR_IN_DELETED_TRANSITION):
                 state_str = f'{state_str} IN_DELETED_TRANSITION +'
             if uefi_platform.IS_VARIABLE_STATE(state, uefi_platform.VAR_DELETED):
-                state_str =  f'{state_str} DELETED +'
+                state_str = f'{state_str} DELETED +'
             if uefi_platform.IS_VARIABLE_STATE(state, uefi_platform.VAR_ADDED):
                 state_str = f'{state_str} ADDED +'
             logger().log(state_str)

--- a/chipsec/helper/efi/efihelper.py
+++ b/chipsec/helper/efi/efihelper.py
@@ -279,7 +279,7 @@ class EfiHelper(Helper):
             if logger().VERBOSE:
                 logger().log_important(f'Setting attributes to: {attrs:04X}')
         elif isinstance(attrs, bytes):
-            attrs =  struct.unpack("L", attrs)[0]
+            attrs = struct.unpack("L", attrs)[0]
 
         (Status, buffer_size, guidstr) = edk2.SetVariable(name, guidstr, int(attrs), buffer, buffer_size)
 

--- a/chipsec/modules/tools/smm/smm_ptr.py
+++ b/chipsec/modules/tools/smm/smm_ptr.py
@@ -809,7 +809,7 @@ class smm_ptr(BaseModule):
             elif test_mode in ['fuzz', 'fuzzmore']:
                 bad_ptr_cnt, _ = self.test_fuzz(thread_id, smic_start, smic_end, _addr, _addr1)
             elif test_mode in ['scan']:
-                scan_mode =  True
+                scan_mode = True
                 scan = None
                 bad_ptr_cnt, scan = self.test_fuzz(thread_id, smic_start, smic_end, _addr, _addr1, True)
         except BadSMIDetected:

--- a/chipsec/testcase.py
+++ b/chipsec/testcase.py
@@ -70,9 +70,9 @@ class TestCase:
 
     def get_fields(self) -> Dict[str, str]:
         try:
-            result_code =  f'0x{self.result_code:016X}'
+            result_code = f'0x{self.result_code:016X}'
         except ValueError:
-            result_code =  f'0x{self.result_code.value:016X}'
+            result_code = f'0x{self.result_code.value:016X}'
         return {'name': self.name, 'output': self.output, 'result': self.result, 'code': result_code}
 
     def start_module(self) -> None:

--- a/chipsec/utilcmd/deltas_cmd.py
+++ b/chipsec/utilcmd/deltas_cmd.py
@@ -46,7 +46,7 @@ class DeltasCommand(BaseCommand):
         options = Options()
         try:
             default_format = options.get_section_data('Util_Config', 'log_output_deltas_format')
-            default_out_file =  options.get_section_data('Util_Config', 'deltas_output_file')
+            default_out_file = options.get_section_data('Util_Config', 'deltas_output_file')
         except Exception:
             default_format = 'JSON'
             default_out_file = 'log_output_deltas.json'


### PR DESCRIPTION
This commit fixes all the E222 errors.  They were found by running "flake8 ." from the root directory.  This is an error defined by "pycodestyle", and has no functional impact to the source.  This is simply fixing whitespace as defined by CHIPSEC's .flake8 configuration.

background:
https://www.flake8rules.com/rules/E222.html
https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes:~:text=spaces%20before%20operator-,E222,-multiple%20spaces%20after

tool versions: flake8 v7.2.0, python v3.12.6