### PR TITLE
Install the configuration files nested below cfg/<vendor>/

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,11 @@ package_data = {
     # Include any configuration file.
     '': ['*.ini', '*.cfg', '*.json'],
     'chipsec': ['*VERSION*', 'WARNING.txt', 'options/*.ini'],
-    'chipsec.cfg': ['8086/*.xml', '1022/*.xml', '*.xml', '*.xsd'],
+    # Vendor directories under cfg/ nest one level deeper than '<vendor>/*.xml'
+    # reaches (e.g. cfg/8086/TPM/tpm12.xml), and those subdirectories are not Python
+    # packages, so they are only installed if matched from here. Matching by depth
+    # rather than by vendor id also picks up vendors added later.
+    'chipsec.cfg': ['*.xml', '*.xsd', '*/*.xml', '*/*/*.xml'],
 }
 data_files = [('', ['chipsec-manual.pdf'])]
 install_requires = []


### PR DESCRIPTION
package_data matches 'cfg/8086/*.xml' and 'cfg/1022/*.xml', but the configuration tree nests a further level in places, for example cfg/8086/TPM/tpm12.xml and cfg/8086/SPI/spibar0.xml. Those subdirectories are not Python packages, so they are only installed if package_data matches them, and it does not.

The result is that 17 of the 54 XML files under chipsec/cfg are installed. At runtime CHIPSEC logs "Configuration file not found" for each of the other 37 and platform identification is degraded accordingly.

Match by depth rather than by vendor identifier. As well as fixing the omission, this picks up vendor directories added in future without needing another entry here.

This affects every installation method, pip included, not just distribution packaging. It is the same class of problem as issue #67, which was resolved by moving to setuptools; that fixed the top level, and the nested directories were added later.

  before: 17 of 54 configuration files installed
  after:  54 of 54