### PR TITLE
Load the Linux driver with modprobe before searching for the file

### DIFF
--- a/chipsec/helper/linux/linuxhelper.py
+++ b/chipsec/helper/linux/linuxhelper.py
@@ -128,6 +128,26 @@ class LinuxHelper(Helper):
             else:
                 a2 = f'a2=0x{phys_mem_access_prot}'
 
+        # Prefer modprobe, which resolves the module by name through the kernel's own
+        # search path. The file probing below only recognises 'chipsec.ko' and
+        # 'chipsec.ko.xz', so it cannot see a module built by DKMS on a distribution
+        # that compresses modules with zstd (Arch Linux installs chipsec.ko.zst), and
+        # insmod could not load a compressed module even if it found one. modprobe
+        # handles every compression format and succeeds harmlessly when the module is
+        # already loaded.
+        try:
+            subprocess.check_output(['modprobe', self.MODULE_NAME] + [p for p in (a1, a2) if p],
+                                    stderr=subprocess.STDOUT)
+        except Exception:
+            pass
+        else:
+            if os.path.exists(self.DEVICE_NAME):
+                os.chown(self.DEVICE_NAME, 0, 0)
+                os.chmod(self.DEVICE_NAME, 0o600)
+                logger().log_debug(f'Module {self.DEVICE_NAME} loaded successfully')
+                self.driverpath = f'(modprobe {self.MODULE_NAME})'
+                return
+
         driver_path = os.path.join(chipsec.library.file.get_main_dir(), 'chipsec', 'helper', 'linux', 'chipsec.ko')
         if not os.path.exists(driver_path):
             driver_path += '.xz'


### PR DESCRIPTION
### Problem

`LinuxHelper.load_chipsec_module()` searches for the driver as a file — `chipsec.ko`, then `chipsec.ko.xz`, then the DKMS directory, then `.ko.xz` again — and loads whatever it finds with `insmod`. Two situations defeat that:

1. **Compressed modules.** Distributions that compress kernel modules with zstd produce `chipsec.ko.zst`, which matches none of those checks. `insmod` could not load it in any case, since it does not decompress. Arch Linux, Fedora and recent Ubuntu all compress modules this way, so a driver correctly built and installed by DKMS is invisible to CHIPSEC, which reports `Cannot find chipsec.ko module`.

2. **Already-loaded modules.** A module loaded by other means is not detected either, because the search is for a file rather than for the loaded module.

### Fix

Try `modprobe` first. It resolves the module by name through the kernel's own module search path, handles every compression format, and succeeds harmlessly when the module is already loaded. The existing file search is untouched and still runs when `modprobe` cannot satisfy the request, so setups relying on a driver built in place continue to work unchanged.

### Verification

Arch Linux, kernel 7.1.5, zstd-compressed modules, driver installed via DKMS:

```
before: ERROR: Message: "Cannot find chipsec.ko module"
after:  [CHIPSEC] Helper  : LinuxHelper (modprobe chipsec)
        [CHIPSEC] Platform: Intel Q35 (ICH9) Chipset
```

Confirmed on Manjaro as well, which compresses modules the same way.

### Notes

Issue #974 reports the same error message from a user who had built the driver correctly and could not get CHIPSEC to use it; the thread was closed without a diagnosis. I cannot confirm it is the same root cause — that report is from 2020 on Ubuntu 20.04, which did not compress kernel modules — but the symptom described there, where the module was loaded manually with `insmod` and CHIPSEC still could not find it, matches the second problem above.

One question for maintainers: this tries `modprobe` **before** the existing file search. Reversing the order would preserve today's behaviour more conservatively, at the cost of still failing when only a compressed module exists. Happy to reorder if you prefer.
