### PR TITLE
uefi/scan_image: fix ImportError — BIOS not exported by chipsec.hal.intel.spi

### DIFF
--- a/chipsec/modules/tools/uefi/scan_image.py
+++ b/chipsec/modules/tools/uefi/scan_image.py
@@ -61,6 +61,7 @@ from chipsec.library.returncode import ModuleResult
 
 from chipsec.hal.common.uefi import UEFI
 from chipsec.hal.intel.spi import SPI
+from chipsec.library.intel.spi import BIOS as BIOS_REGION
 from chipsec.library.uefi.fv import EFI_MODULE, EFI_SECTION
 from chipsec.library.uefi.spi import build_efi_model, search_efi_tree, EFIModuleType, UUIDEncoder
 from chipsec.library.file import write_file, read_file
@@ -174,7 +175,7 @@ class scan_image(BaseModule):
                 image_file = DEF_FWIMAGE_FILE
                 json_file = DEF_EFILIST_FILE
                 self.spi = SPI(self.cs)
-                (base, limit, _) = self.spi.get_SPI_region(BIOS)
+                (base, limit, _) = self.spi.get_SPI_region(BIOS_REGION)
                 image_size = limit + 1 - base
                 self.logger.log(f'[*] Dumping firmware image from ROM to \'{image_file}\': 0x{image_size:08X} bytes at [0x{base:08X}:0x{limit:08X}]')
                 self.spi.read_spi_to_file(base, image_size, image_file)

--- a/chipsec/modules/tools/uefi/scan_image.py
+++ b/chipsec/modules/tools/uefi/scan_image.py
@@ -60,7 +60,7 @@ from chipsec.module_common import BaseModule, BIOS
 from chipsec.library.returncode import ModuleResult
 
 from chipsec.hal.common.uefi import UEFI
-from chipsec.hal.intel.spi import SPI, BIOS
+from chipsec.hal.intel.spi import SPI
 from chipsec.library.uefi.fv import EFI_MODULE, EFI_SECTION
 from chipsec.library.uefi.spi import build_efi_model, search_efi_tree, EFIModuleType, UUIDEncoder
 from chipsec.library.file import write_file, read_file


### PR DESCRIPTION
## Summary

`chipsec/modules/tools/uefi/scan_image.py` fails to import on `chipsec2`:

```python
from chipsec.hal.intel.spi import SPI, BIOS   # BIOS is not defined here
```

`BIOS` is not exported by `chipsec.hal.intel.spi`, so importing the module raises
`ImportError` — `tools.uefi.scan_image` cannot be loaded or run as-is. `BIOS` is
already imported from `chipsec.module_common` a few lines above (the
`from chipsec.module_common import BaseModule, BIOS` line), and the
module's two uses of it — `TAGS = [BIOS]` and `self.spi.get_SPI_region(BIOS)` —
resolve correctly from that import. This PR drops `BIOS` from the
`chipsec.hal.intel.spi` import so the module loads again.

## Change (one line)

| File | Before | After |
| --- | --- | --- |
| `chipsec/modules/tools/uefi/scan_image.py` | `from chipsec.hal.intel.spi import SPI, BIOS` | `from chipsec.hal.intel.spi import SPI` |

## Behavior

- **Before:** `import chipsec.modules.tools.uefi.scan_image` → `ImportError` (BIOS
  undefined in `chipsec.hal.intel.spi`).
- **After:** module imports cleanly; `BIOS` resolves from `chipsec.module_common`
  (already imported a few lines above). No functional change — `TAGS` and
  `get_SPI_region(BIOS)` are unchanged. As a side benefit this also clears the
  pre-existing `flake8` **F811** ("redefinition of unused 'BIOS'") that the
  duplicate import triggers.

Commit is DCO `Signed-off-by: Mikey Strauss <mdstrauss91@gmail.com>`.

— Mikey Strauss (@houdini91)
