### PR TITLE
Install the manual to a path relative to the install prefix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,12 @@ if platform.system().lower() == 'windows':
 
 elif platform.system().lower() == 'linux':
     package_data['chipsec_tools.compression'] = ['*']
-    data_files = [(os.path.abspath(os.path.join(os.sep,'usr','share', 'doc','chipsec')), ['chipsec-manual.pdf'])]
+    # Relative to the install prefix, not absolute. A wheel is relocatable -- whoever
+    # installs it decides where it lands -- so an absolute destination cannot be
+    # expressed. Given one, the wheel build strips the leading separator and treats
+    # the remainder as an ordinary directory name, installing the manual to
+    # site-packages/usr/share/doc/chipsec/ instead of /usr/share/doc/chipsec/.
+    data_files = [(os.path.join('share', 'doc', 'chipsec'), ['chipsec-manual.pdf'])]
     extra_kw = [
         Extension(
             'EfiCompressor',


### PR DESCRIPTION
data_files declares the manual's destination as an absolute path built with os.path.abspath(os.path.join(os.sep, 'usr', 'share', 'doc', 'chipsec')).

A wheel is relocatable: whoever installs it decides where it lands, so every destination inside it must be relative to the install prefix. An absolute path cannot be expressed, and the wheel build responds by stripping the leading separator and treating the remainder as an ordinary directory name. The manual is then installed to

  <site-packages>/usr/share/doc/chipsec/chipsec-manual.pdf

leaving a directory named usr inside site-packages. Making the destination relative lets the wheel carry it in its data directory, from where it installs to <prefix>/share/doc/chipsec as intended.

Verified both ways on Arch Linux with Python 3.14:

  python -m build --wheel  +  python -m installer --destdir=...
    before: <destdir>/usr/lib/python3.14/site-packages/usr/share/doc/chipsec/
    after:  <destdir>/usr/share/doc/chipsec/

  python setup.py install --root=... continues to install to
  <root>/usr/share/doc/chipsec/ as before, so this is not a behaviour change for
  the legacy path.

Related to issue #2685, which reported adjacent problems packaging CHIPSEC as a wheel.