### PR TITLE
fix for flake8 rule E123

### DIFF
--- a/chipsec/hal/uefi_common.py
+++ b/chipsec/hal/uefi_common.py
@@ -314,7 +314,7 @@ sig_types: Dict[str, Tuple[str, Callable, int, str]] = {
     "446dbf63-2502-4cda-bcfa-2465d2b0fe9d": ("EFI_CERT_X509_SHA512_GUID", parse_x509_sha512, 0x60, "X509_SHA512"),
     "452e8ced-dfff-4b8c-ae01-5118862e682c": ("EFI_CERT_EXTERNAL_MANAGEMENT_GUID", parse_external, 0x11, "EXTERNAL_MANAGEMENT"),
     "4AAFD29D-68DF-49EE-8AA9-347D375665A7": ("EFI_CERT_TYPE_PKCS7_GUID", parse_pkcs7, 0, "PKCS7"),
-    }
+}
 
 
 def parse_sb_db(db: bytes, decode_dir: str) -> List[bytes]:
@@ -908,7 +908,7 @@ EFI_REVISIONS: List[int] = [
     EFI_2_00_SYSTEM_TABLE_REVISION,
     EFI_1_10_SYSTEM_TABLE_REVISION,
     EFI_1_02_SYSTEM_TABLE_REVISION
-    ]
+]
 
 
 def EFI_SYSTEM_TABLE_REVISION(revision: int) -> str:

--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -465,7 +465,7 @@ class LinuxHelper(Helper):
             9: 'EFI_OUT_OF_RESOURCES',
             14: 'EFI_NOT_FOUND',
             26: 'EFI_SECURITY_VIOLATION'
-            }
+        }
         off = 0
         data = b''
         attr = 0

--- a/chipsec/testcase.py
+++ b/chipsec/testcase.py
@@ -302,7 +302,7 @@ class LegacyResults(ChipsecResults):
                         'not applicable': ExitCode.NOTAPPLICABLE,
                         'information': ExitCode.INFORMATION,
                         'archived': ExitCode.ARCHIVED
-                        }
+        }
         for result in destination.keys():
             if len(summary[result]) != 0:
                 return destination[result]


### PR DESCRIPTION
This commit fixes all the E123 errors.  They were found by running "flake8 ." from the root directory.  This is an error defined by "pycodestyle", and has no functional impact to the source.  This is simply fixing whitespace as defined by CHIPSEC's .flake8 configuration.

background:
https://www.flake8rules.com/rules/E123
https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes:~:text=indentation%20or%20outdented-,E123,-(*)

tool versions: flake8 v7.3.0, python v3.12.6