### PR TITLE
Convert str to byte object in linuxhelper's kern_set_EFI_variable

### DIFF
--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -572,7 +572,7 @@ class LinuxHelper(Helper):
         header_size = 60  # 4*15
         namelen = len(name)
         if value:
-            if type(value) == str:
+            if isinstance(value, str):
                 value = str.encode(value)
             datalen = len(value)
         else:


### PR DESCRIPTION
This is required to be able to successfuly run the common.uefi.access_uefispec -a modify test from under Linux and resolve the following error:

```
ERROR: Exception occurred during chipsec.modules.common.uefi.access_uefispec.run(): 'argument for 's' must be a bytes object'