### PR TITLE
linuxhelper: assign default value if None is being passed in

### DIFF
--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -551,7 +551,8 @@ class LinuxHelper(Helper):
                 variables[name].append(var)
         return variables
 
-    def kern_set_EFI_variable(self, name: str, guid: str, value: bytes, attr: int = 0x7) -> int:
+    def kern_set_EFI_variable(self, name: str, guid: str, value: bytes, attr: Optional[int] = None) -> int:
+        attr = 0x7 if attr is None else attr
         status_dict = {
             0: 'EFI_SUCCESS',
             1: 'EFI_LOAD_ERROR',


### PR DESCRIPTION
linuxhelper's kern_set_EFI_variable only sets default value for attr if no value has been passed in. In some call-chains (uefi var-write) however None is being passed in, resulting in the following error:

struct.error: required argument is not an integer

Make attr optional input and override if value is None with default value.