### PR TITLE
fix for flake8 rule F401

### DIFF
--- a/chipsec/hal/ec.py
+++ b/chipsec/hal/ec.py
@@ -41,7 +41,7 @@ Usage:
     >>> write_range( start_offset, buffer )
 
 """
-from typing import List, Optional
+from typing import Optional
 from chipsec.hal import hal_base
 from chipsec.library.logger import print_buffer_bytes
 

--- a/chipsec/hal/smbus.py
+++ b/chipsec/hal/smbus.py
@@ -28,7 +28,6 @@
 """
 Access to SMBus Controller
 """
-from typing import List
 from chipsec.hal import iobar, hal_base
 from chipsec.library.exceptions import IOBARNotFoundError, RegisterNotFoundError
 

--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -43,9 +43,6 @@ from chipsec.library.exceptions import OsHelperError, UnimplementedAPIError
 from chipsec.helper.basehelper import Helper
 from chipsec.library.logger import logger
 import chipsec.library.file
-from chipsec.hal.uefi_common import EFI_VARIABLE_NON_VOLATILE, EFI_VARIABLE_BOOTSERVICE_ACCESS, EFI_VARIABLE_RUNTIME_ACCESS
-from chipsec.hal.uefi_common import EFI_VARIABLE_HARDWARE_ERROR_RECORD, EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS
-from chipsec.hal.uefi_common import EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS, EFI_VARIABLE_APPEND_WRITE
 
 MSGBUS_MDR_IN_MASK = 0x1
 MSGBUS_MDR_OUT_MASK = 0x2
@@ -209,7 +206,7 @@ class LinuxHelper(Helper):
     # currently all chipsec ioctl functions are _IOWR
     # currently all size are pointer
     def compute_ioctlbase(self, itype: str = 'C') -> int:
-        # define _IOWR(type,nr,size)	 _IOC(_IOC_READ|_IOC_WRITE,(type),(nr),(_IOC_TYPECHECK(size)))
+        # define _IOWR(type,nr,size)     _IOC(_IOC_READ|_IOC_WRITE,(type),(nr),(_IOC_TYPECHECK(size)))
         # define _IOC(dir,type,nr,size) \
         #    (((dir)  << _IOC_DIRSHIFT) | \
         #    ((type) << _IOC_TYPESHIFT) | \

--- a/chipsec/modules/tools/smm/smm_ptr.py
+++ b/chipsec/modules/tools/smm/smm_ptr.py
@@ -82,7 +82,6 @@ Examples:
 import struct
 import os
 import sys
-import time
 import math
 
 from chipsec.module_common import BaseModule, SMM

--- a/chipsec/modules/tools/uefi/scan_image.py
+++ b/chipsec/modules/tools/uefi/scan_image.py
@@ -22,13 +22,13 @@ file against this list of expected executables
 
 Usage:
   ``chipsec_main -m tools.uefi.scan_image [-a generate|check,<json>,<fw_image>]``
-    - ``generate``	Generates a list of EFI executable binaries from the UEFI
+    - ``generate``  Generates a list of EFI executable binaries from the UEFI
                         firmware image (default)
-    - ``check``		Decodes UEFI firmware image and checks all EFI executable
+    - ``check``     Decodes UEFI firmware image and checks all EFI executable
                         binaries against a specified list
-    - ``json``		JSON file with configuration of allowed list EFI
+    - ``json``      JSON file with configuration of allowed list EFI
                         executables (default = ``efilist.json``)
-    - ``fw_image``	Full file path to UEFI firmware image. If not specified,
+    - ``fw_image``  Full file path to UEFI firmware image. If not specified,
                         the module will dump firmware image directly from ROM
 
 Examples:
@@ -61,7 +61,7 @@ from chipsec.library.returncode import ModuleResult
 
 from chipsec.hal.uefi import UEFI
 from chipsec.hal.spi import SPI, BIOS
-from chipsec.hal.uefi_fv import EFI_MODULE, EFI_SECTION, SECTION_NAMES, EFI_SECTION_PE32
+from chipsec.hal.uefi_fv import EFI_MODULE, EFI_SECTION
 from chipsec.hal.spi_uefi import build_efi_model, search_efi_tree, EFIModuleType, UUIDEncoder
 from chipsec.library.file import write_file, read_file
 

--- a/chipsec/modules/tools/vmm/hv/hypercall.py
+++ b/chipsec/modules/tools/vmm/hv/hypercall.py
@@ -23,10 +23,6 @@
 Hyper-V specific hypercall functionality
 """
 
-import os
-import sys
-import time
-import chipsec_util
 from random import *
 from struct import *
 from chipsec.modules.tools.vmm.hv.define import *

--- a/chipsec/modules/tools/vmm/hv/vmbus.py
+++ b/chipsec/modules/tools/vmm/hv/vmbus.py
@@ -22,10 +22,7 @@
 """
 Hyper-V VMBus functionality
 """
-import os
-import sys
 import time
-import chipsec_util
 from struct import *
 from random import *
 from chipsec.modules.tools.vmm.common import *

--- a/chipsec/modules/tools/vmm/xen/hypercall.py
+++ b/chipsec/modules/tools/vmm/xen/hypercall.py
@@ -23,7 +23,6 @@
 Xen specific hypercall functionality
 """
 
-import collections
 from chipsec.modules.tools.vmm.xen.define import *
 from chipsec.hal.vmm import *
 from chipsec.module_common import *

--- a/chipsec/testcase.py
+++ b/chipsec/testcase.py
@@ -25,7 +25,7 @@ from collections import OrderedDict
 import xml.etree.ElementTree as ET
 import xml.dom.minidom
 from chipsec.library.logger import logger
-from typing import Dict, List, Type, Optional
+from typing import Dict, List, Optional
 
 
 class ExitCode:

--- a/chipsec/utilcmd/igd_cmd.py
+++ b/chipsec/utilcmd/igd_cmd.py
@@ -36,7 +36,6 @@ from chipsec.command import BaseCommand, toLoad
 from chipsec.library.logger import print_buffer_bytes
 from argparse import ArgumentParser
 from chipsec.library.file import read_file, write_file
-from chipsec.hal import igd
 import os
 
 

--- a/tests/hardware/test_ubuntu.py
+++ b/tests/hardware/test_ubuntu.py
@@ -15,11 +15,8 @@
 #
 #
 import os.path
-import subprocess
 
 from tests.hardware import test_generic
-
-from chipsec.helper import oshelper
 
 
 class GenericUbuntuTest(test_generic.GenericHardwareTest):

--- a/tests/software/cs.py
+++ b/tests/software/cs.py
@@ -22,7 +22,6 @@ from tests.software import mock_helper
 
 from chipsec.library import logger
 from chipsec import chipset
-from chipsec.helper import oshelper
 
 
 class TestChipsecCs(unittest.TestCase):

--- a/tests/software/test_tpm_eventlog.py
+++ b/tests/software/test_tpm_eventlog.py
@@ -16,7 +16,7 @@ import struct
 import tempfile
 import unittest
 
-from tests.software import mock_helper, util
+from tests.software import util
 
 
 class TestTpmEventLogChipsecUtil(util.TestChipsecUtil):


### PR DESCRIPTION
This pull request fixes all the F401 errors. They were found by running "flake8 ." from the root directory. 

This checker finds imports that are never used within the module, and so can be safely removed.  This pull request should have no functional impact on the source code.

https://www.flake8rules.com/rules/F401

tool versions: flake8 v7.3.0, python v3.12.6