### PR TITLE
fix for flake8 rule E301

### DIFF
--- a/chipsec/chipset.py
+++ b/chipsec/chipset.py
@@ -114,6 +114,7 @@ class Chipset:
         _cs.load_helper(helper)
         _cs.start_helper()
         return _cs
+
     def init(self, platform_code, req_pch_code, helper_name=None, start_helper=True, load_config=True, ignore_platform=False):
         self.load_config = load_config
         _unknown_proc = True

--- a/chipsec/hal/acpi.py
+++ b/chipsec/hal/acpi.py
@@ -321,6 +321,7 @@ class ACPI(HALBase):
         return (rsdp_pa, rsdp)
 
     RsdtXsdt = Union[acpi_tables.RSDT, acpi_tables.XSDT]
+
     #
     # Retrieves System Description Table (RSDT or XSDT) either from RSDP or using OS API
     #

--- a/chipsec/hal/cpu.py
+++ b/chipsec/hal/cpu.py
@@ -234,6 +234,7 @@ class CPU(hal_base.HALBase):
             avalid = self.cs.register.get_field('SMMMASK', smmmask_msr_reg, 'AVALID')
             tvalid = self.cs.register.get_field('SMMMASK', smmmask_msr_reg, 'TVALID')
             return (1 == avalid and 1 == tvalid)
+
     #
     # Dump CPU page tables at specified physical base of paging-directory hierarchy (CR3)
     #

--- a/chipsec/hal/msr.py
+++ b/chipsec/hal/msr.py
@@ -78,7 +78,6 @@ class Msr:
         core_count = self.cs.register.read_field("IA32_MSR_CORE_THREAD_COUNT", "Core_Count")
         return core_count
 
-
 ##########################################################################################################
 #
 # Read/Write CPU MSRs
@@ -122,7 +121,6 @@ class Msr:
         (limit, base, pa) = self.get_Desc_Table_Register(cpu_thread_id, DESCRIPTOR_TABLE_CODE_LDTR)
         logger().log_hal(f'[cpu{cpu_thread_id:d}] LDTR Limit = 0x{limit:04X}, Base = 0x{base:016X}, Physical Address = 0x{pa:016X}')
         return (limit, base, pa)
-
 
 ##########################################################################################################
 #

--- a/chipsec/helper/dal/dalhelper.py
+++ b/chipsec/helper/dal/dalhelper.py
@@ -67,7 +67,6 @@ class DALHelper(Helper):
             self.base.go()
             logger().log('[helper] Threads are running')
 
-
 ###############################################################################################
 # Driver/service management functions
 ###############################################################################################
@@ -93,7 +92,6 @@ class DALHelper(Helper):
     def delete(self) -> bool:
         logger().log_debug('[helper] DAL Helper deleted')
         return True
-
 
 ###############################################################################################
 # Functions to get information about the remote target

--- a/chipsec/helper/efi/efihelper.py
+++ b/chipsec/helper/efi/efihelper.py
@@ -95,7 +95,6 @@ class EfiHelper(Helper):
         logger().log_debug('[helper] UEFI Helper deleted')
         return True
 
-
 ###############################################################################################
 # Actual API functions to access HW resources
 ###############################################################################################
@@ -103,7 +102,6 @@ class EfiHelper(Helper):
     #
     # Physical memory access
     #
-
     def split_address(self, pa: int) -> Tuple[int, int]:
         return (pa & 0xFFFFFFFF, (pa >> 32) & 0xFFFFFFFF)
 

--- a/chipsec/helper/windows/windowshelper.py
+++ b/chipsec/helper/windows/windowshelper.py
@@ -325,7 +325,6 @@ class WindowsHelper(Helper):
             win32api.CloseHandle(self.driver_handle)
             self.driver_handle = None
 
-
 ###############################################################################################
 # Driver/service management functions
 ###############################################################################################


### PR DESCRIPTION
This commit fixes all the E301 errors.  They were found by running "flake8 ." from the root directory.  This is an error defined by "pycodestyle", and has no functional impact to the source.  This is simply fixing whitespace as defined by CHIPSEC's .flake8 configuration.

background:
https://www.flake8rules.com/rules/E301.html
https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes:~:text=Blank%20line-,E301,-expected%201%20blank

tool versions: flake8 v7.2.0, python v3.12.6