### PR TITLE
Fix typo and missing object reference in interrupt module

### DIFF
--- a/chipsec/hal/common/interrupts.py
+++ b/chipsec/hal/common/interrupts.py
@@ -191,7 +191,7 @@ MdeModulePkg/Core/PiSmmCore/PiSmmCorePrivateData.h
         BufferSize_offset = CommBuffer_offset + 8
         ReturnStatus_offset = BufferSize_offset + 8
 
-        self.hals.memorymem.write_physical_mem(smmc + CommBuffer_offset, 8, struct.pack("Q", payload_loc))
+        self.cs.hals.memory.write_physical_mem(smmc + CommBuffer_offset, 8, struct.pack("Q", payload_loc))
         self.cs.hals.memory.write_physical_mem(smmc + BufferSize_offset, 8, struct.pack("Q", len(data_hdr)))
         self.cs.hals.memory.write_physical_mem(payload_loc, len(data_hdr), data_hdr)
 


### PR DESCRIPTION
Hello :)

This patch fixes an error in the `send_smmc_SMI` function within `chipsec/hal/common/interrupts.py` by correcting an incorrect HAL module name (`memorymem` -> `memory`) and adding a missing chipset object reference (`cs`)

This typo appears to have been introduced in [aaaa9e58](https://github.com/chipsec/chipsec/blob/aaaa9e58a242b6e370e05f78d4e12f66ae4b0c1a/chipsec/hal/common/interrupts.py#L183) and was partially updated during a refactoring in [1259e568d](https://github.com/chipsec/chipsec/blob/1259e568dee938c020e2f28e2ba2cf110e27ec3a/chipsec/hal/common/interrupts.py#L194), but functional errors remained until now.

Thanks for reviewing!