### PR TITLE
Fix CPUID display family/model and summary reporting

### DIFF
--- a/chipsec/modules/common/cpu/cpu_info.py
+++ b/chipsec/modules/common/cpu/cpu_info.py
@@ -100,7 +100,7 @@ class cpu_info(BaseModule):
             if (family == 0x0F) or (family == 0x06):
                 model = ((eax >> 12) & 0xF0) | model
             if family == 0x0F:
-                family = ((eax >> 20) & 0xFF) | family
+                family = ((eax >> 20) & 0xFF) + family
             self.logger.log(f'[*]            Family: {family:02X} Model: {model:02X} Stepping: {stepping:01X}')
 
             self.logger.log(f'[*]            Microcode: {regdata:08X}')
@@ -151,7 +151,7 @@ class cpu_info(BaseModule):
             extFamily = (r_rax >> 20) & 0xF
             stepping = (r_rax) & 0xF
             family = baseFamily + extFamily
-            model = (extModel << 4) & baseModel
+            model = (extModel << 4) + baseModel
             self.logger.log(f'[*]            Family: {family:02X} Model: {model:02X} Stepping: {stepping:01X}')
 
 

--- a/chipsec/modules/common/sgx_check.py
+++ b/chipsec/modules/common/sgx_check.py
@@ -100,7 +100,8 @@ class sgx_check(BaseModule):
                     sgx_cpu_support = True
                 else:
                     self.logger.log_verbose(f'[*]CPU{tid:d}: does not support SGX')
-                    self.logger.log_important('SGX not supported.  Skipping module.')
+            if not sgx_cpu_support:
+                self.logger.log_important('SGX not supported.  Skipping module.')
 
         return sgx_cpu_support
 

--- a/chipsec/testcase.py
+++ b/chipsec/testcase.py
@@ -269,7 +269,7 @@ class LegacyResults(ChipsecResults):
                     logger().log(f'[CHIPSEC] Modules with {result:11}{len(summary[result]):d}:')
                     for mod in summary[result]:
                         logger().log_error(mod)
-            elif result == 'archived':
+            elif result == 'archived' and not summary[result]:
                 continue
             else:
                 logger().log(f'[CHIPSEC] Modules {result:16}{len(summary[result]):d}:')


### PR DESCRIPTION
cpu_info: DisplayFamily was computed with a bitwise OR instead of an add.
That branch only runs when Family_ID == 0xF, so ORing into an already
saturated nibble discards the low nibble of Extended_Family_ID and can
never carry -- NVL-S (CPUID 0x300F11) reported Family 0F instead of 12.
run_amd had the same class of bug, using a bitwise AND for DisplayModel;
ANDing two disjoint bit fields always yields 0, so every AMD part
reported Model 00. Both now use addition per the SDM/APM pseudo-code.

sgx_check: the "SGX not supported" skip message was inside the per-thread
CPUID loop and printed once per logical CPU (28 times on a 28-core part).
Emit it once after the loop instead.

testcase: LegacyResults.print_summary unconditionally skipped the archived
bucket, so "Modules total" did not match the sum of the listed buckets
whenever an ARCHIVED module ran (59 vs 58 with common.uefi.s3bootscript).
Only skip the bucket when it is empty.