### PR TITLE
fix for flake8 E265 on new TPM files

### DIFF
--- a/chipsec/hal/tpm_interface.py
+++ b/chipsec/hal/tpm_interface.py
@@ -1,21 +1,21 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
 
 
@@ -39,9 +39,9 @@ class TPM_BASE(hal_base.HALBase):
         self.TPM_BASE = self.cs.Cfg.MEMORY_RANGES['TPM']['address']
         self.access_address = 0x0
 
-    #def get_registers(self) -> list:
+    # def get_registers(self) -> list:
     #    return self.list_of_registers
-    
+
     def request_locality(self, Locality: int) -> bool:
         self.access_address = self.TPM_BASE | Locality | tpm_defines.TPM_ACCESS
         if self.helper.read_mmio_reg(self.access_address, 4) == tpm_defines.BEENSEIZED:

--- a/chipsec/library/tpm/tpm2_commands.py
+++ b/chipsec/library/tpm/tpm2_commands.py
@@ -1,23 +1,22 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
-
 
 
 """
@@ -50,10 +49,10 @@ class TPM_RESPONSE_HEADER(namedtuple('TPM_RESPONSE_HEADER', 'ResponseTag DataSiz
             _str += f'{response[0]}: {response[1]}'
         except:
             _str += 'Invalid return code'
-        
+
         _str += '\n'
         return _str
-    
+
 
 def startup(command_argv):
     """
@@ -61,7 +60,7 @@ def startup(command_argv):
     1: TPM_ST_CLEAR
     2: TPM_ST_STATE
     """
-    #session = _read_session(int(command_argv[0]), tpm_defines.TPM_ST_NO_SESSIONS)
+    # session = _read_session(int(command_argv[0]), tpm_defines.TPM_ST_NO_SESSIONS)
     command_format = '=HIIH'
     size = 0x0C000000
     try:
@@ -154,7 +153,7 @@ def pcrread(command_argv):
     """
     TPM2_PCR_Read command.
     """
-    #session = _read_session(command_argv[0])
+    # session = _read_session(command_argv[0])
     command_format = '=HIII'
     size = 0x0C000000
     try:

--- a/chipsec/library/tpm/tpm_defines.py
+++ b/chipsec/library/tpm/tpm_defines.py
@@ -1,22 +1,23 @@
-#CHIPSEC: Platform Security Assessment Framework
-#Copyright (c) 2010-2021, Intel Corporation
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2010-2021, Intel Corporation
 #
-#This program is free software; you can redistribute it and/or
-#modify it under the terms of the GNU General Public License
-#as published by the Free Software Foundation; Version 2.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
 #
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#You should have received a copy of the GNU General Public License
-#along with this program; if not, write to the Free Software
-#Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-#Contact information:
-#chipsec@intel.com
+# Contact information:
+# chipsec@intel.com
 #
+
 
 from typing import Dict
 from chipsec.library.tpm import tpm2_commands
@@ -51,11 +52,11 @@ TPM_RID = 0x0F04
 TPM_INTCAP = 0x0014
 TPM_INTENABLE = 0x0008
 
-list_of_registers = ['TPM_ACCESS', 
-                    'TPM_STS', 
-                    'TPM_DID_VID', 
-                    'TPM_RID', 
-                    'TPM_INTF_CAPABILITY', 
+list_of_registers = ['TPM_ACCESS',
+                    'TPM_STS',
+                    'TPM_DID_VID',
+                    'TPM_RID',
+                    'TPM_INTF_CAPABILITY',
                     'TPM_INT_ENABLE']
 
 LOCALITY: Dict[str, int] = {
@@ -338,7 +339,7 @@ RESPONSE_TAG = {}
 RESPONSE_CODE = {
     # https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-2-Structures-01.38.pdf
     # Section 6.6.3
-    #VER1
+    # VER1
     0x000: ['TPM_RC_SUCCESS', 'No error.'],
     0x01E: ['TPM_RC_BAD_TAG', 'Bad tag in the message.'],
     0x100: ['TPM_RC_INITIALIZE', 'TPM not initialized by TPM2_Startup() or already initialized.'],
@@ -377,7 +378,7 @@ RESPONSE_CODE = {
     0x155: ['TPM_RC_SENSITIVE', 'Sensitive area did not unmarshal correctly after decryption.'],
     0x156: ['TPM_RC_READ_ONLY', 'Command failed because TPM is in Read-Only mode.'],
     0x17F: ['TPM_RC_MAX_FM0', 'Largest version 1 code that is not a warning.'],
-    #FMT1
+    # FMT1
     0x081: ['TPM_RC_ASYMMETRIC', 'Asymmetric algorithm not supported or incorrect.'],
     0x082: ['TPM_RC_ATTRIBUTES', 'Inconsistent attributes.'],
     0x083: ['TPM_RC_HASH', 'Unsupported or inappropriate hash algorithm.'],


### PR DESCRIPTION
This commit fixes some E265 errors on newly added TPM files.  They were found by running "flake8 ." from the root directory.  This is an error defined by "pycodestyle", and has no functional impact to the source.  This is simply fixing whitespace as defined by CHIPSEC's .flake8 configuration.

background:
https://www.flake8rules.com/rules/E265
https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes:~:text=should%20start%20with%20%E2%80%98%23%20%E2%80%98-,E265,-block%20comment%20should

tool versions: flake8 v7.3.0, python v3.12.6