### PR TITLE
Avoid UEFI module import handle exhaustion

### DIFF
--- a/chipsec/library/module_helper.py
+++ b/chipsec/library/module_helper.py
@@ -25,15 +25,48 @@ from chipsec.library.file import get_module_dir
 from typing import List
 
 
+def get_module_files(from_path: str, recursive: bool = True, skip_sidekick: bool = False) -> List[str]:
+    files = []
+    root_path = os.path.abspath(from_path)
+
+    def is_module_file(entry: str) -> bool:
+        _, extension = os.path.splitext(entry)
+        rules = (
+            extension == '.py',
+            entry != '__init__.py',
+            not (skip_sidekick and fnmatch.fnmatch(entry, '*sidekick.py')),
+        )
+        return all(rules)
+
+    def walk_path(path: str) -> None:
+        try:
+            entries = sorted(os.listdir(path), key=lambda entry: entry.lower())
+        except OSError:
+            return
+        directories = []
+        for entry in entries:
+            entry_path = os.path.join(path, entry)
+            if os.path.isdir(entry_path) and not os.path.islink(entry_path):
+                directories.append(entry_path)
+                continue
+            if is_module_file(entry):
+                files.append(entry_path)
+        if recursive:
+            for directory in directories:
+                walk_path(directory)
+
+    walk_path(root_path)
+    return files
+
+
 def enumerate_modules() -> List[str]:
     mod_path = get_module_dir()
-    tools_path = os.path.join(mod_path)
     files = []
-    for dirname, _, mod_fnames in os.walk(os.path.abspath(tools_path)):
-        for modx in mod_fnames:
-            if fnmatch.fnmatch(modx, '*.py') and not fnmatch.fnmatch(modx, '__init__.py'):
-                module_path = os.path.relpath(dirname, mod_path).replace('\\', '.').replace('/', '.')
-                files.append(f'{module_path}.{modx[:-3]}')
+    for module_file in get_module_files(mod_path):
+        dirname, modx = os.path.split(module_file)
+        module_path = os.path.relpath(dirname, mod_path)
+        module_path = module_path.replace('\\', '.').replace('/', '.')
+        files.append(f'{module_path}.{modx[:-3]}')
     return files
 
 

--- a/chipsec_main.py
+++ b/chipsec_main.py
@@ -25,7 +25,6 @@ Main application logic and automation functions
 
 # These are for debugging imports
 import sys
-import fnmatch
 import argparse
 import os
 import re
@@ -48,7 +47,7 @@ from chipsec.testcase import ExitCode, TestCase, ReturnCodeResults, LegacyResult
 from chipsec.library.display import print_banner, print_banner_properties
 from chipsec.library.exceptions import UnknownChipsetError, OsHelperError
 from chipsec.library.options import Options
-from chipsec.library.module_helper import enumerate_modules, print_modules
+from chipsec.library.module_helper import enumerate_modules, get_module_files, print_modules
 
 try:
     import importlib
@@ -245,13 +244,8 @@ class ChipsecMain:
     def load_modules_from_path(self, from_path, recursive=True):
         if self.logger.DEBUG:
             self.logger.log(f'[*] Path: {os.path.abspath(from_path)}')
-        for dirname, subdirs, mod_fnames in os.walk(os.path.abspath(from_path)):
-            if not recursive:
-                while len(subdirs) > 0:
-                    subdirs.pop()
-            for modx in mod_fnames:
-                if fnmatch.fnmatch(modx, '*.py') and not fnmatch.fnmatch(modx, '__init__.py') and not fnmatch.fnmatch(modx, '*sidekick.py'):
-                    self.load_module(os.path.join(dirname, modx), self._module_argv)
+        for module_file in get_module_files(from_path, recursive=recursive, skip_sidekick=True):
+            self.load_module(module_file, self._module_argv)
         self.Loaded_Modules.sort()
 
     def load_my_modules(self):

--- a/tests/library/test_module_helper.py
+++ b/tests/library/test_module_helper.py
@@ -1,0 +1,82 @@
+# CHIPSEC: Platform Security Assessment Framework
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from chipsec.library.module_helper import get_module_files
+
+
+class TestModuleHelper(unittest.TestCase):
+
+    def test_get_module_files_filters_modules(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.mkdir(os.path.join(temp_dir, 'nested'))
+            module_file = os.path.join(temp_dir, 'module.py')
+            sidekick_file = os.path.join(temp_dir, 'module_sidekick.py')
+            init_file = os.path.join(temp_dir, '__init__.py')
+            nested_file = os.path.join(temp_dir, 'nested', 'nested_module.py')
+            text_file = os.path.join(temp_dir, 'README.txt')
+            for path in (module_file, sidekick_file, init_file, nested_file, text_file):
+                open(path, 'w').close()
+
+            files = get_module_files(temp_dir, skip_sidekick=True)
+
+        self.assertEqual(files, [module_file, nested_file])
+
+    def test_get_module_files_can_skip_recursion(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.mkdir(os.path.join(temp_dir, 'nested'))
+            module_file = os.path.join(temp_dir, 'module.py')
+            nested_file = os.path.join(temp_dir, 'nested', 'nested_module.py')
+            for path in (module_file, nested_file):
+                open(path, 'w').close()
+
+            files = get_module_files(temp_dir, recursive=False)
+
+        self.assertEqual(files, [module_file])
+
+    def test_get_module_files_skips_missing_paths(self):
+        missing_path = os.path.join(tempfile.gettempdir(), 'chipsec_missing_module_path')
+
+        self.assertEqual(get_module_files(missing_path), [])
+
+    def test_get_module_files_skips_unreadable_paths(self):
+        with patch('chipsec.library.module_helper.os.listdir', side_effect=OSError):
+            self.assertEqual(get_module_files('unreadable'), [])
+
+    def test_get_module_files_does_not_follow_directory_symlinks(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target_dir = os.path.join(temp_dir, 'target')
+            symlink_dir = os.path.join(temp_dir, 'symlink')
+            os.mkdir(target_dir)
+            linked_file = os.path.join(target_dir, 'linked_module.py')
+            open(linked_file, 'w').close()
+            try:
+                os.symlink(target_dir, symlink_dir, target_is_directory=True)
+            except (AttributeError, NotImplementedError, OSError):
+                self.skipTest('directory symlinks are not available')
+
+            files = get_module_files(temp_dir)
+
+        self.assertEqual(files, [linked_file])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Replace os.walk module discovery with os.listdir snapshot recursion and reuse it for CHIPSEC module loading/enumeration. This reduces directory handle lifetime during UEFI runs while preserving existing module selection behavior.