### PR TITLE
access_uefispec: accept both hex and base-10 formatted attr input

### DIFF
--- a/chipsec/modules/common/uefi/access_uefispec.py
+++ b/chipsec/modules/common/uefi/access_uefispec.py
@@ -257,7 +257,7 @@ class access_uefispec(BaseModule):
         attribute = None
 
         if len(module_argv) > 1:
-            attribute = module_argv[1]
+            attribute = int(module_argv[1], base=0)
 
         self.res = self.check_vars(do_modify, attribute)
 


### PR DESCRIPTION
Beside the functional improvement, converting the input to int is required depending on what Python version is being used to avoid the variable propagating down the call-chain as a str.