### PR TITLE
Restore 'uefi types' command from chipsec_util

### DIFF
--- a/chipsec/utilcmd/uefi_cmd.py
+++ b/chipsec/utilcmd/uefi_cmd.py
@@ -22,7 +22,6 @@
 """
 The uefi command provides access to UEFI variables, both on the live system and in a SPI flash image file.
 
->>> chipsec_util uefi types
 >>> chipsec_util uefi var-list
 >>> chipsec_util uefi var-list-spi [rom_file]
 >>> chipsec_util uefi var-find <name>|<GUID>
@@ -37,7 +36,6 @@ The uefi command provides access to UEFI variables, both on the live system and 
 
 Examples:
 
->>> chipsec_util uefi types
 >>> chipsec_util uefi var-list
 >>> chipsec_util uefi var-list-spi
 >>> chipsec_util uefi var-find PK

--- a/chipsec/utilcmd/uefi_cmd.py
+++ b/chipsec/utilcmd/uefi_cmd.py
@@ -87,6 +87,10 @@ class UEFICommand(BaseCommand):
         parser = ArgumentParser(prog='chipsec_util uefi', usage=__doc__)
         subparsers = parser.add_subparsers()
 
+        # types command args
+        parser_types = subparsers.add_parser('types')
+        parser_types.set_defaults(func=self.print_uefi_types)
+
         # var-read command args
         parser_var_read = subparsers.add_parser('var-read')
         parser_var_read.add_argument('name', type=str, help='name of variable to read')
@@ -198,6 +202,9 @@ class UEFICommand(BaseCommand):
 
     def set_up(self) -> None:
         self._uefi = UEFI(self.cs)
+
+    def print_uefi_types(self):
+        self.logger.log(f"The <fwtype> should be one of: {fw_types}")
 
     def var_read(self):
         self.logger.log("[CHIPSEC] Reading EFI variable Name='{}' GUID={{{}}} to '{}' via Variable API..".format(self.name, self.guid, self.filename))

--- a/chipsec/utilcmd/uefi_cmd.py
+++ b/chipsec/utilcmd/uefi_cmd.py
@@ -22,6 +22,7 @@
 """
 The uefi command provides access to UEFI variables, both on the live system and in a SPI flash image file.
 
+>>> chipsec_util uefi types
 >>> chipsec_util uefi var-list
 >>> chipsec_util uefi var-list-spi [rom_file]
 >>> chipsec_util uefi var-find <name>|<GUID>
@@ -36,6 +37,7 @@ The uefi command provides access to UEFI variables, both on the live system and 
 
 Examples:
 
+>>> chipsec_util uefi types
 >>> chipsec_util uefi var-list
 >>> chipsec_util uefi var-list-spi
 >>> chipsec_util uefi var-find PK


### PR DESCRIPTION
Resolves #2558 