### PR TITLE
enforce uppercase registernames

### DIFF
--- a/chipsec/cfg/parsers/core_parser_helper.py
+++ b/chipsec/cfg/parsers/core_parser_helper.py
@@ -70,7 +70,16 @@ class ConversionRules:
             int_list_keys={'bus'},
             str_list_keys={'config'},
             range_list_keys=range_list_keys,
-            case_insensitive_keys={'name'}
+            case_insensitive_keys={
+                'name',
+                'base_field',
+                'baseh_field',
+                'limit_field',
+                'enable_field',
+                'valid',
+                'valid_field',
+                'base_addr',
+            }
         )
     
     def set_did_as_range(self):

--- a/chipsec/cfg/parsers/registers/msgbus.py
+++ b/chipsec/cfg/parsers/registers/msgbus.py
@@ -174,7 +174,7 @@ class MSGBUSRegisters(BaseConfigRegisterHelper):
         try:
             self.logger.log_debug(f'reading {self.name}')
             _cs = cs()
-            self.value = _cs.hals.MsgBus.msgbus_reg_read(self.port, self.offset)
+            self.value = _cs.hals.msgbus.msgbus_reg_read(self.port, self.offset)
             return self.value
         except Exception as e:
             raise MSGBUSRegisterError(
@@ -194,7 +194,7 @@ class MSGBUSRegisters(BaseConfigRegisterHelper):
         try:
             self.logger.log_debug(f'writing 0x{value:X} to {self.name}')
             _cs = cs()
-            _cs.hals.MsgBus.msgbus_reg_write(self.port, self.offset, value)
+            _cs.hals.msgbus.msgbus_reg_write(self.port, self.offset, value)
             self.value = value
         except Exception as e:
             raise MSGBUSRegisterError(

--- a/chipsec/hal/common/mmio.py
+++ b/chipsec/hal/common/mmio.py
@@ -211,7 +211,7 @@ class MMIO(hal_base.HALBase):
                         continue
                     try:
                         reg_mask = bar_reg.get_field_mask(base_field, preserve)
-                    except CSReadError:
+                    except (CSReadError, AttributeError):
                         continue
                     break
             if not preserve:
@@ -227,12 +227,12 @@ class MMIO(hal_base.HALBase):
                     base_field = bar.baseh_field
                     try:
                         baseh = bar_reg.read_field(base_field, preserve)
-                    except CSReadError:
+                    except (CSReadError, AttributeError):
                         self.logger.log_hal('[mmio] Unable to determine MMIO Base registerh.  Using Base = 0x0')
                         baseh = 0
                     try:
                         reg_maskh = bar_reg.get_field_mask(base_field, preserve)
-                    except CSReadError:
+                    except (CSReadError, AttributeError):
                         self.logger.log_hal('[mmio] Unable to determine MMIO Mask registerh.  Using Mask = 0xFFFF')
                         reg_maskh = 0xFFFF
             if not preserve:
@@ -243,7 +243,7 @@ class MMIO(hal_base.HALBase):
         if bar.registertype and bar.registertype == 'dynamic':
             try:
                 dynbase = self.read_MMIO_reg(base, 0)
-            except CSReadError:
+            except (CSReadError, AttributeError):
                 self.logger.log_hal('[mmio] Unable to determine MMIO Base.  Using Base = 0x0')
                 dynbase = 0x0
             base = dynbase

--- a/chipsec/library/register.py
+++ b/chipsec/library/register.py
@@ -332,6 +332,7 @@ class Register:
 
     def has_field(self, reg_name: str, field_name: str) -> bool:
         """Checks if the register has specific field"""
+        field_name = field_name.upper()
         try:
             reg_defs = self.cs.Cfg.get_reglist(reg_name)
         except RegisterNotFoundError:
@@ -517,6 +518,7 @@ class BaseConfigRegisterHelper(BaseConfigHelper):
     def get_field_mask(
         self, reg_field: str, preserve_field_position: Optional[bool] = False
     ) -> int:
+        reg_field = reg_field.upper()
         field_attrs = self.fields[reg_field]
         mask_start = 0
         size = field_attrs['size']


### PR DESCRIPTION
Fix instances where registers were able to be referenced as lowercase causing errors