### PR TITLE
Merged codeql updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get install -qqy nasm
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,6 +53,6 @@ jobs:
           make
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Unified pull request combining the changes from:

- #2854 — Bump github/codeql-action/analyze from 4.37.3 to 4.37.8 (@dependabot[bot]) — https://github.com/chipsec/chipsec/pull/2854
- #2855 — Bump github/codeql-action/init from 4.37.3 to 4.37.8 (@dependabot[bot]) — https://github.com/chipsec/chipsec/pull/2855

Base branch: `chipsec2`

## Commits included

### From #2854
- `de4a88a8` Bump github/codeql-action/analyze from 4.37.3 to 4.37.8

### From #2855
- `39e3145b` Bump github/codeql-action/init from 4.37.3 to 4.37.8

_Generated by `merge_prs.py`._