### PR TITLE
Update chipsec2 to work in UEFI Shell

### DIFF
--- a/chipsec/config.py
+++ b/chipsec/config.py
@@ -821,12 +821,12 @@ class Cfg:
 
         # Locate all root configuration files
         cfg_files = []
-        cfg_vids = [f.name for f in os.scandir(cfg_path) if f.is_dir() and is_hex(f.name)]
+        cfg_vids = [f for f in os.listdir(cfg_path) if os.path.isdir(os.path.join(cfg_path,f)) and is_hex(f)]
         for vid_str in cfg_vids:
             root_path = os.path.join(cfg_path, vid_str)
-            cfg_files.extend([config_data(vid_str, None, f.path, None, None)
-                             for f in sorted(os.scandir(root_path), key=lambda x: x.name.lower())
-                             if fnmatch(f.name, '*.xml')])
+            cfg_files.extend([config_data(vid_str, None, os.path.join(root_path,f), None, None)
+                             for f in sorted(os.listdir(root_path), key=lambda x: x.lower())
+                             if fnmatch(f, '*.xml')])
 
         # Process platform info data and generate lookup tables
         for fxml in cfg_files:

--- a/chipsec/hal/hals.py
+++ b/chipsec/hal/hals.py
@@ -109,7 +109,7 @@ class Hals:
     def update_available_hals(self) -> Dict[str, Any]:
         """Determine available HAL modules"""
         hal_base_dir = os.path.join(get_main_dir(), "chipsec", "hal")
-        hal_dirs = [f.name for f in os.scandir(hal_base_dir) if f.is_dir() and '__' not in f.name]
+        hal_dirs = [f for f in os.listdir(hal_base_dir) if os.path.isdir(os.path.join(hal_base_dir, f)) and '__' not in f]
         hals = []
         for hal_dir in hal_dirs:
             hals += ([f'{hal_dir}.{i[:-3]}' for i in os.listdir(os.path.join(hal_base_dir, hal_dir)) if i[-3:] == ".py" and not i[:2] == "__"])


### PR DESCRIPTION
os.scandir function is not present in python 3.6.8

Also, dataclasses is not present in python 3.6.8, but does exist as a backport: https://pypi.org/project/dataclasses/ 
Integrated the dataclasses backport to the py368 uefi zip.