### PR TITLE
New unit tests and bug fixes found by them (Used Claud and GPT)

### DIFF
--- a/chipsec/fuzzing/primitives.py
+++ b/chipsec/fuzzing/primitives.py
@@ -406,7 +406,7 @@ class string(base_primitive):
             ]
 
         # if the fuzz library has not yet been initialized, do so with all the global values.
-        if not self.fuzz_library:
+        if not string.fuzz_library:
             string.fuzz_library = \
                 [
                     # omission.
@@ -519,13 +519,15 @@ class string(base_primitive):
             except:
                 pass
 
+        self.string_fuzz_library = string.fuzz_library
+
         # delete strings which length is greater than max_len.
         if max_len > 0:
             if any(len(s) > max_len for s in self.this_library):
                 self.this_library = list(set([s[:max_len] for s in self.this_library]))
 
-            if any(len(s) > max_len for s in self.fuzz_library):
-                self.fuzz_library = list(set([s[:max_len] for s in self.fuzz_library]))
+            if any(len(s) > max_len for s in self.string_fuzz_library):
+                self.string_fuzz_library = list(set([s[:max_len] for s in self.string_fuzz_library]))
 
     def add_long_strings(self, sequence):
         '''
@@ -564,7 +566,7 @@ class string(base_primitive):
                 return False
 
             # update the current value from the fuzz library.
-            self.value = (self.fuzz_library + self.this_library)[self.mutant_index]
+            self.value = (self.string_fuzz_library + self.this_library)[self.mutant_index]
 
             # increment the mutation count.
             self.mutant_index += 1
@@ -593,7 +595,7 @@ class string(base_primitive):
         @return: Number of mutated forms this primitive can take
         '''
 
-        return len(self.fuzz_library) + len(self.this_library)
+        return len(self.string_fuzz_library) + len(self.this_library)
 
     def render(self):
         '''

--- a/chipsec/hal/common/smbios.py
+++ b/chipsec/hal/common/smbios.py
@@ -41,6 +41,8 @@ SMBIOS_2_x_INT_SIG = b"_DMI_"
 SMBIOS_2_x_GUID = "EB9D2D31-2D88-11D3-9A16-0090273FC14D"
 SMBIOS_2_x_ENTRY_POINT_FMT = "=4sBBBBHB5B5sBHIHB"
 SMBIOS_2_x_ENTRY_POINT_SIZE = struct.calcsize(SMBIOS_2_x_ENTRY_POINT_FMT)
+SMBIOS_2_x_INT_OFFSET = 0x10
+SMBIOS_2_x_INT_SIZE = 0x0F
 
 
 class SMBIOS_2_x_ENTRY_POINT(namedtuple('SMBIOS_2_x_ENTRY_POINT', 'Anchor EntryCs EntryLen MajorVer MinorVer MaxSize EntryRev \
@@ -281,8 +283,15 @@ class SMBIOS(hal_base.HALBase):
         if not (ep_data.EntryLen == SMBIOS_2_x_ENTRY_SIZE or ep_data.EntryLen == SMBIOS_2_x_ENTRY_SIZE_OLD):
             logger().log_hal('- Invalid structure size')
             return None
+        if sum(mem_buffer[:ep_data.EntryLen]) & 0xFF:
+            logger().log_hal('- Invalid entry point checksum')
+            return None
         if ep_data.IntAnchor != SMBIOS_2_x_INT_SIG:
             logger().log_hal('- Invalid intermediate signature')
+            return None
+        int_end = SMBIOS_2_x_INT_OFFSET + SMBIOS_2_x_INT_SIZE
+        if sum(mem_buffer[SMBIOS_2_x_INT_OFFSET:int_end]) & 0xFF:
+            logger().log_hal('- Invalid intermediate checksum')
             return None
         if (ep_data.TableAddr == 0) or (ep_data.TableLen == 0):
             logger().log_hal('- Invalid table address or length')
@@ -304,6 +313,9 @@ class SMBIOS(hal_base.HALBase):
             return None
         if not (ep_data.EntryLen == SMBIOS_3_x_ENTRY_SIZE):
             logger().log_hal('- Invalid structure size')
+            return None
+        if sum(mem_buffer[:ep_data.EntryLen]) & 0xFF:
+            logger().log_hal('- Invalid entry point checksum')
             return None
         if ep_data.MaxSize == 0 or ep_data.TableAddr == 0:
             logger().log_hal('- Invalid table address or maximum size')

--- a/chipsec/library/acpi_aml_parser.py
+++ b/chipsec/library/acpi_aml_parser.py
@@ -396,7 +396,6 @@ class AMLParser:
             0x0B = word value follows (3 bytes total)
             0x0C = dword value follows (5 bytes total)
             0x0E = qword value follows (9 bytes total)
-            0x02-0x09 = literal single-byte values
         """
         if offset >= len(aml_binary):
             return None, 0
@@ -422,10 +421,6 @@ class AMLParser:
         elif opcode == self.QWORD_PREFIX:
             if offset + 9 <= len(aml_binary):
                 return struct.unpack('<Q', aml_binary[offset + 1:offset + 9])[0], 9
-
-        # Direct single-byte values (0x02-0x09)
-        elif 0x02 <= opcode <= 0x09:
-            return opcode, 1
 
         # If it looks like a NameSeg or path, it's a variable reference
         # Return None to indicate this can't be decoded statically
@@ -670,9 +665,6 @@ class CRSExecutor:
             return struct.unpack('<I', data[offset + 1:offset + 5])[0], 5
         elif op == 0x0E and offset + 9 <= len(data):  # QWord
             return struct.unpack('<Q', data[offset + 1:offset + 9])[0], 9
-        elif 0x02 <= op <= 0x09:
-            return op, 1
-
         return None, 0
 
     def _decode_simple_name(self, data: bytes, offset: int) -> Tuple[Optional[str], int]:
@@ -878,8 +870,8 @@ class CRSResourceParser:
         """Decode a single resource descriptor and extract address/size for memory resources."""
 
         try:
-            # 0x84: 32-bit Memory Range (large)
-            if item_type == 0x84:
+            # 0x85: 32-bit Memory Range (large)
+            if item_type == 0x85:
                 if len(data) >= 9:
                     flags = data[0]
                     min_addr = struct.unpack('<I', data[1:5])[0]
@@ -895,8 +887,8 @@ class CRSResourceParser:
                         'description': f'Memory32: base=0x{min_addr:08x}, size=0x{length:08x}'
                     }
 
-            # 0x85: 32-bit Fixed Memory (large)
-            elif item_type == 0x85:
+            # 0x86: 32-bit Fixed Memory (large)
+            elif item_type == 0x86:
                 if len(data) >= 9:
                     flags = data[0]
                     base = struct.unpack('<I', data[1:5])[0]

--- a/chipsec/library/acpi_tables.py
+++ b/chipsec/library/acpi_tables.py
@@ -520,7 +520,7 @@ class APIC (ACPI_TABLE):
             "LAPIC_ADDRESS_OVERRIDE": '<BBHQ',
             "IOSAPIC": '<BBBBIQ',
             "PROCESSOR_LSAPIC": '<BBBBBHII',
-            "PLATFORM_INTERRUPT_SOURCES": '<BBHBBBII',
+            "PLATFORM_INTERRUPT_SOURCES": '<BBHBBBBII',
             "PROCESSOR_Lx2APIC": '<BBHIII',
             "Lx2APIC_NMI": '<BBHIB3s',
             "GICC_CPU": '<BBHIIIIIQQQQIQQ',

--- a/chipsec/library/acpi_tables.py
+++ b/chipsec/library/acpi_tables.py
@@ -104,6 +104,8 @@ class RSDP(ACPI_TABLE):
             raise ValueError(
                 f"Invalid RSDP table size: {len(table_content)}")
 
+        self.table_content = table_content
+
         # Validate signature
         if self.Signature != b'RSD PTR ':
             logger().log_warning(
@@ -138,7 +140,18 @@ class RSDP(ACPI_TABLE):
 
     # some sanity checking on RSDP
     def is_RSDP_valid(self) -> bool:
-        return 0 != self.Checksum and (0x0 == self.Revision or 0x2 == self.Revision)
+        if self.Signature != b'RSD PTR ' or self.Revision not in (0, 2):
+            return False
+        if sum(self.table_content[:ACPI_RSDP_SIZE]) & 0xFF:
+            return False
+        if self.Revision == 2:
+            if self.Length is None or self.Length < ACPI_RSDP_EXT_SIZE:
+                return False
+            if self.Length > len(self.table_content):
+                return False
+            if sum(self.table_content[:self.Length]) & 0xFF:
+                return False
+        return True
 
 
 ########################################################################################################

--- a/chipsec/library/paging.py
+++ b/chipsec/library/paging.py
@@ -112,15 +112,23 @@ class c_translation:
         return
 
     def expand_pages(self, exp_size: str) -> None:
-        SIZE = {'1GB': '2MB', '2MB': '4KB'}
-        for virt in self.translation.keys():
-            size = self.translation[virt]['size']
-            attr = self.translation[virt]['attr']
-            phys = self.translation[virt]['addr']
-            pgsize = (1 << 12) if size == '2MB' else (1 << 20)
-            if size == exp_size:
-                for i in range(512):
-                    self.add_page(virt + i * pgsize, phys + i * pgsize, SIZE[exp_size], attr)
+        child_pages = {
+            '1GB': ('2MB', SIZE_2MB),
+            '2MB': ('4KB', SIZE_4KB),
+        }
+        if exp_size not in child_pages:
+            raise ValueError(f'Unsupported page size: {exp_size}')
+
+        child_size, page_size = child_pages[exp_size]
+        for virt, page in list(self.translation.items()):
+            if page['size'] != exp_size:
+                continue
+            for index in range(512):
+                self.add_page(
+                    virt + index * page_size,
+                    page['addr'] + index * page_size,
+                    child_size,
+                    page['attr'])
         return
 
 

--- a/chipsec/library/uefi/sleep_states.py
+++ b/chipsec/library/uefi/sleep_states.py
@@ -21,7 +21,7 @@
 import struct
 from typing import List, Dict, Optional, Tuple
 
-from chipsec.library.logger import print_buffer_bytes, logger, dump_buffer, dump_buffer_bytes
+from chipsec.library.logger import print_buffer_bytes, logger, dump_buffer_bytes
 
 ########################################################################################################
 #
@@ -217,7 +217,7 @@ class op_io_pci_mem:
             values_str = '  '.join([fmt.format(v) for v in self.values])
             str_r += f'  Values : {values_str}\n'
         elif self.buffer is not None:
-            str_r += f'  Buffer (size = 0x{len(self.buffer):X}):\n{dump_buffer(self.buffer, 16)}'
+            str_r += f'  Buffer (size = 0x{len(self.buffer):X}):\n{dump_buffer_bytes(self.buffer, 16)}'
         return str_r
 
 
@@ -475,16 +475,20 @@ def encode_s3bs_opcode_def(op) -> bytes:
             encoded_opcode = encoded_hdr + struct.pack(script_width_formats[op.width] * op.count, *op.values)
 
     elif S3BootScriptOpcode_MDE.EFI_BOOT_SCRIPT_PCI_CONFIG_READ_WRITE_OPCODE == op.opcode:
-        frmt = '<BBHIQQQ'
+        encoded_opcode = struct.pack(
+            '<BBHIQQQ', op.opcode, op.width, op.unknown, 0x0,
+            op.address, op.value, op.mask)
 
     elif S3BootScriptOpcode_MDE.EFI_BOOT_SCRIPT_MEM_READ_WRITE_OPCODE == op.opcode:
         encoded_opcode = struct.pack('<BBHIQQQ', op.opcode, op.width, op.unknown, 0x0, op.address, op.value, op.mask)
 
     elif S3BootScriptOpcode_MDE.EFI_BOOT_SCRIPT_SMBUS_EXECUTE_OPCODE == op.opcode:
-        frmt = '<BBQBB'
+        encoded_opcode = struct.pack(
+            '<BBQBB', op.opcode, op.address, op.command,
+            op.operation, op.peccheck)
 
     elif S3BootScriptOpcode_MDE.EFI_BOOT_SCRIPT_STALL_OPCODE == op.opcode:
-        frmt = '<BBQ'
+        encoded_opcode = struct.pack('<BBQ', op.opcode, 0x0, op.duration)
 
     elif S3BootScriptOpcode_MDE.EFI_BOOT_SCRIPT_DISPATCH_OPCODE == op.opcode:
         encoded_opcode = struct.pack('<BBHIQ', op.opcode, 0x0, 0x0, 0x0, op.entrypoint)
@@ -493,7 +497,7 @@ def encode_s3bs_opcode_def(op) -> bytes:
         encoded_opcode = struct.pack('<BBHIQQ', op.opcode, 0x0, 0x0, 0x0, op.entrypoint, op.context)
 
     elif S3BootScriptOpcode_MDE.EFI_BOOT_SCRIPT_TERMINATE_OPCODE == op.opcode:
-        frmt = '<B'
+        encoded_opcode = struct.pack('<B', op.opcode)
 
     else:
         if logger().HAL:
@@ -601,7 +605,7 @@ def encode_s3bs_opcode_edkcompat(op: S3BOOTSCRIPT_ENTRY) -> bytes:
         pass
 
     elif S3BootScriptOpcode_EdkCompat.EFI_BOOT_SCRIPT_STALL_OPCODE == op.opcode:
-        frmt = '<Q'
+        encoded_opcode = struct.pack('<Q', op.duration)
 
     elif S3BootScriptOpcode_EdkCompat.EFI_BOOT_SCRIPT_DISPATCH_OPCODE == op.opcode:
         encoded_opcode = struct.pack('<Q', op.entrypoint)
@@ -610,7 +614,7 @@ def encode_s3bs_opcode_edkcompat(op: S3BOOTSCRIPT_ENTRY) -> bytes:
         encoded_opcode = struct.pack('<IQQQ', op.width, op.address, op.duration, op.looptimes)
 
     elif S3BootScriptOpcode_EdkCompat.EFI_BOOT_SCRIPT_TERMINATE_OPCODE == op.opcode:
-        pass
+        encoded_opcode = b''
 
     return encoded_opcode
 

--- a/chipsec/library/uefi/varstore.py
+++ b/chipsec/library/uefi/varstore.py
@@ -693,17 +693,20 @@ def getEFIvariables_NVAR_simple(nvram_buf: bytes) -> Dict[str, Tuple[int, bytes,
 
     while (start + hdr_size) < nvsize:
         efi_var_hdr = EFI_HDR_NVAR1(*struct.unpack_from(hdr_fmt, nvram_buf[start:]))
+        next_var_offset = start + efi_var_hdr.TotalSize
+        if efi_var_hdr.TotalSize < hdr_size or next_var_offset > nvsize:
+            break
         name_size = 0
         name_terminator_size = 0
         efi_var_name = "NA"
         if not IS_VARIABLE_ATTRIBUTE(efi_var_hdr.Attributes, EFI_VARIABLE_HARDWARE_ERROR_RECORD):
-            name_size = nvram_buf[start + hdr_size:].find(b'\x00')
+            name_size = nvram_buf[
+                start + hdr_size:next_var_offset].find(b'\x00')
             if name_size < 0:
                 break
             efi_var_name = nvram_buf[start + hdr_size: start + hdr_size + name_size].decode('latin1')
             name_terminator_size = 1
 
-        next_var_offset = start + efi_var_hdr.TotalSize
         efi_var_buf = nvram_buf[start: next_var_offset]
         data_offset = start + hdr_size + name_size + name_terminator_size
         efi_var_data = nvram_buf[data_offset: next_var_offset]

--- a/chipsec/library/uefi/varstore.py
+++ b/chipsec/library/uefi/varstore.py
@@ -272,6 +272,13 @@ AUTH_CERT_DB_DATA = "<16sIII"
 AUTH_CERT_DB_DATA_size = struct.calcsize(AUTH_CERT_DB_DATA)
 
 
+def _safe_filename_component(value: str) -> str:
+    invalid_chars = '<>:"/\\|?*'
+    return ''.join(
+        '_' if char in invalid_chars or ord(char) < 0x20 else char
+        for char in value).strip().rstrip('.') or 'unnamed'
+
+
 def parse_auth_var(db: bytes, decode_dir: str) -> List[bytes]:
     entries = []
     dof = 0
@@ -295,14 +302,16 @@ def parse_auth_var(db: bytes, decode_dir: str) -> List[bytes]:
         name_size *= 2  # Name size is actually the number of CHAR16 in the name array
         tof = dof + AUTH_CERT_DB_DATA_size
         try:
-            var_name = codecs.decode(db[tof:tof + name_size], 'utf-16')
+            var_name = codecs.decode(
+                db[tof:tof + name_size], 'utf-16-le').rstrip('\x00')
         except UnicodeDecodeError:
             logger().log_warning(f'Unable to decode {db[tof:tof + name_size]}')
             var_name = "chipsec.library.exceptions!"
         tof += name_size
         sig_data = db[tof:tof + cert_data_size]
         entries.append(sig_data)
-        sig_file_name = f'{vendor_guid}-{codecs.encode(var_name)}-{nsig:02X}.bin'
+        safe_var_name = _safe_filename_component(var_name)
+        sig_file_name = f'{vendor_guid}-{safe_var_name}-{nsig:02X}.bin'
         sig_file_name = os.path.join(decode_dir, sig_file_name)
         write_file(sig_file_name, sig_data)
         dof += cert_node_size
@@ -685,14 +694,19 @@ def getEFIvariables_NVAR_simple(nvram_buf: bytes) -> Dict[str, Tuple[int, bytes,
     while (start + hdr_size) < nvsize:
         efi_var_hdr = EFI_HDR_NVAR1(*struct.unpack_from(hdr_fmt, nvram_buf[start:]))
         name_size = 0
+        name_terminator_size = 0
         efi_var_name = "NA"
         if not IS_VARIABLE_ATTRIBUTE(efi_var_hdr.Attributes, EFI_VARIABLE_HARDWARE_ERROR_RECORD):
             name_size = nvram_buf[start + hdr_size:].find(b'\x00')
+            if name_size < 0:
+                break
             efi_var_name = nvram_buf[start + hdr_size: start + hdr_size + name_size].decode('latin1')
+            name_terminator_size = 1
 
         next_var_offset = start + efi_var_hdr.TotalSize
         efi_var_buf = nvram_buf[start: next_var_offset]
-        efi_var_data = nvram_buf[start + hdr_size + name_size: next_var_offset]
+        data_offset = start + hdr_size + name_size + name_terminator_size
+        efi_var_data = nvram_buf[data_offset: next_var_offset]
 
         if efi_var_name not in variables.keys():
             variables[efi_var_name] = []

--- a/tests/fuzzing/test_primitives.py
+++ b/tests/fuzzing/test_primitives.py
@@ -1,0 +1,339 @@
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2026, Intel Corporation
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Contact information:
+# chipsec@intel.com
+#
+
+import struct
+import unittest
+
+from chipsec.fuzzing.primitives import (
+    bit_field,
+    byte,
+    delim,
+    dword,
+    group,
+    qword,
+    random_data,
+    static,
+    string,
+    word,
+)
+
+
+def drain(primitive, limit: int = 10000) -> list:
+    """Mutate until the primitive reports completion and collect every value."""
+    values = []
+    while primitive.mutate():
+        values.append(primitive.value)
+        if len(values) > limit:
+            raise AssertionError(f'{type(primitive).__name__} never reported completion')
+    return values
+
+
+class TestPrimitiveMutationContract(unittest.TestCase):
+    """Every primitive shares the same mutate/reset/exhaust lifecycle."""
+
+    def test_mutation_count_matches_reported_number_of_mutations(self):
+        primitive = delim(':')
+
+        self.assertEqual(len(drain(primitive)), primitive.num_mutations())
+
+    def test_mutation_stops_and_restores_the_original_value(self):
+        primitive = delim(':')
+        drain(primitive)
+
+        self.assertFalse(primitive.mutate())
+        self.assertTrue(primitive.fuzz_complete)
+        self.assertEqual(primitive.value, primitive.original_value)
+
+    def test_mutation_index_advances_once_per_mutation(self):
+        primitive = delim(':')
+
+        primitive.mutate()
+        primitive.mutate()
+
+        self.assertEqual(primitive.mutant_index, 2)
+
+    def test_reset_returns_the_primitive_to_its_starting_state(self):
+        primitive = delim(':')
+        drain(primitive)
+
+        primitive.reset()
+
+        self.assertFalse(primitive.fuzz_complete)
+        self.assertEqual(primitive.mutant_index, 0)
+        self.assertEqual(primitive.value, primitive.original_value)
+        self.assertTrue(primitive.mutate())
+
+    def test_exhaust_skips_the_remaining_mutations(self):
+        primitive = delim(':')
+        primitive.mutate()
+
+        remaining = primitive.exhaust()
+
+        self.assertEqual(remaining, primitive.num_mutations() - 1)
+        self.assertTrue(primitive.fuzz_complete)
+        self.assertEqual(primitive.value, primitive.original_value)
+        self.assertFalse(primitive.mutate())
+
+    def test_disabling_fuzzing_suppresses_all_mutations(self):
+        primitive = delim(':', fuzzable=False)
+
+        self.assertFalse(primitive.mutate())
+        self.assertEqual(primitive.value, ':')
+
+    def test_render_reflects_the_current_value(self):
+        primitive = delim(':')
+        primitive.mutate()
+
+        self.assertEqual(primitive.render(), primitive.value)
+
+
+class TestDelim(unittest.TestCase):
+
+    def test_library_repeats_the_delimiter(self):
+        primitive = delim(':')
+
+        values = drain(primitive)
+
+        self.assertIn('::', values)
+        self.assertIn('', values)
+
+    def test_space_delimiter_adds_tab_substitutions(self):
+        spaced = drain(delim(' '))
+        colon = drain(delim(':'))
+
+        self.assertGreater(len(spaced), len(colon))
+
+    def test_empty_delimiter_has_no_repetition_cases(self):
+        empty = delim('')
+        colon = delim(':')
+
+        self.assertLess(empty.num_mutations(), colon.num_mutations())
+
+    def test_named_primitive_keeps_its_name(self):
+        self.assertEqual(delim(':', name='separator').name, 'separator')
+
+
+class TestGroup(unittest.TestCase):
+
+    def test_group_steps_through_every_value_in_order(self):
+        primitive = group('opcodes', ['a', 'b', 'c'])
+
+        self.assertEqual(drain(primitive), ['a', 'b', 'c'])
+
+    def test_group_reports_one_mutation_per_value(self):
+        self.assertEqual(group('opcodes', ['a', 'b', 'c']).num_mutations(), 3)
+
+    def test_group_falls_back_to_the_first_value_once_exhausted(self):
+        primitive = group('opcodes', ['a', 'b'])
+        drain(primitive)
+
+        self.assertFalse(primitive.mutate())
+        self.assertEqual(primitive.value, 'a')
+
+    def test_group_rejects_non_string_values(self):
+        with self.assertRaises(AssertionError):
+            group('opcodes', ['a', 1])
+
+
+class TestRandomData(unittest.TestCase):
+
+    def test_default_mutation_budget_is_respected(self):
+        primitive = random_data('seed', 1, 4, max_mutations=7)
+
+        self.assertEqual(len(drain(primitive)), 7)
+
+    def test_generated_values_are_raw_bytes_within_the_requested_range(self):
+        primitive = random_data('seed', 3, 6, max_mutations=20)
+
+        for value in drain(primitive):
+            self.assertIsInstance(value, bytes)
+            self.assertTrue(3 <= len(value) <= 6)
+
+    def test_stepping_produces_deterministic_lengths(self):
+        primitive = random_data('seed', 0, 10, step=5)
+
+        lengths = [len(value) for value in drain(primitive)]
+
+        self.assertEqual(lengths, [0, 5, 10])
+
+    def test_stepping_overrides_the_mutation_budget(self):
+        self.assertEqual(random_data('seed', 0, 10, max_mutations=99, step=5).num_mutations(), 3)
+
+    def test_original_value_is_restored_after_exhaustion(self):
+        primitive = random_data('seed', 1, 2, max_mutations=3)
+        drain(primitive)
+
+        self.assertFalse(primitive.mutate())
+        self.assertEqual(primitive.value, 'seed')
+
+
+class TestStatic(unittest.TestCase):
+
+    def test_static_content_never_mutates(self):
+        primitive = static(b'\x01\x02')
+
+        self.assertFalse(primitive.mutate())
+        self.assertEqual(primitive.num_mutations(), 0)
+        self.assertEqual(primitive.value, b'\x01\x02')
+
+    def test_static_renders_its_value_unchanged(self):
+        self.assertEqual(static(b'\x01\x02').render(), b'\x01\x02')
+
+    def test_static_is_marked_complete_from_the_start(self):
+        self.assertTrue(static(b'').fuzz_complete)
+
+
+class TestString(unittest.TestCase):
+
+    def test_mutation_count_matches_reported_number_of_mutations(self):
+        primitive = string('A')
+
+        self.assertEqual(len(drain(primitive)), primitive.num_mutations())
+
+    def test_mutations_include_repetitions_of_the_original_value(self):
+        values = drain(string('A'))
+
+        self.assertIn('AA', values)
+
+    def test_render_encodes_using_the_configured_encoding(self):
+        primitive = string('A', encoding='utf_16_le')
+
+        self.assertEqual(primitive.render(), 'A'.encode('utf_16_le'))
+
+    def test_render_falls_back_when_a_value_is_not_encodable(self):
+        primitive = string('A')
+        primitive.value = '\xfe'
+
+        self.assertEqual(primitive.render(), b'\xfe')
+
+    def test_fixed_size_strings_are_padded_to_the_requested_width(self):
+        primitive = string('A', size=64, padding='\x00')
+
+        primitive.mutate()
+
+        self.assertEqual(len(primitive.value), 64)
+
+    def test_disabling_fuzzing_suppresses_all_mutations(self):
+        primitive = string('A', fuzzable=False)
+
+        self.assertFalse(primitive.mutate())
+        self.assertEqual(primitive.value, 'A')
+
+
+class TestBitFieldEncoding(unittest.TestCase):
+    """bit_field defines how every integer primitive is serialized."""
+
+    def test_binary_render_is_little_endian_by_default(self):
+        self.assertEqual(bit_field(0x1234, 16).render(), b'\x34\x12')
+
+    def test_binary_render_honors_big_endian(self):
+        self.assertEqual(bit_field(0x1234, 16, endian='>').render(), b'\x12\x34')
+
+    def test_widths_are_padded_up_to_a_byte_boundary(self):
+        rendered = bit_field(0xABC, 12, endian='>').render()
+
+        self.assertEqual(len(rendered), 2)
+        self.assertEqual(rendered, b'\x0a\xbc')
+
+    def test_ascii_render_returns_the_decimal_representation(self):
+        self.assertEqual(bit_field(42, 8, format='ascii').render(), '42')
+
+    def test_ascii_render_of_a_signed_value_is_negative(self):
+        self.assertEqual(bit_field(0xFF, 8, format='ascii', signed=True).render(), '-1')
+
+    def test_binary_conversion_round_trips(self):
+        primitive = bit_field(0, 16)
+
+        self.assertEqual(primitive.to_decimal(primitive.to_binary(0xBEEF, 16)), 0xBEEF)
+
+    def test_to_binary_uses_the_configured_width(self):
+        self.assertEqual(bit_field(0, 8).to_binary(1), '00000001')
+
+
+class TestBitFieldLibrary(unittest.TestCase):
+
+    def test_smart_boundaries_stay_inside_the_representable_range(self):
+        primitive = bit_field(0, 8)
+
+        for value in drain(primitive):
+            self.assertTrue(0 <= value < primitive.max_num)
+
+    def test_full_range_enumerates_every_representable_value(self):
+        primitive = bit_field(0, 4, full_range=True)
+
+        self.assertEqual(primitive.num_mutations(), primitive.max_num)
+        self.assertEqual(sorted(drain(primitive)), list(range(primitive.max_num)))
+
+    def test_supplied_value_list_becomes_the_mutation_library(self):
+        primitive = bit_field([1, 2, 3], 8)
+
+        self.assertEqual(drain(primitive), [1, 2, 3])
+
+    def test_value_list_is_cycled_when_rendering_without_mutation(self):
+        primitive = bit_field([1, 2], 8)
+
+        rendered = [primitive.render(), primitive.render(), primitive.render()]
+
+        self.assertEqual(rendered, [b'\x01', b'\x02', b'\x01'])
+
+    def test_non_numeric_values_are_rejected(self):
+        with self.assertRaises(ValueError):
+            bit_field('not-a-number', 8)
+
+    def test_explicit_max_num_bounds_the_library(self):
+        primitive = bit_field(0, 32, max_num=16)
+
+        for value in drain(primitive):
+            self.assertLess(value, 16)
+
+
+class TestSizedIntegerPrimitives(unittest.TestCase):
+    """byte/word/dword/qword are width-specialized bit_fields."""
+
+    def test_widths(self):
+        self.assertEqual(byte(0).width, 8)
+        self.assertEqual(word(0).width, 16)
+        self.assertEqual(dword(0).width, 32)
+        self.assertEqual(qword(0).width, 64)
+
+    def test_render_widths_match_the_declared_size(self):
+        self.assertEqual(len(byte(0xFF).render()), 1)
+        self.assertEqual(len(word(0xFFFF).render()), 2)
+        self.assertEqual(len(dword(0xFFFFFFFF).render()), 4)
+        self.assertEqual(len(qword(0xFFFFFFFFFFFFFFFF).render()), 8)
+
+    def test_packed_input_is_unpacked_to_an_integer(self):
+        self.assertEqual(byte(struct.pack('<B', 0xAB)).value, 0xAB)
+        self.assertEqual(word(struct.pack('<H', 0xBEEF)).value, 0xBEEF)
+        self.assertEqual(dword(struct.pack('<L', 0xDEADBEEF)).value, 0xDEADBEEF)
+        self.assertEqual(qword(struct.pack('<Q', 0x1122334455667788)).value, 0x1122334455667788)
+
+    def test_dword_round_trips_through_render(self):
+        self.assertEqual(dword(0x12345678).render(), struct.pack('<L', 0x12345678))
+
+    def test_type_identifiers_are_reported(self):
+        self.assertEqual(
+            [byte(0).s_type, word(0).s_type, dword(0).s_type, qword(0).s_type],
+            ['byte', 'word', 'dword', 'qword'],
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/fuzzing/test_primitives.py
+++ b/tests/fuzzing/test_primitives.py
@@ -202,6 +202,26 @@ class TestStatic(unittest.TestCase):
 
 class TestString(unittest.TestCase):
 
+    def test_instances_reuse_the_global_fuzz_library(self):
+        first = string('A')
+        second = string('B')
+
+        self.assertIs(first.string_fuzz_library, second.string_fuzz_library)
+        self.assertIs(first.string_fuzz_library, string.fuzz_library)
+        self.assertGreater(first.num_mutations(), len(first.this_library))
+
+    def test_max_length_filter_does_not_modify_the_global_library(self):
+        unconstrained = string('A')
+        global_count = len(unconstrained.string_fuzz_library)
+
+        constrained = string('A', max_len=32)
+
+        self.assertEqual(len(string.fuzz_library), global_count)
+        self.assertTrue(all(len(value) <= 32
+                    for value in constrained.string_fuzz_library))
+        self.assertTrue(any(len(value) > 32
+                    for value in unconstrained.string_fuzz_library))
+
     def test_mutation_count_matches_reported_number_of_mutations(self):
         primitive = string('A')
 

--- a/tests/hal/test_acpi.py
+++ b/tests/hal/test_acpi.py
@@ -20,13 +20,16 @@ import unittest
 from unittest.mock import MagicMock
 from chipsec.library.acpi_tables import RSDP
 from chipsec.hal.common.acpi import ACPI
+from tests.helpers.acpi_utils import build_rsdp
 
 class TestACPI(unittest.TestCase):
     def test_apci_read_rsdp(self):
         mock_cs = MagicMock()
-        rsdp_buf = b'RSD PTR \x93INTEL\x00\x02(\xd0^z'
-        rsdp_buf_ext = b'RSD PTR \x93INTEL\x00\x02(\xd0^z$\x00\x00\x00\xc0\xd0^z\x00\x00\x00\x00t\x00\x00\x00'
-        mock_cs.hals.memory.read_physical_mem.side_effect = [rsdp_buf, rsdp_buf_ext]
+        rsdp = build_rsdp(
+            revision=2,
+            rsdt_address=0x7A5ED028,
+            xsdt_address=0x7A5ED0C0)
+        mock_cs.hals.memory.read_physical_mem.side_effect = [rsdp[:20], rsdp]
         pa = 983056
         test_acpi = ACPI(mock_cs)
         self.assertIsInstance(test_acpi.read_RSDP(pa), RSDP)

--- a/tests/hal/test_smbios.py
+++ b/tests/hal/test_smbios.py
@@ -1,0 +1,425 @@
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2026, Intel Corporation
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Contact information:
+# chipsec@intel.com
+#
+
+import struct
+import unittest
+from unittest.mock import MagicMock, patch
+
+from chipsec.hal.common import smbios
+from chipsec.hal.common.smbios import (
+    SMBIOS,
+    SMBIOS_2_x_ENTRY_POINT,
+    SMBIOS_3_x_ENTRY_POINT,
+    SMBIOS_BIOS_INFO_2_0,
+    SMBIOS_STRUCT_HEADER,
+    SMBIOS_SYSTEM_INFO_2_0,
+)
+
+TABLE_ADDR = 0x7A600000
+TABLE_LEN = 0x400
+
+
+def smbios_struct(struct_type: int, fixed: bytes, strings=(), handle: int = 0) -> bytes:
+    """Build one SMBIOS structure: header, fixed area, string set, terminator."""
+    length = smbios.SMBIOS_STRUCT_HEADER_SIZE + len(fixed)
+    body = struct.pack(smbios.SMBIOS_STRUCT_HEADER_FMT, struct_type, length, handle) + fixed
+    if strings:
+        string_area = b''.join(s.encode('ascii') + b'\x00' for s in strings) + b'\x00'
+    else:
+        string_area = b'\x00\x00'
+    return body + string_area
+
+
+def bios_info(vendor=1, version=2, release=3, segment=0xE000, rom_sz=0xFF,
+              characteristics=0x0123456789ABCDEF, strings=('Intel Corp.', '1.0', '01/01/2026')):
+    fixed = struct.pack('=BBHBBQ', vendor, version, segment, release, rom_sz, characteristics)
+    return smbios_struct(smbios.SMBIOS_BIOS_INFO_ENTRY_ID, fixed, strings)
+
+
+def system_info(manufacturer=1, product=2, version=3, serial=4,
+                strings=('Intel', 'Board', 'A0', 'SN12345')):
+    fixed = struct.pack('=BBBB', manufacturer, product, version, serial)
+    return smbios_struct(smbios.SMBIOS_SYSTEM_INFO_ENTRY_ID, fixed, strings)
+
+
+def entry_point_2x(table_addr=TABLE_ADDR, table_len=TABLE_LEN, entry_len=0x1F,
+                   anchor=smbios.SMBIOS_2_x_SIG, int_anchor=smbios.SMBIOS_2_x_INT_SIG):
+    return struct.pack(smbios.SMBIOS_2_x_ENTRY_POINT_FMT, anchor, 0x5A, entry_len, 2, 8,
+                       0x100, 0, 0, 0, 0, 0, 0, int_anchor, 0xA5, table_len, table_addr, 4, 0x28)
+
+
+def entry_point_3x(table_addr=TABLE_ADDR, max_size=TABLE_LEN, entry_len=0x18,
+                   anchor=smbios.SMBIOS_3_x_SIG):
+    return struct.pack(smbios.SMBIOS_3_x_ENTRY_POINT_FMT, anchor, 0x5A, entry_len,
+                       3, 4, 0, 1, 0, max_size, table_addr)
+
+
+def make_smbios():
+    """SMBIOS HAL wired to a mock chipset with the UEFI dependency stubbed out."""
+    cs = MagicMock()
+    with patch.object(smbios.uefi, 'UEFI', MagicMock()):
+        hal = SMBIOS(cs)
+    return hal, cs
+
+
+class TestStructureHeader(unittest.TestCase):
+
+    def test_header_exposes_type_length_and_handle(self):
+        hal, _cs = make_smbios()
+
+        header = hal.get_header(smbios_struct(1, b'\x00' * 4, handle=0x1234))
+
+        self.assertEqual(header.Type, 1)
+        self.assertEqual(header.Length, 8)
+        self.assertEqual(header.Handle, 0x1234)
+
+    def test_missing_data_has_no_header(self):
+        hal, _cs = make_smbios()
+
+        self.assertIsNone(hal.get_header(None))
+
+    def test_data_shorter_than_a_header_is_rejected(self):
+        hal, _cs = make_smbios()
+
+        self.assertIsNone(hal.get_header(b'\x00\x01'))
+
+    def test_header_renders_its_fields(self):
+        self.assertIn('0x1234', str(SMBIOS_STRUCT_HEADER(1, 8, 0x1234)))
+
+
+class TestStringList(unittest.TestCase):
+
+    def setUp(self):
+        self.hal, _cs = make_smbios()
+
+    def test_every_string_in_the_string_area_is_returned(self):
+        data = smbios_struct(1, b'\x00' * 4, strings=('Intel', 'Board', 'A0'))
+
+        self.assertEqual(self.hal.get_string_list(data), ['Intel', 'Board', 'A0'])
+
+    def test_a_structure_without_strings_returns_an_empty_list(self):
+        data = smbios_struct(1, b'\x00' * 4)
+
+        self.assertEqual(self.hal.get_string_list(data), [])
+
+    def test_data_too_small_for_the_declared_length_is_rejected(self):
+        data = struct.pack(smbios.SMBIOS_STRUCT_HEADER_FMT, 1, 32, 0)
+
+        self.assertIsNone(self.hal.get_string_list(data))
+
+    def test_data_without_a_header_is_rejected(self):
+        self.assertIsNone(self.hal.get_string_list(b'\x00'))
+
+    def test_strings_are_returned_as_text(self):
+        data = smbios_struct(1, b'\x00' * 4, strings=('Intel',))
+
+        self.assertIsInstance(self.hal.get_string_list(data)[0], str)
+
+
+class TestRawStructureIteration(unittest.TestCase):
+
+    def setUp(self):
+        self.hal, _cs = make_smbios()
+
+    def test_no_table_data_yields_nothing(self):
+        self.assertIsNone(self.hal.get_raw_structs(None, False))
+
+    def test_every_structure_in_the_table_is_returned(self):
+        self.hal.smbios_2_data = bios_info() + system_info()
+
+        self.assertEqual(len(self.hal.get_raw_structs(None, False)), 2)
+
+    def test_structures_can_be_filtered_by_type(self):
+        self.hal.smbios_2_data = bios_info() + system_info()
+
+        structs = self.hal.get_raw_structs(smbios.SMBIOS_SYSTEM_INFO_ENTRY_ID, False)
+
+        self.assertEqual(len(structs), 1)
+        self.assertEqual(self.hal.get_header(structs[0]).Type, smbios.SMBIOS_SYSTEM_INFO_ENTRY_ID)
+
+    def test_a_filter_that_matches_nothing_returns_no_structures(self):
+        self.hal.smbios_2_data = bios_info()
+
+        self.assertEqual(self.hal.get_raw_structs(0x7F, False), [])
+
+    def test_the_64_bit_table_is_preferred_when_both_are_present(self):
+        self.hal.smbios_2_data = bios_info()
+        self.hal.smbios_3_data = system_info()
+
+        structs = self.hal.get_raw_structs(None, False)
+
+        self.assertEqual(self.hal.get_header(structs[0]).Type, smbios.SMBIOS_SYSTEM_INFO_ENTRY_ID)
+
+    def test_the_32_bit_table_can_be_forced(self):
+        self.hal.smbios_2_data = bios_info()
+        self.hal.smbios_3_data = system_info()
+
+        structs = self.hal.get_raw_structs(None, True)
+
+        self.assertEqual(self.hal.get_header(structs[0]).Type, smbios.SMBIOS_BIOS_INFO_ENTRY_ID)
+
+    def test_a_returned_structure_carries_its_own_strings(self):
+        self.hal.smbios_2_data = system_info(strings=('Intel', 'Board'))
+
+        raw = self.hal.get_raw_structs(None, False)[0]
+
+        self.assertEqual(self.hal.get_string_list(raw), ['Intel', 'Board'])
+
+    def test_a_truncated_table_stops_iteration(self):
+        self.hal.smbios_2_data = struct.pack(smbios.SMBIOS_STRUCT_HEADER_FMT, 1, 64, 0)
+
+        self.assertEqual(self.hal.get_raw_structs(None, False), [])
+
+
+class TestDecodedStructures(unittest.TestCase):
+
+    def setUp(self):
+        self.hal, _cs = make_smbios()
+
+    def test_no_table_data_yields_nothing(self):
+        self.assertIsNone(self.hal.get_decoded_structs())
+
+    def test_bios_information_is_decoded_with_its_strings(self):
+        self.hal.smbios_2_data = bios_info(characteristics=0x1122334455667788)
+
+        decoded = self.hal.get_decoded_structs()[0]
+
+        self.assertIsInstance(decoded, SMBIOS_BIOS_INFO_2_0)
+        self.assertEqual(decoded.bios_char, 0x1122334455667788)
+        self.assertEqual(decoded.strings, ['Intel Corp.', '1.0', '01/01/2026'])
+
+    def test_system_information_is_decoded_with_its_strings(self):
+        self.hal.smbios_2_data = system_info()
+
+        decoded = self.hal.get_decoded_structs()[0]
+
+        self.assertIsInstance(decoded, SMBIOS_SYSTEM_INFO_2_0)
+        self.assertEqual(decoded.strings, ['Intel', 'Board', 'A0', 'SN12345'])
+
+    def test_structures_without_a_decoder_are_skipped(self):
+        self.hal.smbios_2_data = smbios_struct(0x7F, b'\x00' * 8) + system_info()
+
+        decoded = self.hal.get_decoded_structs()
+
+        self.assertEqual(len(decoded), 1)
+        self.assertIsInstance(decoded[0], SMBIOS_SYSTEM_INFO_2_0)
+
+    def test_decoding_can_be_restricted_to_one_structure_type(self):
+        self.hal.smbios_2_data = bios_info() + system_info()
+
+        decoded = self.hal.get_decoded_structs(smbios.SMBIOS_BIOS_INFO_ENTRY_ID)
+
+        self.assertEqual(len(decoded), 1)
+        self.assertIsInstance(decoded[0], SMBIOS_BIOS_INFO_2_0)
+
+
+class TestDecodedStructureRendering(unittest.TestCase):
+    """String indexes are one-based references into the structure's string set."""
+
+    def test_bios_information_resolves_its_string_indexes(self):
+        info = SMBIOS_BIOS_INFO_2_0(0, 18, 0, 1, 2, 0xE000, 3, 0xFF, 0, ['Intel Corp.', '1.0', '01/01/2026'])
+
+        rendered = str(info)
+
+        self.assertIn('Intel Corp.', rendered)
+        self.assertIn('01/01/2026', rendered)
+
+    def test_bios_information_tolerates_missing_strings(self):
+        info = SMBIOS_BIOS_INFO_2_0(0, 18, 0, 0, 0, 0xE000, 0, 0xFF, 0, [])
+
+        self.assertIn('SMBIOS BIOS Information', str(info))
+
+    def test_bios_information_tolerates_out_of_range_indexes(self):
+        info = SMBIOS_BIOS_INFO_2_0(0, 18, 0, 9, 9, 0xE000, 9, 0xFF, 0, ['Intel Corp.'])
+
+        self.assertIn('SMBIOS BIOS Information', str(info))
+
+    def test_system_information_resolves_its_string_indexes(self):
+        info = SMBIOS_SYSTEM_INFO_2_0(1, 8, 0, 1, 2, 3, 4, ['Intel', 'Board', 'A0', 'SN12345'])
+
+        rendered = str(info)
+
+        self.assertIn('Intel', rendered)
+        self.assertIn('SN12345', rendered)
+
+    def test_system_information_tolerates_missing_strings(self):
+        info = SMBIOS_SYSTEM_INFO_2_0(1, 8, 0, 0, 0, 0, 0, [])
+
+        self.assertIn('SMBIOS System Information', str(info))
+
+
+class TestEntryPointValidation(unittest.TestCase):
+    """Entry points are only accepted when their anchors and sizes check out."""
+
+    def _validate_2x(self, buffer):
+        hal, cs = make_smbios()
+        cs.hals.memory.read_physical_mem.return_value = buffer
+        return hal._SMBIOS__validate_ep_2_values(0xF0000)
+
+    def _validate_3x(self, buffer):
+        hal, cs = make_smbios()
+        cs.hals.memory.read_physical_mem.return_value = buffer
+        return hal._SMBIOS__validate_ep_3_values(0xF0000)
+
+    def test_a_well_formed_2x_entry_point_is_accepted(self):
+        ep = self._validate_2x(entry_point_2x())
+
+        self.assertIsNotNone(ep)
+        self.assertEqual(ep.TableAddr, TABLE_ADDR)
+        self.assertEqual(ep.TableLen, TABLE_LEN)
+
+    def test_the_legacy_2x_entry_point_size_is_accepted(self):
+        self.assertIsNotNone(self._validate_2x(entry_point_2x(entry_len=0x1E)))
+
+    def test_a_2x_entry_point_with_a_bad_anchor_is_rejected(self):
+        self.assertIsNone(self._validate_2x(entry_point_2x(anchor=b'BAD_')))
+
+    def test_a_2x_entry_point_with_a_bad_intermediate_anchor_is_rejected(self):
+        self.assertIsNone(self._validate_2x(entry_point_2x(int_anchor=b'BAD__')))
+
+    def test_a_2x_entry_point_with_an_unexpected_size_is_rejected(self):
+        self.assertIsNone(self._validate_2x(entry_point_2x(entry_len=0x10)))
+
+    def test_a_2x_entry_point_without_a_table_is_rejected(self):
+        self.assertIsNone(self._validate_2x(entry_point_2x(table_addr=0)))
+        self.assertIsNone(self._validate_2x(entry_point_2x(table_len=0)))
+
+    def test_an_unreadable_2x_entry_point_is_rejected(self):
+        self.assertIsNone(self._validate_2x(b'\x00' * 4))
+
+    def test_a_well_formed_3x_entry_point_is_accepted(self):
+        ep = self._validate_3x(entry_point_3x())
+
+        self.assertIsNotNone(ep)
+        self.assertEqual(ep.TableAddr, TABLE_ADDR)
+        self.assertEqual(ep.MaxSize, TABLE_LEN)
+
+    def test_a_3x_entry_point_with_a_bad_anchor_is_rejected(self):
+        self.assertIsNone(self._validate_3x(entry_point_3x(anchor=b'BAD__')))
+
+    def test_a_3x_entry_point_with_an_unexpected_size_is_rejected(self):
+        self.assertIsNone(self._validate_3x(entry_point_3x(entry_len=0x20)))
+
+    def test_a_3x_entry_point_without_a_table_is_rejected(self):
+        self.assertIsNone(self._validate_3x(entry_point_3x(table_addr=0)))
+        self.assertIsNone(self._validate_3x(entry_point_3x(max_size=0)))
+
+    def test_entry_points_render_their_table_location(self):
+        ep2 = SMBIOS_2_x_ENTRY_POINT(*struct.unpack_from(smbios.SMBIOS_2_x_ENTRY_POINT_FMT, entry_point_2x()))
+        ep3 = SMBIOS_3_x_ENTRY_POINT(*struct.unpack_from(smbios.SMBIOS_3_x_ENTRY_POINT_FMT, entry_point_3x()))
+
+        self.assertIn('7A600000', str(ep2))
+        self.assertIn('7A600000', str(ep3))
+
+
+class TestTableDiscovery(unittest.TestCase):
+    """The table is located through the UEFI config table or a memory scan."""
+
+    @staticmethod
+    def _hal_with_memory(memory_map, config_table=(False, None, None, None)):
+        hal, cs = make_smbios()
+        hal.uefi.find_EFI_Configuration_Table.return_value = config_table
+
+        def read(pa, size):
+            return memory_map.get(pa, b'\x00' * size)
+
+        cs.hals.memory.read_physical_mem.side_effect = read
+        return hal, cs
+
+    def test_an_already_located_table_is_not_searched_again(self):
+        hal, cs = make_smbios()
+        hal.smbios_2_ep = object()
+
+        self.assertTrue(hal.find_smbios_table())
+        cs.hals.memory.read_physical_mem.assert_not_called()
+
+    def test_a_memory_scan_that_finds_nothing_reports_failure(self):
+        hal, _cs = self._hal_with_memory({})
+
+        self.assertFalse(hal.find_smbios_table())
+
+    def test_a_2x_entry_point_found_by_scanning_loads_the_table(self):
+        table = bios_info()
+        scan_page = entry_point_2x(table_len=len(table)).ljust(smbios.SCAN_SIZE, b'\x00')
+        hal, _cs = self._hal_with_memory({
+            smbios.SCAN_LOW_LIMIT: scan_page,
+            TABLE_ADDR: table,
+        })
+
+        self.assertTrue(hal.find_smbios_table())
+        self.assertEqual(hal.smbios_2_pa, smbios.SCAN_LOW_LIMIT)
+        self.assertEqual(hal.smbios_2_data, table)
+
+    def test_a_3x_entry_point_found_by_scanning_loads_the_table(self):
+        table = system_info()
+        scan_page = entry_point_3x(max_size=len(table)).ljust(smbios.SCAN_SIZE, b'\x00')
+        hal, _cs = self._hal_with_memory({
+            smbios.SCAN_LOW_LIMIT: scan_page,
+            TABLE_ADDR: table,
+        })
+
+        self.assertTrue(hal.find_smbios_table())
+        self.assertEqual(hal.smbios_3_data, table)
+
+    def test_a_discovered_table_can_be_decoded_end_to_end(self):
+        table = bios_info() + system_info()
+        scan_page = entry_point_2x(table_len=len(table)).ljust(smbios.SCAN_SIZE, b'\x00')
+        hal, _cs = self._hal_with_memory({
+            smbios.SCAN_LOW_LIMIT: scan_page,
+            TABLE_ADDR: table,
+        })
+        hal.find_smbios_table()
+
+        decoded = hal.get_decoded_structs()
+
+        self.assertEqual([type(d) for d in decoded], [SMBIOS_BIOS_INFO_2_0, SMBIOS_SYSTEM_INFO_2_0])
+
+    def test_config_table_guids_are_recorded_when_present(self):
+        config = MagicMock()
+        config.VendorTables = {smbios.SMBIOS_2_x_GUID: TABLE_ADDR}
+        table = bios_info()
+        scan_page = entry_point_2x(table_len=len(table)).ljust(smbios.SCAN_SIZE, b'\x00')
+        hal, cs = self._hal_with_memory(
+            {smbios.SCAN_LOW_LIMIT: scan_page, TABLE_ADDR: table},
+            config_table=(True, 0, config, None))
+        cs.hals.cpu.get_SMRAM.return_value = (smbios.SCAN_LOW_LIMIT + smbios.SCAN_SIZE, 0, 0)
+
+        self.assertTrue(hal.find_smbios_table())
+        self.assertTrue(hal.smbios_2_guid_found)
+
+
+class TestEntryPointFormats(unittest.TestCase):
+    """The entry point layouts are fixed by the SMBIOS specification."""
+
+    def test_declared_entry_point_sizes(self):
+        self.assertEqual(smbios.SMBIOS_2_x_ENTRY_POINT_SIZE, smbios.SMBIOS_2_x_ENTRY_SIZE)
+        self.assertEqual(smbios.SMBIOS_3_x_ENTRY_POINT_SIZE, smbios.SMBIOS_3_x_ENTRY_SIZE)
+
+    def test_structure_header_is_four_bytes(self):
+        self.assertEqual(smbios.SMBIOS_STRUCT_HEADER_SIZE, 4)
+
+    def test_every_decodable_type_has_a_class_and_a_format(self):
+        for entry in smbios.struct_decode_tree.values():
+            self.assertIn('class', entry)
+            self.assertIn('format', entry)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/hal/test_smbios.py
+++ b/tests/hal/test_smbios.py
@@ -107,7 +107,7 @@ class TestStructureHeader(unittest.TestCase):
 class TestStringList(unittest.TestCase):
 
     def setUp(self):
-        self.hal, _cs = make_smbios()
+        self.hal = make_smbios()[0]
 
     def test_every_string_in_the_string_area_is_returned(self):
         data = smbios_struct(1, b'\x00' * 4, strings=('Intel', 'Board', 'A0'))
@@ -136,7 +136,7 @@ class TestStringList(unittest.TestCase):
 class TestRawStructureIteration(unittest.TestCase):
 
     def setUp(self):
-        self.hal, _cs = make_smbios()
+        self.hal = make_smbios()[0]
 
     def test_no_table_data_yields_nothing(self):
         self.assertIsNone(self.hal.get_raw_structs(None, False))
@@ -191,7 +191,7 @@ class TestRawStructureIteration(unittest.TestCase):
 class TestDecodedStructures(unittest.TestCase):
 
     def setUp(self):
-        self.hal, _cs = make_smbios()
+        self.hal = make_smbios()[0]
 
     def test_no_table_data_yields_nothing(self):
         self.assertIsNone(self.hal.get_decoded_structs())

--- a/tests/hal/test_smbios.py
+++ b/tests/hal/test_smbios.py
@@ -61,14 +61,25 @@ def system_info(manufacturer=1, product=2, version=3, serial=4,
 
 def entry_point_2x(table_addr=TABLE_ADDR, table_len=TABLE_LEN, entry_len=0x1F,
                    anchor=smbios.SMBIOS_2_x_SIG, int_anchor=smbios.SMBIOS_2_x_INT_SIG):
-    return struct.pack(smbios.SMBIOS_2_x_ENTRY_POINT_FMT, anchor, 0x5A, entry_len, 2, 8,
-                       0x100, 0, 0, 0, 0, 0, 0, int_anchor, 0xA5, table_len, table_addr, 4, 0x28)
+    entry = bytearray(struct.pack(
+        smbios.SMBIOS_2_x_ENTRY_POINT_FMT, anchor, 0, entry_len, 2, 8,
+        0x100, 0, 0, 0, 0, 0, 0, int_anchor, 0,
+        table_len, table_addr, 4, 0x28))
+    int_start = smbios.SMBIOS_2_x_INT_OFFSET
+    int_end = int_start + smbios.SMBIOS_2_x_INT_SIZE
+    entry[0x15] = (-sum(entry[int_start:int_end])) & 0xFF
+    entry[0x04] = (-sum(entry[:entry_len])) & 0xFF
+    return bytes(entry)
 
 
 def entry_point_3x(table_addr=TABLE_ADDR, max_size=TABLE_LEN, entry_len=0x18,
                    anchor=smbios.SMBIOS_3_x_SIG):
-    return struct.pack(smbios.SMBIOS_3_x_ENTRY_POINT_FMT, anchor, 0x5A, entry_len,
-                       3, 4, 0, 1, 0, max_size, table_addr)
+    entry = bytearray(struct.pack(
+        smbios.SMBIOS_3_x_ENTRY_POINT_FMT, anchor, 0, entry_len,
+        3, 4, 0, 1, 0, max_size, table_addr))
+    if entry_len <= len(entry):
+        entry[0x05] = (-sum(entry[:entry_len])) & 0xFF
+    return bytes(entry)
 
 
 def make_smbios():
@@ -297,6 +308,20 @@ class TestEntryPointValidation(unittest.TestCase):
     def test_a_2x_entry_point_with_an_unexpected_size_is_rejected(self):
         self.assertIsNone(self._validate_2x(entry_point_2x(entry_len=0x10)))
 
+    def test_a_2x_entry_point_with_a_bad_checksum_is_rejected(self):
+        entry = bytearray(entry_point_2x())
+        entry[0x06] ^= 0x01
+
+        self.assertIsNone(self._validate_2x(bytes(entry)))
+
+    def test_a_2x_entry_point_with_a_bad_intermediate_checksum_is_rejected(self):
+        entry = bytearray(entry_point_2x())
+        entry[0x15] ^= 0x01
+        entry[0x04] = 0
+        entry[0x04] = (-sum(entry)) & 0xFF
+
+        self.assertIsNone(self._validate_2x(bytes(entry)))
+
     def test_a_2x_entry_point_without_a_table_is_rejected(self):
         self.assertIsNone(self._validate_2x(entry_point_2x(table_addr=0)))
         self.assertIsNone(self._validate_2x(entry_point_2x(table_len=0)))
@@ -316,6 +341,12 @@ class TestEntryPointValidation(unittest.TestCase):
 
     def test_a_3x_entry_point_with_an_unexpected_size_is_rejected(self):
         self.assertIsNone(self._validate_3x(entry_point_3x(entry_len=0x20)))
+
+    def test_a_3x_entry_point_with_a_bad_checksum_is_rejected(self):
+        entry = bytearray(entry_point_3x())
+        entry[0x07] ^= 0x01
+
+        self.assertIsNone(self._validate_3x(bytes(entry)))
 
     def test_a_3x_entry_point_without_a_table_is_rejected(self):
         self.assertIsNone(self._validate_3x(entry_point_3x(table_addr=0)))

--- a/tests/helpers/acpi_utils.py
+++ b/tests/helpers/acpi_utils.py
@@ -1,0 +1,45 @@
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2026, Intel Corporation
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Contact information:
+# chipsec@intel.com
+#
+
+import struct
+from typing import Optional
+
+
+def build_rsdp(
+        revision: int = 0,
+        rsdt_address: int = 0,
+        xsdt_address: Optional[int] = None,
+        oem_id: bytes = b'INTEL ',
+        signature: bytes = b'RSD PTR ',
+        length: int = 36
+) -> bytes:
+    """Build an RSDP with valid legacy and, when present, extended checksums."""
+    if xsdt_address is None:
+        data = bytearray(struct.pack(
+            '<8sB6sBI', signature, 0, oem_id, revision, rsdt_address))
+        data[8] = (-sum(data)) & 0xFF
+        return bytes(data)
+
+    data = bytearray(struct.pack(
+        '<8sB6sBIIQB3s', signature, 0, oem_id, revision,
+        rsdt_address, length, xsdt_address, 0, b'\x00\x00\x00'))
+    data[8] = (-sum(data[:20])) & 0xFF
+    data[32] = (-sum(data[:length])) & 0xFF
+    return bytes(data)

--- a/tests/library/test_acpi_aml_parser.py
+++ b/tests/library/test_acpi_aml_parser.py
@@ -218,8 +218,11 @@ class TestAMLParserIntegerDecoding(unittest.TestCase):
         self.assertEqual(self.parser._decode_aml_integer(b'\x00', 0), (0, 1))
         self.assertEqual(self.parser._decode_aml_integer(b'\x01', 0), (1, 1))
 
-    def test_literal_single_byte_opcodes(self):
-        self.assertEqual(self.parser._decode_aml_integer(b'\x05', 0), (5, 1))
+    def test_non_integer_opcode_is_not_decoded_as_a_literal(self):
+        self.assertEqual(self.parser._decode_aml_integer(b'\x05', 0), (None, 0))
+
+    def test_value_five_uses_the_byte_prefix(self):
+        self.assertEqual(self.parser._decode_aml_integer(aml_byte(5), 0), (5, 2))
 
     def test_prefixed_widths(self):
         self.assertEqual(self.parser._decode_aml_integer(aml_byte(0xAB), 0), (0xAB, 2))
@@ -303,7 +306,7 @@ class TestCRSResourceDecoding(unittest.TestCase):
     """Resource descriptors inside a _CRS buffer map to address/size pairs."""
 
     def test_fixed_memory32_descriptor(self):
-        buf = (b'\x85\x09\x00' + b'\x00' + struct.pack('<I', 0xFED00000) +
+        buf = (b'\x86\x09\x00' + b'\x00' + struct.pack('<I', 0xFED00000) +
                struct.pack('<I', 0x1000) + b'\x79\x00')
 
         resources = CRSResourceParser.decode_crs_buffer(buf)
@@ -316,7 +319,7 @@ class TestCRSResourceDecoding(unittest.TestCase):
     def test_memory32_descriptor_derives_size_from_range_when_length_is_zero(self):
         data = (b'\x01' + struct.pack('<I', 0x1000) + struct.pack('<I', 0x1FFF) +
                 struct.pack('<I', 0) + struct.pack('<I', 0))
-        buf = b'\x84' + struct.pack('<H', len(data)) + data + b'\x79\x00'
+        buf = b'\x85' + struct.pack('<H', len(data)) + data + b'\x79\x00'
 
         resources = CRSResourceParser.decode_crs_buffer(buf)
 

--- a/tests/library/test_acpi_aml_parser.py
+++ b/tests/library/test_acpi_aml_parser.py
@@ -1,0 +1,423 @@
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2026, Intel Corporation
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Contact information:
+# chipsec@intel.com
+#
+
+import struct
+import unittest
+
+from chipsec.library.acpi_aml_parser import (
+    AMLParser,
+    CRSExecutor,
+    CRSResourceParser,
+    OperationRegion,
+    ResourceDescriptorParser,
+    parse_operation_regions,
+)
+
+ACPI_HEADER_SIZE = 36
+
+
+def aml_byte(value: int) -> bytes:
+    """Encode an AML BytePrefix integer."""
+    return b'\x0a' + struct.pack('<B', value)
+
+
+def aml_word(value: int) -> bytes:
+    return b'\x0b' + struct.pack('<H', value)
+
+
+def aml_dword(value: int) -> bytes:
+    return b'\x0c' + struct.pack('<I', value)
+
+
+def aml_qword(value: int) -> bytes:
+    return b'\x0e' + struct.pack('<Q', value)
+
+
+def op_region(name: bytes, space_type: int, base: bytes, length: bytes) -> bytes:
+    """Build an AML OperationRegion declaration."""
+    return b'\x5b\x80' + name + struct.pack('<B', space_type) + base + length
+
+
+def name_decl(name: bytes, value: bytes) -> bytes:
+    """Build an AML Name() declaration."""
+    return b'\x08' + name + value
+
+
+def table(*payloads: bytes) -> bytes:
+    """Prefix an AML payload with a dummy 36-byte ACPI description header."""
+    return b'\x00' * ACPI_HEADER_SIZE + b''.join(payloads) + b'\x00' * 8
+
+
+class TestAMLParserOperationRegions(unittest.TestCase):
+    """OperationRegion discovery is the primary contract of the AML parser."""
+
+    def test_finds_operation_region_with_literal_address(self):
+        dsdt = table(op_region(b'PMCR', 0x00, aml_dword(0xFE000000), aml_dword(0x1000)))
+
+        regions = AMLParser().parse([dsdt])
+
+        self.assertEqual(len(regions), 1)
+        self.assertEqual(regions[0].name, 'PMCR')
+        self.assertEqual(regions[0].base, 0xFE000000)
+        self.assertEqual(regions[0].length, 0x1000)
+
+    def test_space_type_is_resolved_to_a_readable_name(self):
+        dsdt = table(op_region(b'IOPR', 0x01, aml_dword(0x00001000), aml_byte(0x40)))
+
+        regions = AMLParser().parse([dsdt])
+
+        self.assertEqual(regions[0].space_type, 0x01)
+        self.assertEqual(regions[0].space_type_name, 'SystemIO')
+
+    def test_unknown_space_type_is_reported_rather_than_dropped(self):
+        dsdt = table(op_region(b'ODDR', 0x42, aml_dword(0xFE000000), aml_byte(0x40)))
+
+        regions = AMLParser().parse([dsdt])
+
+        self.assertEqual(len(regions), 1)
+        self.assertIn('Unknown', regions[0].space_type_name)
+
+    def test_address_declared_through_a_name_symbol_is_resolved(self):
+        dsdt = table(
+            name_decl(b'BASV', aml_dword(0xFE000000)),
+            op_region(b'RGNX', 0x00, b'BASV', aml_dword(0x2000)),
+        )
+
+        regions = AMLParser().parse([dsdt])
+
+        self.assertEqual(len(regions), 1)
+        self.assertEqual(regions[0].base, 0xFE000000)
+        self.assertEqual(regions[0].length, 0x2000)
+
+    def test_unresolvable_symbol_reference_is_skipped(self):
+        dsdt = table(op_region(b'RGNX', 0x00, b'NOPE', aml_dword(0x2000)))
+
+        self.assertEqual(AMLParser().parse([dsdt]), [])
+
+    def test_regions_with_no_length_are_rejected(self):
+        dsdt = table(op_region(b'RGNX', 0x00, aml_dword(0xFE000000), b'\x00'))
+
+        self.assertEqual(AMLParser().parse([dsdt]), [])
+
+    def test_regions_with_implausible_length_are_rejected(self):
+        dsdt = table(op_region(b'RGNX', 0x00, aml_dword(0xFE000000), aml_dword(0x20000000)))
+
+        self.assertEqual(AMLParser().parse([dsdt]), [])
+
+    def test_regions_with_invalid_base_are_rejected(self):
+        zero_base = table(op_region(b'RGNA', 0x00, b'\x00', aml_dword(0x1000)))
+        all_ones_base = table(op_region(b'RGNB', 0x00, aml_dword(0xFFFFFFFF), aml_dword(0x1000)))
+
+        self.assertEqual(AMLParser().parse([zero_base]), [])
+        self.assertEqual(AMLParser().parse([all_ones_base]), [])
+
+    def test_regions_above_the_supported_address_ceiling_are_dropped(self):
+        dsdt = table(op_region(b'HIGH', 0x00, aml_qword(0x2000000000), aml_dword(0x1000)))
+
+        self.assertEqual(AMLParser().parse([dsdt]), [])
+
+    def test_regions_are_returned_sorted_by_base_address(self):
+        dsdt = table(
+            op_region(b'HIGH', 0x00, aml_dword(0xFF000000), aml_dword(0x1000)),
+            op_region(b'LOWR', 0x00, aml_dword(0xE0000000), aml_dword(0x1000)),
+        )
+
+        bases = [r.base for r in AMLParser().parse([dsdt])]
+
+        self.assertEqual(bases, sorted(bases))
+
+    def test_regions_are_collected_across_multiple_tables(self):
+        dsdt = table(op_region(b'RGNA', 0x00, aml_dword(0xE0000000), aml_dword(0x1000)))
+        ssdt = table(op_region(b'RGNB', 0x00, aml_dword(0xF0000000), aml_dword(0x1000)))
+
+        names = {r.name for r in AMLParser().parse([dsdt, ssdt])}
+
+        self.assertEqual(names, {'RGNA', 'RGNB'})
+
+    def test_tables_smaller_than_an_acpi_header_are_ignored(self):
+        self.assertEqual(AMLParser().parse([b'\x00' * 10]), [])
+
+    def test_parse_is_repeatable_and_does_not_accumulate_state(self):
+        dsdt = table(op_region(b'PMCR', 0x00, aml_dword(0xFE000000), aml_dword(0x1000)))
+        parser = AMLParser()
+
+        first = parser.parse([dsdt])
+        second = parser.parse([dsdt])
+
+        self.assertEqual(len(first), len(second))
+
+    def test_garbage_input_does_not_raise(self):
+        garbage = b'\x00' * ACPI_HEADER_SIZE + bytes(range(256)) * 4
+
+        self.assertIsInstance(AMLParser().parse([garbage]), list)
+
+
+class TestAMLParserNameDecoding(unittest.TestCase):
+    """Name string decoding drives both symbol resolution and region naming."""
+
+    def setUp(self):
+        self.parser = AMLParser()
+
+    def test_simple_name_segment(self):
+        self.assertEqual(self.parser._decode_name_string_simple(b'PMCR', 0), ('PMCR', 4))
+
+    def test_trailing_underscore_padding_is_stripped(self):
+        name, consumed = self.parser._decode_name_string_simple(b'PM__', 0)
+        self.assertEqual(name, 'PM')
+        self.assertEqual(consumed, 4)
+
+    def test_root_prefixed_name(self):
+        name, consumed = self.parser._decode_name_string_simple(b'\\PMCR', 0)
+        self.assertEqual(name, '\\PMCR')
+        self.assertEqual(consumed, 5)
+
+    def test_dual_name_path(self):
+        name, consumed = self.parser._decode_name_string_simple(b'\x2ePCI0PMCR', 0)
+        self.assertEqual(name, 'PCI0.PMCR')
+        self.assertEqual(consumed, 9)
+
+    def test_multi_name_path(self):
+        name, consumed = self.parser._decode_name_string_simple(b'\x2f\x03SB__PCI0PMCR', 0)
+        self.assertEqual(name, 'SB.PCI0.PMCR')
+        self.assertEqual(consumed, 14)
+
+    def test_parent_prefix_is_not_supported(self):
+        self.assertEqual(self.parser._decode_name_string_simple(b'\x5ePMCR', 0), (None, 0))
+
+    def test_non_name_bytes_are_rejected(self):
+        self.assertEqual(self.parser._decode_name_string_simple(b'\xff\xff\xff\xff', 0), (None, 0))
+
+    def test_offset_past_end_of_buffer(self):
+        self.assertEqual(self.parser._decode_name_string_simple(b'PMCR', 99), (None, 0))
+
+
+class TestAMLParserIntegerDecoding(unittest.TestCase):
+    """AML integers use a variable-length encoding that the parser must honor."""
+
+    def setUp(self):
+        self.parser = AMLParser()
+
+    def test_zero_and_one_opcodes(self):
+        self.assertEqual(self.parser._decode_aml_integer(b'\x00', 0), (0, 1))
+        self.assertEqual(self.parser._decode_aml_integer(b'\x01', 0), (1, 1))
+
+    def test_literal_single_byte_opcodes(self):
+        self.assertEqual(self.parser._decode_aml_integer(b'\x05', 0), (5, 1))
+
+    def test_prefixed_widths(self):
+        self.assertEqual(self.parser._decode_aml_integer(aml_byte(0xAB), 0), (0xAB, 2))
+        self.assertEqual(self.parser._decode_aml_integer(aml_word(0xBEEF), 0), (0xBEEF, 3))
+        self.assertEqual(self.parser._decode_aml_integer(aml_dword(0xDEADBEEF), 0), (0xDEADBEEF, 5))
+        self.assertEqual(
+            self.parser._decode_aml_integer(aml_qword(0x1122334455667788), 0),
+            (0x1122334455667788, 9),
+        )
+
+    def test_truncated_encoding_is_not_decoded(self):
+        self.assertEqual(self.parser._decode_aml_integer(b'\x0c\x01\x02', 0), (None, 0))
+
+    def test_name_reference_is_reported_as_undecodable(self):
+        self.assertEqual(self.parser._decode_aml_integer(b'BASV', 0), (None, 0))
+
+    def test_offset_past_end_of_buffer(self):
+        self.assertEqual(self.parser._decode_aml_integer(b'\x0a\x01', 5), (None, 0))
+
+
+class TestParseOperationRegionsFunction(unittest.TestCase):
+    """The module level helper adapts the parser output for callers."""
+
+    def test_returns_serializable_dictionaries(self):
+        dsdt = table(op_region(b'PMCR', 0x00, aml_dword(0xFE000000), aml_dword(0x1000)))
+
+        results = parse_operation_regions([dsdt])
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(
+            set(results[0]),
+            {'name', 'space_type', 'space_type_name', 'base', 'length', 'source'},
+        )
+        self.assertEqual(results[0]['base'], 0xFE000000)
+
+    def test_no_tables_yields_no_regions(self):
+        self.assertEqual(parse_operation_regions([]), [])
+
+
+class TestCRSPackageLength(unittest.TestCase):
+    """AML package lengths use a lead byte that selects the encoding width."""
+
+    def test_single_byte_encoding(self):
+        self.assertEqual(CRSResourceParser.parse_pkg_length(b'\x25', 0), (0x25, 1))
+
+    def test_multi_byte_encoding_consumes_follow_on_bytes(self):
+        length, pos = CRSResourceParser.parse_pkg_length(b'\x41\x02', 0)
+        self.assertEqual(length, 0x21)
+        self.assertEqual(pos, 2)
+
+    def test_offset_past_end_of_buffer_is_safe(self):
+        self.assertEqual(CRSResourceParser.parse_pkg_length(b'\x25', 5), (0, 5))
+
+
+class TestCRSBufferExtraction(unittest.TestCase):
+    """_CRS methods that simply return a Buffer are decoded statically."""
+
+    @staticmethod
+    def _crs_method(resource_bytes: bytes) -> bytes:
+        buffer_op = (b'\x11' + struct.pack('<B', len(resource_bytes) + 2) +
+                     b'\x0a' + struct.pack('<B', len(resource_bytes)) + resource_bytes)
+        body = b'\xa4' + buffer_op
+        rest = b'_CRS' + b'\x00' + body
+        return b'\x14' + struct.pack('<B', len(rest)) + rest
+
+    def test_buffer_is_extracted_from_crs_method(self):
+        resource = b'\x85\x09\x00\x00' + struct.pack('<I', 0xFED00000) + struct.pack('<I', 0x1000)
+
+        extracted = CRSResourceParser.extract_crs_buffer(self._crs_method(resource))
+
+        self.assertEqual(extracted, resource)
+
+    def test_missing_crs_method_returns_none(self):
+        self.assertIsNone(CRSResourceParser.extract_crs_buffer(b'\x00' * 64))
+
+    def test_truncated_input_returns_none(self):
+        self.assertIsNone(CRSResourceParser.extract_crs_buffer(b''))
+
+
+class TestCRSResourceDecoding(unittest.TestCase):
+    """Resource descriptors inside a _CRS buffer map to address/size pairs."""
+
+    def test_fixed_memory32_descriptor(self):
+        buf = (b'\x85\x09\x00' + b'\x00' + struct.pack('<I', 0xFED00000) +
+               struct.pack('<I', 0x1000) + b'\x79\x00')
+
+        resources = CRSResourceParser.decode_crs_buffer(buf)
+
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['type'], 'FixedMemory32')
+        self.assertEqual(resources[0]['address'], 0xFED00000)
+        self.assertEqual(resources[0]['size'], 0x1000)
+
+    def test_memory32_descriptor_derives_size_from_range_when_length_is_zero(self):
+        data = (b'\x01' + struct.pack('<I', 0x1000) + struct.pack('<I', 0x1FFF) +
+                struct.pack('<I', 0) + struct.pack('<I', 0))
+        buf = b'\x84' + struct.pack('<H', len(data)) + data + b'\x79\x00'
+
+        resources = CRSResourceParser.decode_crs_buffer(buf)
+
+        self.assertEqual(resources[0]['type'], 'Memory32')
+        self.assertEqual(resources[0]['address'], 0x1000)
+        self.assertEqual(resources[0]['size'], 0x1000)
+
+    def test_dword_address_space_memory_descriptor(self):
+        data = (b'\x00\x00\x00\x00' + struct.pack('<I', 0xC0000000) +
+                struct.pack('<I', 0xCFFFFFFF) + struct.pack('<I', 0) +
+                struct.pack('<I', 0) + struct.pack('<I', 0x10000000))
+        buf = b'\x87' + struct.pack('<H', len(data)) + data + b'\x79\x00'
+
+        resources = CRSResourceParser.decode_crs_buffer(buf)
+
+        self.assertEqual(resources[0]['type'], 'DWordMemory')
+        self.assertEqual(resources[0]['address'], 0xC0000000)
+        self.assertEqual(resources[0]['size'], 0x10000000)
+
+    def test_qword_address_space_memory_descriptor(self):
+        data = (b'\x00\x00\x00\x00' + struct.pack('<Q', 0x100000000) +
+                struct.pack('<Q', 0x1FFFFFFFF) + struct.pack('<Q', 0) +
+                struct.pack('<Q', 0) + struct.pack('<Q', 0x100000000) + b'\x00' * 3)
+        buf = b'\x8a' + struct.pack('<H', len(data)) + data + b'\x79\x00'
+
+        resources = CRSResourceParser.decode_crs_buffer(buf)
+
+        self.assertEqual(resources[0]['type'], 'QWordMemory')
+        self.assertEqual(resources[0]['address'], 0x100000000)
+
+    def test_small_irq_and_dma_descriptors(self):
+        buf = b'\x23\x00\xf8\x00' + b'\x2a\x00\x04' + b'\x79\x00'
+
+        types = [r['type'] for r in CRSResourceParser.decode_crs_buffer(buf)]
+
+        self.assertEqual(types, ['IRQ', 'DMA'])
+
+    def test_decoding_stops_at_the_end_tag(self):
+        trailing = b'\x85\x09\x00' + b'\x00' + struct.pack('<I', 0xFED00000) + struct.pack('<I', 0x1000)
+        buf = b'\x79\x00' + trailing
+
+        self.assertEqual(CRSResourceParser.decode_crs_buffer(buf), [])
+
+    def test_empty_buffer_yields_no_resources(self):
+        self.assertEqual(CRSResourceParser.decode_crs_buffer(b''), [])
+
+
+class TestCRSExecutor(unittest.TestCase):
+    """Dynamic _CRS methods assign their base/length through Store operations."""
+
+    def test_store_assignments_to_known_fields_are_captured(self):
+        aml = (b'\x70' + aml_dword(0xFE000000) + b'BAS1' +
+               b'\x70' + aml_dword(0x00001000) + b'LEN1')
+
+        fields = CRSExecutor().extract_crs_fields(aml)
+
+        self.assertEqual(fields['BAS1'], 0xFE000000)
+        self.assertEqual(fields['LEN1'], 0x1000)
+
+    def test_stores_to_unrelated_fields_are_ignored(self):
+        aml = b'\x70' + aml_dword(0x1234) + b'FOO1' + b'\x00' * 8
+
+        self.assertEqual(CRSExecutor().extract_crs_fields(aml), {})
+
+    def test_synthetic_regions_are_created_from_crs_field_pairs(self):
+        aml = (b'\x70' + aml_dword(0xFE000000) + b'BAS1' +
+               b'\x70' + aml_dword(0x00001000) + b'LEN1')
+
+        regions = AMLParser().parse([b'\x00' * ACPI_HEADER_SIZE + aml + b'\x00' * 8])
+
+        crs_regions = [r for r in regions if r.source == 'CRS_Fields']
+        self.assertEqual(len(crs_regions), 1)
+        self.assertEqual(crs_regions[0].base, 0xFE000000)
+        self.assertEqual(crs_regions[0].length, 0x1000)
+        self.assertTrue(crs_regions[0].name.endswith('BAS1'))
+
+    def test_base_without_a_matching_length_produces_no_region(self):
+        aml = b'\x70' + aml_dword(0xFE000000) + b'BAS1'
+
+        regions = AMLParser().parse([b'\x00' * ACPI_HEADER_SIZE + aml + b'\x00' * 8])
+
+        self.assertEqual([r for r in regions if r.source == 'CRS_Fields'], [])
+
+
+class TestResourceDescriptorParser(unittest.TestCase):
+    """The descriptor scanner walks a raw _CRS body without a package wrapper."""
+
+    def test_returns_nothing_for_buffers_without_descriptors(self):
+        self.assertEqual(ResourceDescriptorParser().extract_from_crs_binary(b'\x00' * 32, {}), [])
+
+    def test_malformed_large_descriptor_does_not_raise(self):
+        self.assertEqual(ResourceDescriptorParser().extract_from_crs_binary(b'\x87\xff\xff\x01', {}), [])
+
+
+class TestOperationRegionDataclass(unittest.TestCase):
+
+    def test_source_defaults_to_static_operation_region(self):
+        region = OperationRegion('PMCR', 0, 'SystemMemory', 0xFE000000, 0x1000)
+
+        self.assertEqual(region.source, 'OperationRegion')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/library/test_acpi_tables.py
+++ b/tests/library/test_acpi_tables.py
@@ -32,6 +32,7 @@ from chipsec.library.acpi_tables import (
     XSDT,
     safe_struct_unpack,
 )
+from tests.helpers.acpi_utils import build_rsdp
 
 
 class TestACPITables(unittest.TestCase):
@@ -132,11 +133,27 @@ class TestACPITableBase(unittest.TestCase):
         self.assertIn('Table Content', str(ACPI_TABLE()))
 
 
+def legacy_rsdp(revision=0, signature=b'RSD PTR '):
+    return build_rsdp(
+        revision=revision,
+        rsdt_address=0x7A611000,
+        signature=signature)
+
+
+def extended_rsdp(revision=2, length=36, signature=b'RSD PTR '):
+    return build_rsdp(
+        revision=revision,
+        rsdt_address=0x7A611000,
+        xsdt_address=0x7A612000,
+        signature=signature,
+        length=length)
+
+
 class TestRSDP(unittest.TestCase):
     """The RSDP is the entry point that points at the RSDT and/or XSDT."""
 
-    LEGACY = struct.pack('<8sB6sBI', b'RSD PTR ', 0xA5, b'INTEL ', 0, 0x7A611000)
-    EXTENDED = LEGACY + struct.pack('<IQB3s', 36, 0x7A612000, 0x5A, b'\x00\x00\x00')
+    LEGACY = legacy_rsdp()
+    EXTENDED = extended_rsdp()
 
     def test_legacy_rsdp_exposes_the_rsdt_pointer(self):
         rsdp = RSDP()
@@ -183,15 +200,33 @@ class TestRSDP(unittest.TestCase):
 
         self.assertTrue(rsdp.is_RSDP_valid())
 
-    def test_zero_checksum_is_not_valid(self):
+    def test_bad_legacy_checksum_is_not_valid(self):
         rsdp = RSDP()
-        rsdp.parse(struct.pack('<8sB6sBI', b'RSD PTR ', 0, b'INTEL ', 0, 0x1000))
+        data = bytearray(self.LEGACY)
+        data[19] ^= 0x01
+        rsdp.parse(bytes(data))
+
+        self.assertFalse(rsdp.is_RSDP_valid())
+
+    def test_bad_extended_checksum_is_not_valid(self):
+        rsdp = RSDP()
+        data = bytearray(self.EXTENDED)
+        data[24] ^= 0x01
+        data[8] = 0
+        data[8] = (-sum(data[:20])) & 0xFF
+        rsdp.parse(bytes(data))
 
         self.assertFalse(rsdp.is_RSDP_valid())
 
     def test_unknown_revision_is_not_valid(self):
         rsdp = RSDP()
-        rsdp.parse(struct.pack('<8sB6sBI', b'RSD PTR ', 0xA5, b'INTEL ', 9, 0x1000))
+        rsdp.parse(legacy_rsdp(revision=9))
+
+        self.assertFalse(rsdp.is_RSDP_valid())
+
+    def test_bad_signature_is_not_valid(self):
+        rsdp = RSDP()
+        rsdp.parse(legacy_rsdp(signature=b'BAD PTR '))
 
         self.assertFalse(rsdp.is_RSDP_valid())
 
@@ -202,6 +237,25 @@ class TestRSDP(unittest.TestCase):
 
         self.assertNotIn('XSDT Address', str(legacy))
         self.assertIn('XSDT Address', str(extended))
+
+
+class TestRSDPBuilder(unittest.TestCase):
+
+    def test_legacy_rsdp_has_a_valid_checksum(self):
+        data = build_rsdp(revision=0, rsdt_address=0x12345678)
+
+        self.assertEqual(len(data), 20)
+        self.assertEqual(sum(data) & 0xFF, 0)
+
+    def test_extended_rsdp_has_valid_legacy_and_extended_checksums(self):
+        data = build_rsdp(
+            revision=2,
+            rsdt_address=0x12345678,
+            xsdt_address=0x123456789ABCDEF0)
+
+        self.assertEqual(len(data), 36)
+        self.assertEqual(sum(data[:20]) & 0xFF, 0)
+        self.assertEqual(sum(data) & 0xFF, 0)
 
 
 class TestRSDTAndXSDT(unittest.TestCase):

--- a/tests/library/test_acpi_tables.py
+++ b/tests/library/test_acpi_tables.py
@@ -15,9 +15,23 @@
 #
 #
 
+import struct
 import unittest
 
-from chipsec.library.acpi_tables import APIC, BGRT, DMAR, XSDT, UEFI_TABLE, WSMT
+from chipsec.library.acpi_tables import (
+    ACPI_TABLE,
+    APIC,
+    BGRT,
+    DMAR,
+    FADT,
+    GAS,
+    RSDP,
+    RSDT,
+    UEFI_TABLE,
+    WSMT,
+    XSDT,
+    safe_struct_unpack,
+)
 
 
 class TestACPITables(unittest.TestCase):
@@ -106,6 +120,579 @@ class TestACPITables(unittest.TestCase):
     #         test_dmar._get_structure_DMAR(i, test_table_content[])
     #         i += 1
     #     print(test_dmar._get_DMAR_structure_SATC(b'\x00'))
+
+
+class TestACPITableBase(unittest.TestCase):
+    """The base class supplies inert defaults for tables without a parser."""
+
+    def test_parse_accepts_any_content(self):
+        self.assertIsNone(ACPI_TABLE().parse(b'\x00' * 16))
+
+    def test_default_rendering_reports_an_unparsed_table(self):
+        self.assertIn('Table Content', str(ACPI_TABLE()))
+
+
+class TestRSDP(unittest.TestCase):
+    """The RSDP is the entry point that points at the RSDT and/or XSDT."""
+
+    LEGACY = struct.pack('<8sB6sBI', b'RSD PTR ', 0xA5, b'INTEL ', 0, 0x7A611000)
+    EXTENDED = LEGACY + struct.pack('<IQB3s', 36, 0x7A612000, 0x5A, b'\x00\x00\x00')
+
+    def test_legacy_rsdp_exposes_the_rsdt_pointer(self):
+        rsdp = RSDP()
+        rsdp.parse(self.LEGACY)
+
+        self.assertEqual(rsdp.Signature, b'RSD PTR ')
+        self.assertEqual(rsdp.RsdtAddress, 0x7A611000)
+
+    def test_legacy_rsdp_has_no_extended_fields(self):
+        rsdp = RSDP()
+        rsdp.parse(self.LEGACY)
+
+        self.assertIsNone(rsdp.XsdtAddress)
+        self.assertIsNone(rsdp.Length)
+
+    def test_extended_rsdp_exposes_the_xsdt_pointer(self):
+        rsdp = RSDP()
+        rsdp.parse(self.EXTENDED)
+
+        self.assertEqual(rsdp.XsdtAddress, 0x7A612000)
+        self.assertEqual(rsdp.Length, 36)
+
+    def test_trailing_bytes_beyond_the_extended_structure_are_ignored(self):
+        rsdp = RSDP()
+        rsdp.parse(self.EXTENDED + b'\xff' * 8)
+
+        self.assertEqual(rsdp.XsdtAddress, 0x7A612000)
+
+    def test_empty_content_is_rejected(self):
+        with self.assertRaises(ValueError):
+            RSDP().parse(b'')
+
+    def test_truncated_content_is_rejected(self):
+        with self.assertRaises(ValueError):
+            RSDP().parse(b'\x00' * 8)
+
+    def test_content_between_the_two_known_sizes_is_rejected(self):
+        with self.assertRaises(ValueError):
+            RSDP().parse(self.LEGACY + b'\x00' * 4)
+
+    def test_valid_rsdp_requires_a_checksum_and_a_known_revision(self):
+        rsdp = RSDP()
+        rsdp.parse(self.LEGACY)
+
+        self.assertTrue(rsdp.is_RSDP_valid())
+
+    def test_zero_checksum_is_not_valid(self):
+        rsdp = RSDP()
+        rsdp.parse(struct.pack('<8sB6sBI', b'RSD PTR ', 0, b'INTEL ', 0, 0x1000))
+
+        self.assertFalse(rsdp.is_RSDP_valid())
+
+    def test_unknown_revision_is_not_valid(self):
+        rsdp = RSDP()
+        rsdp.parse(struct.pack('<8sB6sBI', b'RSD PTR ', 0xA5, b'INTEL ', 9, 0x1000))
+
+        self.assertFalse(rsdp.is_RSDP_valid())
+
+    def test_rendering_includes_the_extended_fields_when_present(self):
+        legacy, extended = RSDP(), RSDP()
+        legacy.parse(self.LEGACY)
+        extended.parse(self.EXTENDED)
+
+        self.assertNotIn('XSDT Address', str(legacy))
+        self.assertIn('XSDT Address', str(extended))
+
+
+class TestRSDTAndXSDT(unittest.TestCase):
+    """RSDT and XSDT are arrays of 32-bit and 64-bit table pointers."""
+
+    def test_rsdt_entries_are_32_bit_pointers(self):
+        rsdt = RSDT()
+        rsdt.parse(struct.pack('<2I', 0x7A611000, 0x7A612000))
+
+        self.assertEqual(list(rsdt.Entries), [0x7A611000, 0x7A612000])
+
+    def test_xsdt_entries_are_64_bit_pointers(self):
+        xsdt = XSDT()
+        xsdt.parse(struct.pack('<2Q', 0x7A611000, 0x7A612000))
+
+        self.assertEqual(list(xsdt.Entries), [0x7A611000, 0x7A612000])
+
+    def test_trailing_partial_entries_are_dropped(self):
+        rsdt = RSDT()
+        rsdt.parse(struct.pack('<I', 0x7A611000) + b'\x00\x00')
+
+        self.assertEqual(len(rsdt.Entries), 1)
+
+    def test_content_smaller_than_one_entry_yields_no_entries(self):
+        xsdt = XSDT()
+        xsdt.parse(b'\x00' * 4)
+
+        self.assertEqual(len(xsdt.Entries), 0)
+
+    def test_empty_content_is_rejected(self):
+        with self.assertRaises(ValueError):
+            RSDT().parse(b'')
+        with self.assertRaises(ValueError):
+            XSDT().parse(b'')
+
+    def test_entries_are_listed_when_rendered(self):
+        xsdt = XSDT()
+        xsdt.parse(struct.pack('<Q', 0x7A611000))
+
+        self.assertIn('0x000000007A611000', str(xsdt))
+
+
+class TestFADT(unittest.TestCase):
+    """The FADT locates the DSDT through either a 32-bit or 64-bit pointer."""
+
+    @staticmethod
+    def _fadt(dsdt=0x7A611000, x_dsdt=None, smi=0xB2, enable=0xA0, disable=0xA1):
+        content = bytearray(112 if x_dsdt is not None else 64)
+        struct.pack_into('<I', content, 4, dsdt)
+        struct.pack_into('<I', content, 12, smi)
+        content[16] = enable
+        content[17] = disable
+        if x_dsdt is not None:
+            struct.pack_into('<Q', content, 104, x_dsdt)
+        return bytes(content)
+
+    def test_legacy_fields_are_parsed(self):
+        fadt = FADT()
+        fadt.parse(self._fadt())
+
+        self.assertEqual(fadt.dsdt, 0x7A611000)
+        self.assertEqual(fadt.smi, 0xB2)
+        self.assertEqual(fadt.acpi_enable, 0xA0)
+        self.assertEqual(fadt.acpi_disable, 0xA1)
+
+    def test_short_tables_have_no_extended_dsdt_pointer(self):
+        fadt = FADT()
+        fadt.parse(self._fadt())
+
+        self.assertIsNone(fadt.x_dsdt)
+
+    def test_extended_dsdt_pointer_is_parsed_when_present(self):
+        fadt = FADT()
+        fadt.parse(self._fadt(x_dsdt=0x7A620000))
+
+        self.assertEqual(fadt.x_dsdt, 0x7A620000)
+
+    def test_empty_content_is_rejected(self):
+        with self.assertRaises(ValueError):
+            FADT().parse(b'')
+
+    def test_truncated_content_is_rejected(self):
+        with self.assertRaises(ValueError):
+            FADT().parse(b'\x00' * 10)
+
+    def test_legacy_pointer_is_used_when_there_is_no_extended_pointer(self):
+        fadt = FADT()
+        fadt.parse(self._fadt(dsdt=0x7A611000))
+
+        self.assertEqual(fadt.get_DSDT_address_to_use(), 0x7A611000)
+
+    def test_extended_pointer_wins_when_the_legacy_pointer_is_empty(self):
+        fadt = FADT()
+        fadt.parse(self._fadt(dsdt=0, x_dsdt=0x7A620000))
+
+        self.assertEqual(fadt.get_DSDT_address_to_use(), 0x7A620000)
+
+    def test_legacy_pointer_is_used_when_the_extended_pointer_is_empty(self):
+        fadt = FADT()
+        fadt.parse(self._fadt(dsdt=0x7A611000, x_dsdt=0))
+
+        self.assertEqual(fadt.get_DSDT_address_to_use(), 0x7A611000)
+
+    def test_matching_pointers_resolve_to_a_single_address(self):
+        fadt = FADT()
+        fadt.parse(self._fadt(dsdt=0x7A611000, x_dsdt=0x7A611000))
+
+        self.assertEqual(fadt.get_DSDT_address_to_use(), 0x7A611000)
+
+    def test_conflicting_pointers_are_not_resolved(self):
+        fadt = FADT()
+        fadt.parse(self._fadt(dsdt=0x7A611000, x_dsdt=0x7A620000))
+
+        self.assertIsNone(fadt.get_DSDT_address_to_use())
+
+    def test_no_pointer_at_all_is_not_resolved(self):
+        fadt = FADT()
+        fadt.parse(self._fadt(dsdt=0))
+
+        self.assertIsNone(fadt.get_DSDT_address_to_use())
+
+    def test_rendering_reports_a_missing_extended_pointer(self):
+        fadt = FADT()
+        fadt.parse(self._fadt())
+
+        self.assertIn('Not found', str(fadt))
+
+
+class TestBGRT(unittest.TestCase):
+    """BGRT describes the boot logo and its orientation."""
+
+    @staticmethod
+    def _bgrt(status=0, image_type=0):
+        return struct.pack('<HbbQII', 1, status, image_type, 0x769F5018, 0x2F3, 0x127)
+
+    def test_image_geometry_is_parsed(self):
+        bgrt = BGRT()
+        bgrt.parse(self._bgrt())
+
+        self.assertEqual(bgrt.ImageAddress, 0x769F5018)
+        self.assertEqual(bgrt.ImageOffsetX, 0x2F3)
+        self.assertEqual(bgrt.ImageOffsetY, 0x127)
+
+    def test_each_defined_status_maps_to_a_rotation(self):
+        rotations = []
+        for status in range(4):
+            bgrt = BGRT()
+            bgrt.parse(self._bgrt(status=status))
+            rotations.append(bgrt.OrientationOffset)
+
+        self.assertEqual(rotations, ['0 degrees', '90 degrees', '180 degrees', '270 degrees'])
+
+    def test_undefined_status_is_reported_as_reserved(self):
+        bgrt = BGRT()
+        bgrt.parse(self._bgrt(status=7))
+
+        self.assertIn('Reserved', bgrt.OrientationOffset)
+
+    def test_image_type_zero_is_a_bitmap(self):
+        bgrt = BGRT()
+        bgrt.parse(self._bgrt(image_type=0))
+
+        self.assertIn('Bitmap', bgrt.ImageTypeStr)
+
+    def test_other_image_types_are_reserved(self):
+        bgrt = BGRT()
+        bgrt.parse(self._bgrt(image_type=1))
+
+        self.assertEqual(bgrt.ImageTypeStr, 'Reserved')
+
+    def test_rendering_includes_the_decoded_orientation(self):
+        bgrt = BGRT()
+        bgrt.parse(self._bgrt(status=2))
+
+        self.assertIn('180 degrees', str(bgrt))
+
+
+class TestWSMT(unittest.TestCase):
+    """WSMT advertises which SMM mitigations the firmware implements."""
+
+    def test_no_mitigations_are_reported_when_no_bits_are_set(self):
+        wsmt = WSMT()
+        wsmt.parse(struct.pack('<L', 0))
+
+        self.assertFalse(wsmt.fixed_comm_buffers)
+        self.assertFalse(wsmt.comm_buffer_nested_ptr_protection)
+        self.assertFalse(wsmt.system_resource_protection)
+
+    def test_each_mitigation_bit_is_decoded_independently(self):
+        wsmt = WSMT()
+        wsmt.parse(struct.pack('<L', WSMT.FIXED_COMM_BUFFERS | WSMT.SYSTEM_RESOURCE_PROTECTION))
+
+        self.assertTrue(wsmt.fixed_comm_buffers)
+        self.assertFalse(wsmt.comm_buffer_nested_ptr_protection)
+        self.assertTrue(wsmt.system_resource_protection)
+
+    def test_all_mitigations_can_be_set_at_once(self):
+        wsmt = WSMT()
+        wsmt.parse(struct.pack('<L', 0x7))
+
+        self.assertTrue(all([wsmt.fixed_comm_buffers,
+                             wsmt.comm_buffer_nested_ptr_protection,
+                             wsmt.system_resource_protection]))
+
+    def test_truncated_content_leaves_the_defaults_in_place(self):
+        wsmt = WSMT()
+        wsmt.parse(b'\x00')
+
+        self.assertFalse(wsmt.fixed_comm_buffers)
+
+    def test_rendering_lists_every_mitigation(self):
+        wsmt = WSMT()
+        wsmt.parse(struct.pack('<L', 0x7))
+        rendered = str(wsmt)
+
+        self.assertIn('FIXED_COMM_BUFFERS', rendered)
+        self.assertIn('SYSTEM_RESOURCE_PROTECTION', rendered)
+
+
+class TestUEFITable(unittest.TestCase):
+    """The UEFI table carries the SMM communication buffer description."""
+
+    SMM_COMM_GUID = b'\xe2\xd8\x8e\xc6\xc6\x9d\xbdL\x9d\x94\xdbe\xac\xc5\xc32'
+    OTHER_GUID = b'\x11' * 16
+
+    @classmethod
+    def _table(cls, guid=None, data_offset=54, smi=1, buf_addr=0x7A9FB000, gas=None):
+        content = (guid or cls.SMM_COMM_GUID) + struct.pack('<H', data_offset)
+        content += struct.pack('<I', smi) + struct.pack('<Q', buf_addr)
+        if gas is not None:
+            content += gas
+        return content
+
+    def test_content_too_short_for_a_guid_is_ignored(self):
+        table = UEFI_TABLE()
+        table.parse(b'\x00' * 8)
+
+        self.assertEqual(table.get_commbuf_info(), (0, 0, None))
+
+    def test_tables_for_other_guids_are_not_decoded_further(self):
+        table = UEFI_TABLE()
+        table.parse(self._table(guid=self.OTHER_GUID))
+
+        self.assertEqual(table.get_commbuf_info(), (0, 0, None))
+
+    def test_smm_communication_buffer_is_decoded(self):
+        table = UEFI_TABLE()
+        table.parse(self._table())
+
+        smi, buf_addr, _invoc = table.get_commbuf_info()
+        self.assertEqual(smi, 1)
+        self.assertEqual(buf_addr, 0x7A9FB000)
+
+    def test_missing_invocation_register_is_reported(self):
+        table = UEFI_TABLE()
+        table.parse(self._table())
+
+        self.assertIsNone(table.get_commbuf_info()[2])
+        self.assertIn('Invocation Register        : None', str(table))
+
+    def test_invocation_register_is_decoded_when_present(self):
+        gas = struct.pack('<BBBBQ', 1, 8, 0, 1, 0xB2)
+        table = UEFI_TABLE()
+        table.parse(self._table(gas=gas))
+
+        invoc = table.get_commbuf_info()[2]
+        self.assertIsInstance(invoc, GAS)
+        self.assertEqual(invoc.addr, 0xB2)
+
+    def test_data_offset_outside_the_table_is_ignored(self):
+        table = UEFI_TABLE()
+        table.parse(self._table(data_offset=0))
+
+        self.assertEqual(table.get_commbuf_info()[0], 0)
+
+
+class TestGenericAddressStructure(unittest.TestCase):
+    """GAS is the generic register descriptor reused across ACPI tables."""
+
+    @staticmethod
+    def _gas(space_id=0, access_size=3, addr=0xFED40000):
+        return struct.pack('<BBBBQ', space_id, 32, 0, access_size, addr)
+
+    def test_fields_are_decoded_in_order(self):
+        gas = GAS(self._gas())
+
+        self.assertEqual(gas.get_info(), (0, 32, 0, 3, 0xFED40000))
+
+    def test_known_address_spaces_are_named(self):
+        names = [GAS(self._gas(space_id=sid)).addrSpaceID_str for sid in (0, 1, 2, 3, 4, 0x0A, 0x7F)]
+
+        self.assertNotIn('Reserved', names)
+        self.assertEqual(names[0], 'System Memory Space')
+
+    def test_oem_range_is_recognized(self):
+        self.assertEqual(GAS(self._gas(space_id=0xC5)).addrSpaceID_str, 'OEM Defined')
+
+    def test_unassigned_address_space_is_reserved(self):
+        self.assertEqual(GAS(self._gas(space_id=0x50)).addrSpaceID_str, 'Reserved')
+
+    def test_known_access_sizes_are_named(self):
+        self.assertEqual(GAS(self._gas(access_size=2)).accessSize_str, 'Word Access')
+
+    def test_out_of_range_access_size_falls_back_to_the_catch_all(self):
+        self.assertIn('Not a defined value', GAS(self._gas(access_size=9)).accessSize_str)
+
+    def test_rendering_includes_the_address(self):
+        self.assertIn('FED40000', str(GAS(self._gas())))
+
+
+class TestSafeStructUnpack(unittest.TestCase):
+
+    def test_unpacks_when_enough_data_is_available(self):
+        self.assertEqual(safe_struct_unpack('<I', struct.pack('<I', 0x1234)), (0x1234,))
+
+    def test_honors_the_requested_offset(self):
+        self.assertEqual(safe_struct_unpack('<I', b'\xff' * 4 + struct.pack('<I', 7), 4), (7,))
+
+    def test_insufficient_data_is_rejected(self):
+        with self.assertRaises(ValueError):
+            safe_struct_unpack('<Q', b'\x00' * 4)
+
+    def test_insufficient_data_after_the_offset_is_rejected(self):
+        with self.assertRaises(ValueError):
+            safe_struct_unpack('<I', b'\x00' * 6, 4)
+
+
+class TestDMARStructureTypes(unittest.TestCase):
+    """Each DMAR remapping structure type has its own decoder."""
+
+    def setUp(self):
+        self.dmar = DMAR()
+
+    def test_hardware_unit_definition(self):
+        structure = struct.pack('=HHBBHQ', 0, 24, 0, 0, 0, 0xFED90000)
+        structure += struct.pack('=BBBBBB', 1, 8, 0, 0, 0, 0) + b'\x02\x00'
+
+        rendered = self.dmar._get_structure_DMAR(0x00, structure)
+
+        self.assertIn('DMA Remapping Hardware Unit Definition', rendered)
+        self.assertIn('FED90000', rendered)
+
+    def test_reserved_memory_region(self):
+        structure = struct.pack('=HHHHQQ', 1, 24, 0, 0, 0x7AB90000, 0x7ADEFFFF)
+
+        rendered = self.dmar._get_structure_DMAR(0x01, structure)
+
+        self.assertIn('Reserved Memory Range', rendered)
+        self.assertIn('7AB90000', rendered)
+
+    def test_root_port_ats_capability(self):
+        rendered = self.dmar._get_structure_DMAR(0x02, struct.pack('=HHBBH', 2, 8, 0, 0, 0))
+
+        self.assertIn('Root Port ATS Capability', rendered)
+
+    def test_hardware_static_affinity(self):
+        structure = struct.pack('=HHIQI', 3, 20, 0, 0xFED91000, 0)
+
+        rendered = self.dmar._get_structure_DMAR(0x03, structure)
+
+        self.assertIn('FED91000', rendered)
+
+    def test_namespace_device_declaration(self):
+        structure = struct.pack('HH3sB4s', 4, 12, b'\x00\x00\x00', 1, b'NAME')
+
+        rendered = self.dmar._get_structure_DMAR(0x04, structure)
+
+        self.assertIn('ACPI Device Number', rendered)
+
+    def test_soc_address_translation_cache(self):
+        rendered = str(self.dmar._get_structure_DMAR(0x05, struct.pack('HHBBH', 5, 8, 0, 0, 0)))
+
+        self.assertIn('SoC Integrated Address Translation Cache', rendered)
+
+    def test_soc_device_property(self):
+        rendered = str(self.dmar._get_structure_DMAR(0x06, struct.pack('HHHH', 6, 8, 0, 0)))
+
+        self.assertIn('Reporting Structure', rendered)
+
+    def test_device_scope_entries_are_attached_to_their_parent(self):
+        structure = struct.pack('=HHBBHQ', 0, 24, 0, 0, 0, 0xFED90000)
+        structure += struct.pack('=BBBBBB', 3, 8, 0, 0, 2, 0) + b'\x1f\x00'
+
+        rendered = self.dmar._get_structure_DMAR(0x00, structure)
+
+        self.assertIn('I/O APIC Device', rendered)
+
+    def test_empty_content_is_rejected(self):
+        with self.assertRaises(ValueError):
+            DMAR().parse(b'')
+
+    def test_truncated_content_is_rejected(self):
+        with self.assertRaises(ValueError):
+            DMAR().parse(b'\x00' * 4)
+
+    def test_structure_longer_than_the_table_stops_parsing(self):
+        header = struct.pack('=BB10s', 39, 0, b'\x00' * 10)
+        table = DMAR()
+        table.parse(header + struct.pack('=HH', 0, 0xFF))
+
+        self.assertEqual(table.dmar_structures, [])
+
+    def test_zero_length_structure_stops_parsing(self):
+        header = struct.pack('=BB10s', 39, 0, b'\x00' * 10)
+        table = DMAR()
+        table.parse(header + struct.pack('=HH', 0, 0))
+
+        self.assertEqual(table.dmar_structures, [])
+        self.assertEqual(table.HostAddrWidth, 39)
+
+
+class TestAPICStructureTypes(unittest.TestCase):
+    """Each MADT interrupt controller structure type has its own decoder."""
+
+    def setUp(self):
+        self.apic = APIC()
+
+    def _render(self, type_id, fmt_key, *fields):
+        data = struct.pack(self.apic.APIC_TABLE_FORMAT[fmt_key], *fields)
+        return self.apic.get_structure_APIC(type_id, data)
+
+    def test_processor_local_apic(self):
+        self.assertIn('Processor Local APIC', self._render(0x00, 'PROCESSOR_LAPIC', 0, 8, 1, 2, 1))
+
+    def test_io_apic(self):
+        self.assertIn('I/O APIC', self._render(0x01, 'IOAPIC', 1, 12, 2, 0, 0xFEC00000, 0))
+
+    def test_interrupt_source_override(self):
+        self.assertIn('Interrupt Source Override',
+                      self._render(0x02, 'INTERRUPT_SOURSE_OVERRIDE', 2, 10, 0, 0, 2, 0))
+
+    def test_nmi_source(self):
+        self.assertIn('Non-maskable Interrupt', self._render(0x03, 'NMI_SOURCE', 3, 8, 0, 0))
+
+    def test_local_apic_nmi(self):
+        self.assertIn('Local APIC NMI', self._render(0x04, 'LAPIC_NMI', 4, 6, 1, 0, 1))
+
+    def test_local_apic_address_override(self):
+        self.assertIn('Local APIC Address Override',
+                      self._render(0x05, 'LAPIC_ADDRESS_OVERRIDE', 5, 12, 0, 0xFEE00000))
+
+    def test_io_sapic(self):
+        self.assertIn('I/O SAPIC', self._render(0x06, 'IOSAPIC', 6, 16, 1, 0, 0, 0xFEC00000))
+
+    def test_processor_local_x2apic(self):
+        self.assertIn('Processor Local x2APIC',
+                      self._render(0x09, 'PROCESSOR_Lx2APIC', 9, 16, 0, 4, 1, 4))
+
+    def test_local_x2apic_nmi(self):
+        self.assertIn('Local x2APIC NMI',
+                      self._render(0x0A, 'Lx2APIC_NMI', 0x0A, 12, 0, 0, 1, b'\x00\x00\x00'))
+
+    def test_gicc_cpu_interface(self):
+        self.assertIn('GICC CPU Interface',
+                      self._render(0x0B, 'GICC_CPU', 0x0B, 76, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+
+    def test_gic_distributor(self):
+        self.assertIn('GIC Distributor',
+                      self._render(0x0C, 'GIC_DISTRIBUTOR', 0x0C, 24, 0, 0, 0, 0, 0))
+
+    def test_gic_msi_frame(self):
+        self.assertIn('MSI Frame', self._render(0x0D, 'GIC_MSI', 0x0D, 24, 0, 0, 0, 0, 0, 0))
+
+    def test_gic_redistributor(self):
+        self.assertIn('Redistributor', self._render(0x0E, 'GIC_REDISTRIBUTOR', 0x0E, 16, 0, 0, 0))
+
+    def test_unknown_structure_type_is_dumped_rather_than_dropped(self):
+        rendered = self.apic.get_structure_APIC(0x7F, b'\xAA' * 8)
+
+        self.assertIn('Reserved', rendered)
+
+    def test_empty_content_is_rejected(self):
+        with self.assertRaises(ValueError):
+            APIC().parse(b'')
+
+    def test_truncated_content_is_rejected(self):
+        with self.assertRaises(ValueError):
+            APIC().parse(b'\x00' * 4)
+
+    def test_zero_length_structure_stops_parsing(self):
+        table = APIC()
+        table.parse(struct.pack('=II', 0xFEE00000, 1) + struct.pack('=BB', 0, 0))
+
+        self.assertEqual(table.apic_structs, [])
+        self.assertEqual(table.LAPICBase, 0xFEE00000)
+
+    def test_structure_longer_than_the_table_stops_parsing(self):
+        table = APIC()
+        table.parse(struct.pack('=II', 0xFEE00000, 1) + struct.pack('=BB', 0, 0xFF))
+
+        self.assertEqual(table.apic_structs, [])
 
 
 if __name__ == '__main__':

--- a/tests/library/test_acpi_tables.py
+++ b/tests/library/test_acpi_tables.py
@@ -646,6 +646,15 @@ class TestAPICStructureTypes(unittest.TestCase):
     def test_io_sapic(self):
         self.assertIn('I/O SAPIC', self._render(0x06, 'IOSAPIC', 6, 16, 1, 0, 0, 0xFEC00000))
 
+    def test_platform_interrupt_sources(self):
+        rendered = self._render(
+            0x08, 'PLATFORM_INTERRUPT_SOURCES',
+            8, 16, 0x1, 0x2, 0x3, 0x4, 0x5, 0x1234, 0x6)
+
+        self.assertIn('Platform Interrupt Sources', rendered)
+        self.assertIn('0x05', rendered)
+        self.assertIn('0x1234', rendered)
+
     def test_processor_local_x2apic(self):
         self.assertIn('Processor Local x2APIC',
                       self._render(0x09, 'PROCESSOR_Lx2APIC', 9, 16, 0, 4, 1, 4))

--- a/tests/library/test_paging.py
+++ b/tests/library/test_paging.py
@@ -1,0 +1,559 @@
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2026, Intel Corporation
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Contact information:
+# chipsec@intel.com
+#
+
+import os
+import struct
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+from chipsec.library import paging
+from chipsec.library.exceptions import InvalidMemoryAddress
+
+PAGE_SIZE = 0x1000
+PRESENT = 0x1
+WRITABLE = 0x2
+USER = 0x4
+BIG_PAGE = 0x80
+
+
+class FakePhysicalMemory:
+    """Backing store that serves 4KB pages of 64-bit page table entries."""
+
+    def __init__(self):
+        self.pages = {}
+        self.writes = []
+        self.raise_on_read = None
+
+    def set_page(self, addr, entries):
+        data = b''.join(struct.pack('<Q', entry) for entry in entries)
+        self.pages[addr] = data.ljust(PAGE_SIZE, b'\x00')
+
+    def read_physical_mem(self, addr, size):
+        if self.raise_on_read is not None:
+            raise self.raise_on_read
+        return self.pages.get(addr, b'\x00' * PAGE_SIZE)[:size]
+
+    def write_physical_mem(self, addr, size, buf):
+        self.writes.append((addr, size, buf))
+
+
+def fake_cs(memory=None):
+    cs = MagicMock()
+    cs.hals.memory = memory if memory is not None else FakePhysicalMemory()
+    return cs
+
+
+def four_level_memory():
+    """A 4-level hierarchy mapping VA 0 to a 2MB page at PA 0x400000."""
+    mem = FakePhysicalMemory()
+    mem.set_page(0x1000, [0x2000 | PRESENT | WRITABLE])
+    mem.set_page(0x2000, [0x3000 | PRESENT | WRITABLE])
+    mem.set_page(0x3000, [0x400000 | PRESENT | WRITABLE | BIG_PAGE])
+    return mem
+
+
+def four_kb_memory():
+    """A 4-level hierarchy mapping VA 0 to a 4KB page at PA 0x500000."""
+    mem = FakePhysicalMemory()
+    mem.set_page(0x1000, [0x2000 | PRESENT | WRITABLE])
+    mem.set_page(0x2000, [0x3000 | PRESENT | WRITABLE])
+    mem.set_page(0x3000, [0x4000 | PRESENT | WRITABLE])
+    mem.set_page(0x4000, [0x500000 | PRESENT | WRITABLE])
+    return mem
+
+
+class TestTranslation(unittest.TestCase):
+    """c_translation stores the virtual to physical map built while walking tables."""
+
+    def setUp(self):
+        self.translation = paging.c_translation()
+
+    def test_empty_translation_is_an_identity_map(self):
+        self.assertEqual(self.translation.get_translation(0x1234), 0x1234)
+
+    def test_4kb_page_translation_preserves_the_page_offset(self):
+        self.translation.add_page(0x1000, 0x500000, '4KB', 'RW')
+
+        self.assertEqual(self.translation.get_translation(0x1123), 0x500123)
+
+    def test_2mb_page_translation_preserves_the_page_offset(self):
+        self.translation.add_page(0x200000, 0x400000, '2MB', 'RW')
+
+        self.assertEqual(self.translation.get_translation(0x201234), 0x401234)
+
+    def test_1gb_page_translation_preserves_the_page_offset(self):
+        self.translation.add_page(0x40000000, 0x80000000, '1GB', 'RW')
+
+        self.assertEqual(self.translation.get_translation(0x40000ABC), 0x80000ABC)
+
+    def test_unmapped_address_has_no_translation(self):
+        self.translation.add_page(0x1000, 0x500000, '4KB', 'RW')
+
+        self.assertIsNone(self.translation.get_translation(0xDEAD0000))
+
+    def test_unsupported_page_size_is_rejected(self):
+        with self.assertRaises(Exception):
+            self.translation.add_page(0x1000, 0x2000, '8KB', 'RW')
+
+    def test_deleting_a_page_removes_its_translation(self):
+        self.translation.add_page(0x1000, 0x500000, '4KB', 'RW')
+        self.translation.add_page(0x2000, 0x600000, '4KB', 'RW')
+
+        self.translation.del_page(0x1000)
+
+        self.assertIsNone(self.translation.get_translation(0x1000))
+        self.assertEqual(self.translation.get_translation(0x2000), 0x600000)
+
+    def test_deleting_an_unknown_page_is_a_no_op(self):
+        self.translation.del_page(0x1000)
+
+        self.assertEqual(self.translation.translation, {})
+
+    def test_pages_can_be_looked_up_by_physical_address(self):
+        self.translation.add_page(0x1000, 0x500000, '4KB', 'RW')
+        self.translation.add_page(0x2000, 0x600000, '4KB', 'RW')
+
+        pages = self.translation.get_pages_by_physaddr(0x500ABC)
+
+        self.assertEqual(len(pages), 1)
+        self.assertEqual(pages[0]['addr'], 0x500000)
+
+    def test_adjacent_pages_with_matching_attributes_are_merged(self):
+        self.translation.add_page(0x1000, 0x500000, '4KB', 'RW')
+        self.translation.add_page(0x2000, 0x501000, '4KB', 'RW')
+
+        self.assertEqual(self.translation.get_mem_range(), [[0x500000, 0x502000, 'RW']])
+
+    def test_adjacent_pages_with_different_attributes_stay_separate(self):
+        self.translation.add_page(0x1000, 0x500000, '4KB', 'RW')
+        self.translation.add_page(0x2000, 0x501000, '4KB', 'R')
+
+        self.assertEqual(len(self.translation.get_mem_range()), 2)
+
+    def test_attributes_can_be_ignored_when_merging(self):
+        self.translation.add_page(0x1000, 0x500000, '4KB', 'RW')
+        self.translation.add_page(0x2000, 0x501000, '4KB', 'R')
+
+        self.assertEqual(self.translation.get_mem_range(noattr=True), [[0x500000, 0x502000, '']])
+
+    def test_non_adjacent_pages_stay_separate(self):
+        self.translation.add_page(0x1000, 0x500000, '4KB', 'RW')
+        self.translation.add_page(0x2000, 0x900000, '4KB', 'RW')
+
+        self.assertEqual(len(self.translation.get_mem_range()), 2)
+
+    def test_address_space_is_the_total_of_all_mapped_ranges(self):
+        self.translation.add_page(0x1000, 0x500000, '4KB', 'RW')
+        self.translation.add_page(0x200000, 0x800000, '2MB', 'RW')
+
+        self.assertEqual(self.translation.get_address_space(), paging.SIZE_4KB + paging.SIZE_2MB)
+
+    def test_empty_translation_has_no_address_space(self):
+        self.assertEqual(self.translation.get_address_space(), 0)
+
+
+class TestReverseTranslation(unittest.TestCase):
+    """c_reverse_translation answers "which virtual pages map here?"."""
+
+    def test_multiple_virtual_pages_can_share_one_physical_page(self):
+        forward = {
+            0x1000: {'addr': 0x500000, 'size': '4KB', 'attr': 'RW'},
+            0x9000: {'addr': 0x500000, 'size': '4KB', 'attr': 'R'},
+        }
+
+        reverse = paging.c_reverse_translation(forward)
+
+        virts = sorted(entry['addr'] for entry in reverse.get_reverse_translation(0x500000))
+        self.assertEqual(virts, [0x1000, 0x9000])
+
+    def test_lookup_is_aligned_to_the_containing_page(self):
+        forward = {0x1000: {'addr': 0x500000, 'size': '4KB', 'attr': 'RW'}}
+
+        reverse = paging.c_reverse_translation(forward)
+
+        self.assertEqual(len(reverse.get_reverse_translation(0x500FFF)), 1)
+
+    def test_unmapped_physical_address_yields_no_entries(self):
+        reverse = paging.c_reverse_translation({})
+
+        self.assertEqual(reverse.get_reverse_translation(0x500000), [])
+
+
+class TestMemoryAccess(unittest.TestCase):
+    """Page table reads go through the HAL, optionally via a second translation level."""
+
+    def test_reads_are_delegated_to_the_memory_hal(self):
+        mem = FakePhysicalMemory()
+        mem.set_page(0x1000, [0xAABBCCDD])
+
+        data = paging.c_paging_memory_access(fake_cs(mem)).readmem('test', 0x1000, 8)
+
+        self.assertEqual(data, struct.pack('<Q', 0xAABBCCDD))
+
+    def test_without_a_second_level_the_address_is_used_as_is(self):
+        mem = FakePhysicalMemory()
+        mem.set_page(0x1000, [0x1111])
+
+        access = paging.c_paging_with_2nd_level_translation(fake_cs(mem))
+
+        self.assertEqual(access.readmem('test', 0x1000, 8), struct.pack('<Q', 0x1111))
+
+    def test_second_level_translation_redirects_the_read(self):
+        mem = FakePhysicalMemory()
+        mem.set_page(0x7000, [0x2222])
+        access = paging.c_paging_with_2nd_level_translation(fake_cs(mem))
+        access.translation_level2.add_page(0x1000, 0x7000, '4KB', 'RW')
+
+        self.assertEqual(access.readmem('test', 0x1000, 8), struct.pack('<Q', 0x2222))
+
+    def test_unmapped_guest_address_reads_nothing(self):
+        access = paging.c_paging_with_2nd_level_translation(fake_cs())
+        access.translation_level2.add_page(0x1000, 0x7000, '4KB', 'RW')
+
+        self.assertEqual(access.readmem('test', 0xDEAD0000, 8), b'')
+
+
+class TestPagingHelpers(unittest.TestCase):
+    """Shared helpers used by every page table flavor."""
+
+    def setUp(self):
+        self.paging = paging.c_paging(fake_cs())
+
+    def test_addresses_below_the_canonical_boundary_are_unchanged(self):
+        self.assertEqual(self.paging.get_canonical(0x1000), 0x1000)
+
+    def test_addresses_above_the_canonical_boundary_are_sign_extended(self):
+        self.assertEqual(self.paging.get_canonical(1 << 47), 0xFFFF800000000000)
+
+    def test_field_extraction_and_insertion_are_inverses(self):
+        desc = {'mask': 0x1FF, 'offset': 30}
+
+        self.assertEqual(self.paging.get_field(self.paging.set_field(0x123, desc), desc), 0x123)
+
+    def test_field_extraction_masks_out_neighboring_bits(self):
+        self.assertEqual(self.paging.get_field(0xFF, {'mask': 0xF, 'offset': 4}), 0xF)
+
+    def test_uniform_pages_are_collapsed_to_a_single_entry(self):
+        mem = FakePhysicalMemory()
+        walker = paging.c_paging(fake_cs(mem))
+
+        self.assertEqual(walker.read_entries('pml4', 0x1000), [0])
+
+    def test_non_uniform_pages_return_every_entry(self):
+        mem = FakePhysicalMemory()
+        mem.set_page(0x1000, [1])
+        walker = paging.c_paging(fake_cs(mem))
+
+        self.assertEqual(len(walker.read_entries('pml4', 0x1000)), 512)
+
+    def test_wide_entries_are_returned_as_pairs(self):
+        mem = FakePhysicalMemory()
+        mem.set_page(0x1000, [1, 2])
+        walker = paging.c_paging(fake_cs(mem))
+
+        entries = walker.read_entries('re', 0x1000, 16)
+
+        self.assertEqual(len(entries), 256)
+        self.assertEqual(entries[0], [1, 2])
+
+    def test_base_class_cannot_walk_page_tables(self):
+        with self.assertRaises(Exception):
+            self.paging.read_page_tables(0x1000)
+
+
+class TestConfigurationPersistence(unittest.TestCase):
+    """Captured page tables can be saved and reloaded for offline analysis."""
+
+    def setUp(self):
+        handle, self.path = tempfile.mkstemp()
+        os.close(handle)
+        self.addCleanup(os.remove, self.path)
+
+    def test_saved_state_is_restored_on_load(self):
+        original = paging.c_paging(fake_cs())
+        original.add_page(0x1000, 0x500000, '4KB', 'RW')
+        original.translation_level2.add_page(0x2000, 0x600000, '4KB', 'R')
+        original.pt = {0x1000: 'pml4'}
+        original.save_configuration(self.path)
+
+        restored = paging.c_paging(fake_cs())
+        restored.load_configuration(self.path)
+
+        self.assertEqual(restored.translation, original.translation)
+        self.assertEqual(restored.translation_level2.translation, original.translation_level2.translation)
+        self.assertEqual(restored.pt, original.pt)
+
+    def test_corrupt_configuration_does_not_raise(self):
+        with open(self.path, 'w') as handle:
+            handle.write('not a python literal\n')
+
+        restored = paging.c_paging(fake_cs())
+        restored.load_configuration(self.path)
+
+        self.assertEqual(restored.translation, {})
+
+
+class TestFourLevelPageTables(unittest.TestCase):
+    """The 4-level walker is the base for IA32e, EPT and VT-d second level tables."""
+
+    def test_virtual_address_is_composed_from_the_table_indices(self):
+        walker = paging.c_4level_page_tables(fake_cs())
+
+        self.assertEqual(
+            walker.get_virt_addr(1, 2, 3, 4),
+            (1 << 39) | (2 << 30) | (3 << 21) | (4 << 12),
+        )
+
+    def test_presence_and_page_size_are_read_from_the_entry_flags(self):
+        walker = paging.c_4level_page_tables(fake_cs())
+
+        self.assertTrue(walker.is_present(PRESENT))
+        self.assertFalse(walker.is_present(0))
+        self.assertTrue(walker.is_bigpage(BIG_PAGE))
+        self.assertFalse(walker.is_bigpage(PRESENT))
+
+    def test_walking_records_every_table_page(self):
+        walker = paging.c_4level_page_tables(fake_cs(four_level_memory()))
+
+        walker.read_page_tables(0x1000)
+
+        self.assertEqual(set(walker.pt), {0x1000, 0x2000, 0x3000})
+
+    def test_walking_records_the_mapped_large_page(self):
+        walker = paging.c_4level_page_tables(fake_cs(four_level_memory()))
+
+        walker.read_page_tables(0x1000)
+
+        self.assertEqual(walker.translation[0]['addr'], 0x400000)
+        self.assertEqual(walker.translation[0]['size'], '2MB')
+
+    def test_walking_descends_into_leaf_page_tables(self):
+        walker = paging.c_4level_page_tables(fake_cs(four_kb_memory()))
+
+        walker.read_page_tables(0x1000)
+
+        self.assertEqual(walker.translation[0]['size'], '4KB')
+        self.assertEqual(walker.translation[0]['addr'], 0x500000)
+
+    def test_walking_replaces_the_results_of_a_previous_walk(self):
+        walker = paging.c_4level_page_tables(fake_cs(four_level_memory()))
+
+        walker.read_page_tables(0x1000)
+        walker.read_page_tables(0x1000)
+
+        self.assertEqual(len(walker.translation), 1)
+
+    def test_lookup_of_a_large_page_keeps_the_offset_within_the_page(self):
+        walker = paging.c_4level_page_tables(fake_cs(four_level_memory()))
+        walker.read_page_tables(0x1000)
+
+        entry = walker.read_entry_by_virt_addr(0x1234)
+
+        self.assertEqual(entry['addr'], 0x401234)
+        self.assertEqual(entry['size'], '2MB')
+
+    def test_lookup_of_a_small_page_keeps_the_offset_within_the_page(self):
+        walker = paging.c_4level_page_tables(fake_cs(four_kb_memory()))
+        walker.read_page_tables(0x1000)
+
+        entry = walker.read_entry_by_virt_addr(0x123)
+
+        self.assertEqual(entry['addr'], 0x500123)
+        self.assertEqual(entry['size'], '4KB')
+
+    def test_lookup_of_an_unmapped_address_reports_no_mapping(self):
+        walker = paging.c_4level_page_tables(fake_cs(four_level_memory()))
+        walker.read_page_tables(0x1000)
+
+        self.assertEqual(walker.read_entry_by_virt_addr(1 << 40), {'addr': 0, 'attr': '', 'size': ''})
+
+    def test_lookup_before_a_walk_is_rejected(self):
+        walker = paging.c_4level_page_tables(fake_cs())
+
+        with self.assertRaises(Exception):
+            walker.read_entry_by_virt_addr(0)
+
+    def test_attributes_describe_write_and_privilege_bits(self):
+        walker = paging.c_4level_page_tables(fake_cs())
+
+        self.assertEqual(walker.get_attr(PRESENT), 'RS')
+        self.assertEqual(walker.get_attr(PRESENT | WRITABLE | USER), 'WU')
+
+    def test_status_report_records_a_successful_walk(self):
+        walker = paging.c_4level_page_tables(fake_cs(four_level_memory()))
+
+        walker.read_pt_and_show_status(self.id(), 'test', 0x1000)
+
+        self.assertFalse(walker.failure)
+
+    def test_status_report_clears_state_when_memory_is_unreadable(self):
+        mem = four_level_memory()
+        mem.raise_on_read = InvalidMemoryAddress('bad address')
+        walker = paging.c_4level_page_tables(fake_cs(mem))
+
+        walker.read_pt_and_show_status(self.id(), 'test', 0x1000)
+
+        self.assertTrue(walker.failure)
+        self.assertEqual(walker.translation, {})
+        self.assertEqual(walker.pt, {})
+
+    def test_misconfiguration_check_tolerates_page_table_pages_in_range(self):
+        walker = paging.c_4level_page_tables(fake_cs(four_level_memory()))
+        walker.read_page_tables(0x1000)
+
+        walker.check_misconfig(list(walker.pt))
+
+
+class TestIA32ePageTables(unittest.TestCase):
+
+    def test_presence_and_size_use_the_architectural_bit_positions(self):
+        walker = paging.c_ia32e_page_tables(fake_cs())
+
+        self.assertTrue(walker.is_present(PRESENT))
+        self.assertFalse(walker.is_present(BIG_PAGE))
+        self.assertTrue(walker.is_bigpage(BIG_PAGE))
+
+    def test_attributes_report_read_write_and_supervisor_user(self):
+        walker = paging.c_ia32e_page_tables(fake_cs())
+
+        self.assertEqual(walker.get_attr(PRESENT), 'R S')
+        self.assertEqual(walker.get_attr(PRESENT | WRITABLE), 'W S')
+        self.assertEqual(walker.get_attr(PRESENT | WRITABLE | USER), 'W U')
+
+    def test_mapped_pages_are_labelled_with_the_virtual_address_name(self):
+        walker = paging.c_ia32e_page_tables(fake_cs(four_level_memory()))
+
+        walker.read_page_tables(0x1000)
+
+        self.assertEqual(walker.translation[0]['attr'], 'W S')
+
+
+class TestPAEPageTables(unittest.TestCase):
+
+    def test_pae_tables_have_no_pml4_level(self):
+        walker = paging.c_pae_page_tables(fake_cs())
+
+        with self.assertRaises(Exception):
+            walker.read_pml4(0x1000)
+
+    def test_pae_only_addresses_two_pdpt_index_bits(self):
+        walker = paging.c_pae_page_tables(fake_cs())
+
+        self.assertEqual(walker.PDPT_INDX['mask'], 0x3)
+
+
+class TestExtendedPageTables(unittest.TestCase):
+    """EPT entries encode access rights and memory type instead of R/W/U."""
+
+    def test_presence_is_driven_by_the_access_rights_field(self):
+        walker = paging.c_extended_page_tables(fake_cs())
+
+        self.assertTrue(walker.is_present(0x7))
+        self.assertFalse(walker.is_present(0x8))
+
+    def test_attributes_report_access_rights_and_memory_type(self):
+        walker = paging.c_extended_page_tables(fake_cs())
+
+        self.assertEqual(walker.get_attr(0x7 | (6 << 3)), 'XWR WB')
+        self.assertEqual(walker.get_attr(0x1), '--R UC')
+
+    def test_guest_physical_addresses_are_not_sign_extended(self):
+        walker = paging.c_extended_page_tables(fake_cs())
+
+        self.assertEqual(walker.get_canonical(1 << 47), 1 << 47)
+
+    def test_remapping_a_1gb_entry_writes_back_a_new_entry(self):
+        mem = FakePhysicalMemory()
+        mem.set_page(0x1000, [0x2000 | 0x7])
+        mem.set_page(0x2000, [0x3000 | 0x7])
+        walker = paging.c_extended_page_tables(fake_cs(mem))
+        walker.read_page_tables(0x1000)
+
+        walker.map_bigpage_1G(0, 0)
+
+        self.assertEqual(len(mem.writes), 1)
+        addr, size, _buf = mem.writes[0]
+        self.assertEqual((addr, size), (0x2000, 8))
+
+    def test_remapping_before_a_walk_is_rejected(self):
+        walker = paging.c_extended_page_tables(fake_cs())
+
+        with self.assertRaises(Exception):
+            walker.map_bigpage_1G(0, 0)
+
+
+class TestVTdPageTables(unittest.TestCase):
+    """VT-d adds root and context entry tables in front of the second level tables."""
+
+    @staticmethod
+    def _vtd_memory():
+        mem = FakePhysicalMemory()
+        mem.set_page(0x1000, [0x2000 | 0x1, 0x0])
+        mem.set_page(0x2000, [0x3000 | 0x1, 0x0])
+        return mem
+
+    def test_root_entries_lead_to_context_pages(self):
+        walker = paging.c_vtd_page_tables(fake_cs(self._vtd_memory()))
+
+        walker.read_re(0x1000)
+
+        self.assertIn(0x2000, walker.cpt)
+
+    def test_present_context_entries_are_recorded_by_source_id(self):
+        walker = paging.c_vtd_page_tables(fake_cs(self._vtd_memory()))
+
+        walker.read_ce(0x2000, 0)
+
+        self.assertIn(0, walker.context)
+
+    def test_context_entries_register_their_translation_domain(self):
+        walker = paging.c_vtd_page_tables(fake_cs(self._vtd_memory()))
+
+        walker.read_ce(0x2000, 0)
+
+        self.assertIn(0x3000, walker.domains)
+
+    def test_absent_root_entries_are_skipped(self):
+        walker = paging.c_vtd_page_tables(fake_cs(FakePhysicalMemory()))
+
+        walker.read_re(0x1000)
+
+        self.assertEqual(walker.cpt, {})
+
+    def test_reading_the_context_writes_a_report_and_records_domains(self):
+        handle, path = tempfile.mkstemp()
+        os.close(handle)
+        self.addCleanup(os.remove, path)
+        walker = paging.c_vtd_page_tables(fake_cs(self._vtd_memory()))
+
+        walker.read_vtd_context(path, 0x1000)
+
+        self.assertIn(0x3000, walker.domains)
+        self.assertIn(0, walker.context)
+
+    def test_context_entry_is_printable(self):
+        walker = paging.c_vtd_page_tables(fake_cs())
+
+        walker.print_context_entry(0x0100, [0x3000 | 0x1, 0x0])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/library/test_paging.py
+++ b/tests/library/test_paging.py
@@ -169,6 +169,45 @@ class TestTranslation(unittest.TestCase):
     def test_empty_translation_has_no_address_space(self):
         self.assertEqual(self.translation.get_address_space(), 0)
 
+    def test_2mb_page_expands_into_512_4kb_pages(self):
+        self.translation.add_page(0x200000, 0x400000, '2MB', 'RW')
+
+        self.translation.expand_pages('2MB')
+
+        self.assertEqual(len(self.translation.translation), 512)
+        self.assertEqual(
+            self.translation.translation[0x200000],
+            {'addr': 0x400000, 'size': '4KB', 'attr': 'RW'})
+        self.assertEqual(
+            self.translation.translation[0x3FF000],
+            {'addr': 0x5FF000, 'size': '4KB', 'attr': 'RW'})
+
+    def test_1gb_page_expands_into_512_2mb_pages(self):
+        self.translation.add_page(0x40000000, 0x80000000, '1GB', 'R')
+
+        self.translation.expand_pages('1GB')
+
+        self.assertEqual(len(self.translation.translation), 512)
+        self.assertEqual(
+            self.translation.translation[0x40000000],
+            {'addr': 0x80000000, 'size': '2MB', 'attr': 'R'})
+        self.assertEqual(
+            self.translation.translation[0x7FE00000],
+            {'addr': 0xBFE00000, 'size': '2MB', 'attr': 'R'})
+
+    def test_expansion_leaves_other_page_sizes_unchanged(self):
+        self.translation.add_page(0x1000, 0x500000, '4KB', 'RW')
+
+        self.translation.expand_pages('2MB')
+
+        self.assertEqual(
+            self.translation.translation,
+            {0x1000: {'addr': 0x500000, 'size': '4KB', 'attr': 'RW'}})
+
+    def test_unsupported_expansion_size_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, 'Unsupported page size'):
+            self.translation.expand_pages('4KB')
+
 
 class TestReverseTranslation(unittest.TestCase):
     """c_reverse_translation answers "which virtual pages map here?"."""

--- a/tests/library/uefi/test_sleep_states.py
+++ b/tests/library/uefi/test_sleep_states.py
@@ -1,0 +1,539 @@
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2026, Intel Corporation
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Contact information:
+# chipsec@intel.com
+#
+
+import struct
+import unittest
+
+from chipsec.library.uefi.sleep_states import (
+    MAX_S3_BOOTSCRIPT_ENTRY_LENGTH,
+    S3BOOTSCRIPT_ENTRY,
+    S3BootScriptOpcode,
+    S3BootScriptOpcode_EdkCompat,
+    S3BootScriptOpcode_MDE,
+    S3BootScriptType,
+    S3BootScriptWidth,
+    create_s3bootscript_entry_buffer,
+    decode_s3bs_opcode,
+    encode_s3bootscript_entry,
+    encode_s3bs_opcode,
+    id_s3bootscript_type,
+    op_dispatch,
+    op_io_pci_mem,
+    op_mem_poll,
+    op_smbus_execute,
+    op_stall,
+    op_terminate,
+    op_unknown,
+    parse_s3bootscript_entry,
+    parse_script,
+    script_width_formats,
+    script_width_sizes,
+)
+
+OPCODE = S3BootScriptOpcode_MDE
+EDK = S3BootScriptOpcode_EdkCompat
+DEFAULT_TYPE = S3BootScriptType.EFI_BOOT_SCRIPT_TYPE_DEFAULT
+EDKCOMPAT_TYPE = S3BootScriptType.EFI_BOOT_SCRIPT_TYPE_EDKCOMPAT
+UINT32 = S3BootScriptWidth.EFI_BOOT_SCRIPT_WIDTH_UINT32
+
+
+def default_entry(payload: bytes, index: int = 0) -> bytes:
+    """Wrap an opcode payload in a default-format boot script entry header."""
+    return struct.pack('<II', index, len(payload) + 8) + payload
+
+
+def io_write(width=UINT32, address=0x80, count=1, values=(0xAABBCCDD,)):
+    fmt = script_width_formats[width]
+    buffer = struct.pack(f'<{len(values)}{fmt}', *values)
+    return struct.pack('<BBHIQ', OPCODE.EFI_BOOT_SCRIPT_IO_WRITE_OPCODE, width, address, 0, count) + buffer
+
+
+def mem_write(width=UINT32, address=0xFED00000, unknown=0x1234, count=1, values=(0x11223344,)):
+    fmt = script_width_formats[width]
+    buffer = struct.pack(f'<{len(values)}{fmt}', *values)
+    header = struct.pack('<BBHIQQ', OPCODE.EFI_BOOT_SCRIPT_MEM_WRITE_OPCODE, width, unknown, 0, address, count)
+    return header + buffer
+
+
+class TestOpcodeDecodeDefault(unittest.TestCase):
+    """The default (MdePkg) boot script encodes each opcode with its own layout."""
+
+    def test_io_write_exposes_address_width_and_payload(self):
+        op = decode_s3bs_opcode(DEFAULT_TYPE, io_write(address=0xB2, values=(0xDEADBEEF,)))
+
+        self.assertIsInstance(op, op_io_pci_mem)
+        self.assertEqual(op.opcode, OPCODE.EFI_BOOT_SCRIPT_IO_WRITE_OPCODE)
+        self.assertEqual(op.address, 0xB2)
+        self.assertEqual(op.width, UINT32)
+        self.assertEqual(op.values, [0xDEADBEEF])
+
+    def test_io_write_decodes_every_value_in_the_payload(self):
+        op = decode_s3bs_opcode(DEFAULT_TYPE, io_write(count=3, values=(1, 2, 3)))
+
+        self.assertEqual(op.values, [1, 2, 3])
+
+    def test_payload_that_disagrees_with_the_count_is_left_undecoded(self):
+        op = decode_s3bs_opcode(DEFAULT_TYPE, io_write(count=4, values=(1, 2)))
+
+        self.assertIsNone(op.values)
+        self.assertEqual(len(op.buffer), 8)
+
+    def test_io_read_write_exposes_value_and_mask(self):
+        data = struct.pack('<BBHIQQ', OPCODE.EFI_BOOT_SCRIPT_IO_READ_WRITE_OPCODE, UINT32, 0xB2, 0, 0xAA, 0xFF)
+
+        op = decode_s3bs_opcode(DEFAULT_TYPE, data)
+
+        self.assertEqual(op.address, 0xB2)
+        self.assertEqual((op.value, op.mask), (0xAA, 0xFF))
+
+    def test_mem_write_exposes_a_64_bit_address(self):
+        op = decode_s3bs_opcode(DEFAULT_TYPE, mem_write(address=0xFED00000))
+
+        self.assertEqual(op.address, 0xFED00000)
+        self.assertEqual(op.values, [0x11223344])
+
+    def test_mem_read_write_exposes_value_and_mask(self):
+        data = struct.pack('<BBHIQQQ', OPCODE.EFI_BOOT_SCRIPT_MEM_READ_WRITE_OPCODE,
+                           UINT32, 0, 0, 0xFED00000, 0x1, 0xF)
+
+        op = decode_s3bs_opcode(DEFAULT_TYPE, data)
+
+        self.assertEqual(op.address, 0xFED00000)
+        self.assertEqual((op.value, op.mask), (0x1, 0xF))
+
+    def test_pci_config_write_exposes_the_config_address(self):
+        data = struct.pack('<BBHIQQ', OPCODE.EFI_BOOT_SCRIPT_PCI_CONFIG_WRITE_OPCODE,
+                           UINT32, 0, 0, 0x000000F8, 1) + struct.pack('<I', 0x5A5A5A5A)
+
+        op = decode_s3bs_opcode(DEFAULT_TYPE, data)
+
+        self.assertEqual(op.address, 0xF8)
+        self.assertEqual(op.values, [0x5A5A5A5A])
+
+    def test_pci_config_read_write_exposes_value_and_mask(self):
+        data = struct.pack('<BBHIQQQ', OPCODE.EFI_BOOT_SCRIPT_PCI_CONFIG_READ_WRITE_OPCODE,
+                           UINT32, 0, 0, 0xF8, 0x1, 0xF)
+
+        op = decode_s3bs_opcode(DEFAULT_TYPE, data)
+
+        self.assertEqual((op.value, op.mask), (0x1, 0xF))
+
+    def test_smbus_execute_exposes_the_transaction_details(self):
+        data = struct.pack('<BBQBB', OPCODE.EFI_BOOT_SCRIPT_SMBUS_EXECUTE_OPCODE, 0x50, 0x10, 0x04, 1)
+
+        op = decode_s3bs_opcode(DEFAULT_TYPE, data)
+
+        self.assertIsInstance(op, op_smbus_execute)
+        self.assertEqual(op.address, 0x50)
+        self.assertEqual(op.command, 0x10)
+        self.assertEqual(op.operation, 0x04)
+        self.assertEqual(op.peccheck, 1)
+
+    def test_stall_exposes_its_duration(self):
+        data = struct.pack('<BBQ', OPCODE.EFI_BOOT_SCRIPT_STALL_OPCODE, 0, 0x1388)
+
+        op = decode_s3bs_opcode(DEFAULT_TYPE, data)
+
+        self.assertIsInstance(op, op_stall)
+        self.assertEqual(op.duration, 0x1388)
+
+    def test_dispatch_exposes_its_entry_point(self):
+        data = struct.pack('<BBHIQ', OPCODE.EFI_BOOT_SCRIPT_DISPATCH_OPCODE, 0, 0, 0, 0x7A000000)
+
+        op = decode_s3bs_opcode(DEFAULT_TYPE, data)
+
+        self.assertIsInstance(op, op_dispatch)
+        self.assertEqual(op.entrypoint, 0x7A000000)
+        self.assertIsNone(op.context)
+
+    def test_terminate_is_a_single_byte_opcode(self):
+        op = decode_s3bs_opcode(DEFAULT_TYPE, struct.pack('<B', OPCODE.EFI_BOOT_SCRIPT_TERMINATE_OPCODE))
+
+        self.assertIsInstance(op, op_terminate)
+        self.assertEqual(op.size, 1)
+
+    def test_unrecognized_opcodes_are_reported_rather_than_dropped(self):
+        op = decode_s3bs_opcode(DEFAULT_TYPE, b'\x7f' + b'\x00' * 16)
+
+        self.assertIsInstance(op, op_unknown)
+        self.assertEqual(op.opcode, 0x7F)
+
+
+class TestOpcodeDecodeEdkCompat(unittest.TestCase):
+    """The EdkCompat boot script prefixes each opcode with a 16-bit id and length."""
+
+    @staticmethod
+    def _entry(opcode, payload):
+        return struct.pack('<HB', opcode, len(payload) + 3) + payload
+
+    def test_io_write_exposes_address_width_and_payload(self):
+        payload = struct.pack('<IIQ', UINT32, 1, 0xB2) + struct.pack('<I', 0xDEADBEEF)
+
+        op = decode_s3bs_opcode(EDKCOMPAT_TYPE, self._entry(EDK.EFI_BOOT_SCRIPT_IO_WRITE_OPCODE, payload))
+
+        self.assertEqual(op.address, 0xB2)
+        self.assertEqual(op.values, [0xDEADBEEF])
+
+    def test_mem_write_shares_the_write_layout(self):
+        payload = struct.pack('<IIQ', UINT32, 2, 0xFED00000) + struct.pack('<2I', 1, 2)
+
+        op = decode_s3bs_opcode(EDKCOMPAT_TYPE, self._entry(EDK.EFI_BOOT_SCRIPT_MEM_WRITE_OPCODE, payload))
+
+        self.assertEqual(op.address, 0xFED00000)
+        self.assertEqual(op.values, [1, 2])
+
+    def test_read_write_value_and_mask_are_sized_by_the_width_field(self):
+        payload = struct.pack('<IQ', UINT32, 0xFED00000) + struct.pack('=2I', 0xAA, 0xFF)
+
+        op = decode_s3bs_opcode(EDKCOMPAT_TYPE, self._entry(EDK.EFI_BOOT_SCRIPT_MEM_READ_WRITE_OPCODE, payload))
+
+        self.assertEqual((op.value, op.mask), (0xAA, 0xFF))
+
+    def test_stall_exposes_its_duration(self):
+        payload = struct.pack('<Q', 0x64)
+
+        op = decode_s3bs_opcode(EDKCOMPAT_TYPE, self._entry(EDK.EFI_BOOT_SCRIPT_STALL_OPCODE, payload))
+
+        self.assertIsInstance(op, op_stall)
+        self.assertEqual(op.duration, 0x64)
+
+    def test_dispatch_exposes_its_entry_point(self):
+        payload = struct.pack('<Q', 0x7A000000)
+
+        op = decode_s3bs_opcode(EDKCOMPAT_TYPE, self._entry(EDK.EFI_BOOT_SCRIPT_DISPATCH_OPCODE, payload))
+
+        self.assertEqual(op.entrypoint, 0x7A000000)
+
+    def test_mem_poll_exposes_duration_and_loop_count(self):
+        payload = struct.pack('<IQQQ', UINT32, 0xFED00000, 0x10, 0x20)
+
+        op = decode_s3bs_opcode(EDKCOMPAT_TYPE, self._entry(EDK.EFI_BOOT_SCRIPT_MEM_POLL_OPCODE, payload))
+
+        self.assertIsInstance(op, op_mem_poll)
+        self.assertEqual(op.address, 0xFED00000)
+        self.assertEqual((op.duration, op.looptimes), (0x10, 0x20))
+
+    def test_terminate_is_recognized(self):
+        op = decode_s3bs_opcode(EDKCOMPAT_TYPE, self._entry(EDK.EFI_BOOT_SCRIPT_TERMINATE_OPCODE, b''))
+
+        self.assertIsInstance(op, op_terminate)
+
+    def test_smbus_execute_is_not_decoded_yet(self):
+        op = decode_s3bs_opcode(EDKCOMPAT_TYPE, self._entry(EDK.EFI_BOOT_SCRIPT_SMBUS_EXECUTE_OPCODE, b'\x00' * 8))
+
+        self.assertIsNone(op)
+
+    def test_unrecognized_opcodes_are_reported_rather_than_dropped(self):
+        op = decode_s3bs_opcode(EDKCOMPAT_TYPE, self._entry(0x7F, b'\x00' * 8))
+
+        self.assertIsInstance(op, op_unknown)
+
+
+class TestOpcodeEncoding(unittest.TestCase):
+    """Opcodes that support encoding must round-trip through decode."""
+
+    def _round_trip(self, script_type, data):
+        decoded = decode_s3bs_opcode(script_type, data)
+        return encode_s3bs_opcode(script_type, decoded)
+
+    def test_default_io_write_round_trips(self):
+        data = io_write(address=0xB2, count=2, values=(1, 2))
+
+        self.assertEqual(self._round_trip(DEFAULT_TYPE, data), data)
+
+    def test_default_io_read_write_round_trips(self):
+        data = struct.pack('<BBHIQQ', OPCODE.EFI_BOOT_SCRIPT_IO_READ_WRITE_OPCODE, UINT32, 0xB2, 0, 0xAA, 0xFF)
+
+        self.assertEqual(self._round_trip(DEFAULT_TYPE, data), data)
+
+    def test_default_mem_write_round_trips(self):
+        data = mem_write(count=2, values=(1, 2))
+
+        self.assertEqual(self._round_trip(DEFAULT_TYPE, data), data)
+
+    def test_default_mem_read_write_round_trips(self):
+        data = struct.pack('<BBHIQQQ', OPCODE.EFI_BOOT_SCRIPT_MEM_READ_WRITE_OPCODE,
+                           UINT32, 0x11, 0, 0xFED00000, 0x1, 0xF)
+
+        self.assertEqual(self._round_trip(DEFAULT_TYPE, data), data)
+
+    def test_default_dispatch_round_trips(self):
+        data = struct.pack('<BBHIQ', OPCODE.EFI_BOOT_SCRIPT_DISPATCH_OPCODE, 0, 0, 0, 0x7A000000)
+
+        self.assertEqual(self._round_trip(DEFAULT_TYPE, data), data)
+
+    def test_edkcompat_write_payload_round_trips(self):
+        payload = struct.pack('<IIQ', UINT32, 2, 0xFED00000) + struct.pack('<2I', 1, 2)
+        entry = struct.pack('<HB', EDK.EFI_BOOT_SCRIPT_MEM_WRITE_OPCODE, len(payload) + 3) + payload
+
+        self.assertEqual(self._round_trip(EDKCOMPAT_TYPE, entry), payload)
+
+    def test_edkcompat_dispatch_payload_round_trips(self):
+        payload = struct.pack('<Q', 0x7A000000)
+        entry = struct.pack('<HB', EDK.EFI_BOOT_SCRIPT_DISPATCH_OPCODE, len(payload) + 3) + payload
+
+        self.assertEqual(self._round_trip(EDKCOMPAT_TYPE, entry), payload)
+
+    def test_edkcompat_mem_poll_payload_round_trips(self):
+        payload = struct.pack('<IQQQ', UINT32, 0xFED00000, 0x10, 0x20)
+        entry = struct.pack('<HB', EDK.EFI_BOOT_SCRIPT_MEM_POLL_OPCODE, len(payload) + 3) + payload
+
+        self.assertEqual(self._round_trip(EDKCOMPAT_TYPE, entry), payload)
+
+    def test_unsupported_opcodes_encode_to_nothing(self):
+        data = struct.pack('<BBQ', OPCODE.EFI_BOOT_SCRIPT_STALL_OPCODE, 0, 0x1388)
+
+        self.assertEqual(self._round_trip(DEFAULT_TYPE, data), b'')
+
+
+class TestEntryBufferCreation(unittest.TestCase):
+    """Entry buffers pair an opcode payload with the script-type specific header."""
+
+    def test_default_entry_buffer_declares_its_own_length(self):
+        op = decode_s3bs_opcode(DEFAULT_TYPE, io_write())
+
+        buf = create_s3bootscript_entry_buffer(DEFAULT_TYPE, op, index=7)
+
+        index, length = struct.unpack('<II', buf[:8])
+        self.assertEqual(index, 7)
+        self.assertEqual(length, len(buf))
+
+    def test_edkcompat_entry_buffer_declares_its_own_length(self):
+        payload = struct.pack('<Q', 0x7A000000)
+        entry = struct.pack('<HB', EDK.EFI_BOOT_SCRIPT_DISPATCH_OPCODE, len(payload) + 3) + payload
+        op = decode_s3bs_opcode(EDKCOMPAT_TYPE, entry)
+
+        buf = create_s3bootscript_entry_buffer(EDKCOMPAT_TYPE, op)
+
+        opcode, length = struct.unpack('<HB', buf[:3])
+        self.assertEqual(opcode, EDK.EFI_BOOT_SCRIPT_DISPATCH_OPCODE)
+        self.assertEqual(length, len(buf))
+
+    def test_a_created_entry_can_be_parsed_back(self):
+        op = decode_s3bs_opcode(DEFAULT_TYPE, io_write(address=0xB2, values=(0x1234,)))
+        buf = create_s3bootscript_entry_buffer(DEFAULT_TYPE, op, index=0)
+
+        _opcode, entry = parse_s3bootscript_entry(DEFAULT_TYPE, buf, 0)
+
+        self.assertEqual(entry.decoded_opcode.address, 0xB2)
+
+    def test_parsed_entries_can_be_re_encoded(self):
+        buf = default_entry(io_write(address=0xB2), index=3)
+        _opcode, entry = parse_s3bootscript_entry(DEFAULT_TYPE, buf, 0)
+
+        self.assertEqual(encode_s3bootscript_entry(entry), buf)
+
+
+class TestEntryParsing(unittest.TestCase):
+    """Entry parsing must respect declared lengths and reject malformed headers."""
+
+    def test_default_entry_reports_its_index_and_length(self):
+        buf = default_entry(io_write(), index=5)
+
+        opcode, entry = parse_s3bootscript_entry(DEFAULT_TYPE, buf, 0)
+
+        self.assertEqual(opcode, OPCODE.EFI_BOOT_SCRIPT_IO_WRITE_OPCODE)
+        self.assertEqual(entry.index, 5)
+        self.assertEqual(entry.length, len(buf))
+        self.assertEqual(entry.header_length, 8)
+
+    def test_default_entry_is_parsed_at_the_requested_offset(self):
+        buf = b'\xcc' * 16 + default_entry(io_write(address=0xB2))
+
+        _opcode, entry = parse_s3bootscript_entry(DEFAULT_TYPE, buf, 16)
+
+        self.assertEqual(entry.offset_in_script, 16)
+        self.assertEqual(entry.decoded_opcode.address, 0xB2)
+
+    def test_default_terminate_entry_uses_the_minimum_length(self):
+        buf = struct.pack('<II', 0, 0) + struct.pack('<B', OPCODE.EFI_BOOT_SCRIPT_TERMINATE_OPCODE)
+
+        opcode, entry = parse_s3bootscript_entry(DEFAULT_TYPE, buf, 0)
+
+        self.assertEqual(opcode, OPCODE.EFI_BOOT_SCRIPT_TERMINATE_OPCODE)
+        self.assertEqual(entry.length, 9)
+        self.assertEqual(entry.index, -1)
+
+    def test_default_entry_shorter_than_a_header_is_rejected(self):
+        self.assertEqual(parse_s3bootscript_entry(DEFAULT_TYPE, b'\x00' * 4, 0), (0, None))
+
+    def test_implausibly_long_entries_are_rejected(self):
+        buf = struct.pack('<II', 0, MAX_S3_BOOTSCRIPT_ENTRY_LENGTH + 1) + b'\x00' * 8
+
+        self.assertEqual(parse_s3bootscript_entry(DEFAULT_TYPE, buf, 0), (0, None))
+
+    def test_edkcompat_entry_reports_its_length(self):
+        payload = struct.pack('<Q', 0x7A000000)
+        buf = struct.pack('<HB', EDK.EFI_BOOT_SCRIPT_DISPATCH_OPCODE, len(payload) + 3) + payload
+
+        opcode, entry = parse_s3bootscript_entry(EDKCOMPAT_TYPE, buf, 0)
+
+        self.assertEqual(opcode, EDK.EFI_BOOT_SCRIPT_DISPATCH_OPCODE)
+        self.assertEqual(entry.length, len(buf))
+
+    def test_edkcompat_terminate_entry_uses_the_header_length(self):
+        buf = struct.pack('<HB', EDK.EFI_BOOT_SCRIPT_TERMINATE_OPCODE, 0xFF)
+
+        _opcode, entry = parse_s3bootscript_entry(EDKCOMPAT_TYPE, buf, 0)
+
+        self.assertEqual(entry.length, 3)
+
+    def test_edkcompat_entry_shorter_than_a_header_is_rejected(self):
+        self.assertEqual(parse_s3bootscript_entry(EDKCOMPAT_TYPE, b'\x00' * 2, 0), (0, None))
+
+
+class TestScriptTypeIdentification(unittest.TestCase):
+
+    def test_a_table_opcode_marks_an_edkcompat_script(self):
+        script_type, header_length = id_s3bootscript_type(b'\xaa' + b'\x00' * 32)
+
+        self.assertEqual(script_type, EDKCOMPAT_TYPE)
+        self.assertEqual(header_length, 13)
+
+    def test_anything_else_is_a_default_script(self):
+        script_type, header_length = id_s3bootscript_type(b'\x00' * 32)
+
+        self.assertEqual(script_type, DEFAULT_TYPE)
+        self.assertEqual(header_length, 0)
+
+
+class TestScriptParsing(unittest.TestCase):
+    """parse_script walks a whole boot script until the terminate opcode."""
+
+    @staticmethod
+    def _default_script(*payloads):
+        script = b''
+        for index, payload in enumerate(payloads):
+            script += default_entry(payload, index)
+        script += struct.pack('<II', 0, 0) + struct.pack('<B', OPCODE.EFI_BOOT_SCRIPT_TERMINATE_OPCODE)
+        return script
+
+    def test_every_entry_up_to_terminate_is_returned(self):
+        script = self._default_script(io_write(address=0xB2), mem_write(address=0xFED00000))
+
+        entries = parse_script(script)
+
+        self.assertEqual(len(entries), 3)
+        self.assertIsInstance(entries[-1].decoded_opcode, op_terminate)
+
+    def test_entries_are_reported_at_increasing_offsets(self):
+        script = self._default_script(io_write(), io_write())
+
+        offsets = [entry.offset_in_script for entry in parse_script(script)]
+
+        self.assertEqual(offsets, sorted(offsets))
+        self.assertEqual(offsets[0], 0)
+
+    def test_parsing_stops_at_the_terminate_opcode(self):
+        script = self._default_script(io_write()) + default_entry(io_write(), 99)
+
+        entries = parse_script(script)
+
+        self.assertEqual(len(entries), 2)
+
+    def test_content_after_a_malformed_entry_is_discarded(self):
+        script = default_entry(io_write()) + b'\x00' * 4
+
+        entries = parse_script(script)
+
+        self.assertEqual(len(entries), 1)
+
+    def test_edkcompat_scripts_skip_their_table_header(self):
+        payload = struct.pack('<Q', 0x7A000000)
+        header = b'\xaa' + b'\x00' * 12
+        dispatch = struct.pack('<HB', EDK.EFI_BOOT_SCRIPT_DISPATCH_OPCODE, len(payload) + 3) + payload
+        terminate = struct.pack('<HB', EDK.EFI_BOOT_SCRIPT_TERMINATE_OPCODE, 3)
+
+        entries = parse_script(header + dispatch + terminate)
+
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0].offset_in_script, 13)
+
+
+class TestOpcodeRendering(unittest.TestCase):
+    """Every decoded opcode must render without raising."""
+
+    def test_write_opcode_lists_its_values(self):
+        op = decode_s3bs_opcode(DEFAULT_TYPE, io_write(count=2, values=(1, 2)))
+
+        rendered = str(op)
+
+        self.assertIn('S3_BOOTSCRIPT_IO_WRITE', rendered)
+        self.assertIn('Values', rendered)
+
+    def test_write_opcode_lists_its_address_and_width(self):
+        op = decode_s3bs_opcode(DEFAULT_TYPE, mem_write(address=0xFED00000))
+
+        rendered = str(op)
+
+        self.assertIn('0xFED00000', rendered)
+        self.assertIn('Width', rendered)
+
+    def test_read_write_opcode_shows_value_and_mask(self):
+        data = struct.pack('<BBHIQQ', OPCODE.EFI_BOOT_SCRIPT_IO_READ_WRITE_OPCODE, UINT32, 0xB2, 0, 0xAA, 0xFF)
+
+        rendered = str(decode_s3bs_opcode(DEFAULT_TYPE, data))
+
+        self.assertIn('Value', rendered)
+        self.assertIn('Mask', rendered)
+
+    def test_other_opcodes_render(self):
+        rendered = [
+            str(op_smbus_execute(OPCODE.EFI_BOOT_SCRIPT_SMBUS_EXECUTE_OPCODE, 12, 0x50, 0x10, 4, 1)),
+            str(op_stall(OPCODE.EFI_BOOT_SCRIPT_STALL_OPCODE, 10, 0x64)),
+            str(op_dispatch(OPCODE.EFI_BOOT_SCRIPT_DISPATCH_OPCODE, 16, 0x7A000000, context=0x1000)),
+            str(op_mem_poll(EDK.EFI_BOOT_SCRIPT_MEM_POLL_OPCODE, 31, UINT32, 0xFED00000, 1, 2)),
+            str(op_terminate(OPCODE.EFI_BOOT_SCRIPT_TERMINATE_OPCODE, 1)),
+            str(op_unknown(0x7F, 1)),
+        ]
+
+        self.assertTrue(all(rendered))
+
+    def test_entry_rendering_includes_the_decoded_opcode(self):
+        buf = default_entry(io_write(address=0xB2))
+        _opcode, entry = parse_s3bootscript_entry(DEFAULT_TYPE, buf, 0)
+
+        rendered = str(entry)
+
+        self.assertIn('Entry at offset', rendered)
+        self.assertIn('Decoded', rendered)
+
+    def test_entry_without_data_renders_a_header_only(self):
+        entry = S3BOOTSCRIPT_ENTRY(DEFAULT_TYPE, None, 0x10, 0x20)
+
+        self.assertIn('Entry at offset 0x0010', str(entry))
+
+
+class TestWidthTables(unittest.TestCase):
+    """Width encodings, byte sizes and struct formats must stay consistent."""
+
+    def test_every_width_has_a_size_and_a_format(self):
+        for width in script_width_sizes:
+            self.assertIn(width, script_width_formats)
+            self.assertEqual(struct.calcsize(f'<{script_width_formats[width]}'), script_width_sizes[width])
+
+    def test_opcode_ids_are_shared_between_the_two_script_dialects(self):
+        for name in ('EFI_BOOT_SCRIPT_IO_WRITE_OPCODE', 'EFI_BOOT_SCRIPT_TERMINATE_OPCODE'):
+            self.assertEqual(getattr(OPCODE, name), getattr(S3BootScriptOpcode, name))
+            self.assertEqual(getattr(EDK, name), getattr(S3BootScriptOpcode, name))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/library/uefi/test_sleep_states.py
+++ b/tests/library/uefi/test_sleep_states.py
@@ -274,6 +274,32 @@ class TestOpcodeEncoding(unittest.TestCase):
 
         self.assertEqual(self._round_trip(DEFAULT_TYPE, data), data)
 
+    def test_default_pci_config_read_write_round_trips(self):
+        data = struct.pack(
+            '<BBHIQQQ', OPCODE.EFI_BOOT_SCRIPT_PCI_CONFIG_READ_WRITE_OPCODE,
+            UINT32, 0x11, 0, 0xF8, 0x1, 0xF)
+
+        self.assertEqual(self._round_trip(DEFAULT_TYPE, data), data)
+
+    def test_default_smbus_execute_round_trips(self):
+        data = struct.pack(
+            '<BBQBB', OPCODE.EFI_BOOT_SCRIPT_SMBUS_EXECUTE_OPCODE,
+            0x50, 0x10, 0x04, 1)
+
+        self.assertEqual(self._round_trip(DEFAULT_TYPE, data), data)
+
+    def test_default_stall_round_trips(self):
+        data = struct.pack(
+            '<BBQ', OPCODE.EFI_BOOT_SCRIPT_STALL_OPCODE, 0, 0x1388)
+
+        self.assertEqual(self._round_trip(DEFAULT_TYPE, data), data)
+
+    def test_default_terminate_round_trips(self):
+        data = struct.pack(
+            '<B', OPCODE.EFI_BOOT_SCRIPT_TERMINATE_OPCODE)
+
+        self.assertEqual(self._round_trip(DEFAULT_TYPE, data), data)
+
     def test_default_dispatch_round_trips(self):
         data = struct.pack('<BBHIQ', OPCODE.EFI_BOOT_SCRIPT_DISPATCH_OPCODE, 0, 0, 0, 0x7A000000)
 
@@ -297,10 +323,19 @@ class TestOpcodeEncoding(unittest.TestCase):
 
         self.assertEqual(self._round_trip(EDKCOMPAT_TYPE, entry), payload)
 
-    def test_unsupported_opcodes_encode_to_nothing(self):
-        data = struct.pack('<BBQ', OPCODE.EFI_BOOT_SCRIPT_STALL_OPCODE, 0, 0x1388)
+    def test_edkcompat_stall_payload_round_trips(self):
+        payload = struct.pack('<Q', 0x1388)
+        entry = struct.pack(
+            '<HB', EDK.EFI_BOOT_SCRIPT_STALL_OPCODE,
+            len(payload) + 3) + payload
 
-        self.assertEqual(self._round_trip(DEFAULT_TYPE, data), b'')
+        self.assertEqual(self._round_trip(EDKCOMPAT_TYPE, entry), payload)
+
+    def test_edkcompat_terminate_has_no_payload(self):
+        entry = struct.pack(
+            '<HB', EDK.EFI_BOOT_SCRIPT_TERMINATE_OPCODE, 3)
+
+        self.assertEqual(self._round_trip(EDKCOMPAT_TYPE, entry), b'')
 
 
 class TestEntryBufferCreation(unittest.TestCase):
@@ -485,6 +520,15 @@ class TestOpcodeRendering(unittest.TestCase):
 
         self.assertIn('0xFED00000', rendered)
         self.assertIn('Width', rendered)
+
+    def test_write_opcode_dumps_a_payload_it_could_not_decode(self):
+        op = decode_s3bs_opcode(
+            DEFAULT_TYPE, io_write(count=4, values=(1, 2)))
+
+        rendered = str(op)
+
+        self.assertIn('Buffer', rendered)
+        self.assertIn('01 00 00 00', rendered)
 
     def test_read_write_opcode_shows_value_and_mask(self):
         data = struct.pack('<BBHIQQ', OPCODE.EFI_BOOT_SCRIPT_IO_READ_WRITE_OPCODE, UINT32, 0xB2, 0, 0xAA, 0xFF)

--- a/tests/library/uefi/test_varstore_nvram.py
+++ b/tests/library/uefi/test_varstore_nvram.py
@@ -1,0 +1,467 @@
+# CHIPSEC: Platform Security Assessment Framework
+# Copyright (c) 2026, Intel Corporation
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; Version 2.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Contact information:
+# chipsec@intel.com
+#
+
+import os
+import struct
+import tempfile
+import unittest
+from uuid import UUID
+
+import chipsec.library.uefi.varstore as varstore
+from chipsec.library.uefi.platform import FWType
+
+VENDOR_GUID = UUID('8BE4DF61-93CA-11D2-AA0D-00E098032B8C')
+VENDOR_GUID_BYTES = VENDOR_GUID.bytes_le
+VAR_ADDED_STATE = 0x3F
+
+
+def utf16(name: str) -> bytes:
+    return (name + '\x00').encode('utf-16-le')
+
+
+def vss_variable(name='TestVar', data=b'\xAA' * 8, state=VAR_ADDED_STATE, attributes=0x7):
+    encoded = utf16(name)
+    header = struct.pack(varstore.HDR_FMT_VSS, varstore.VARIABLE_DATA, state, 0,
+                         attributes, len(encoded), len(data), VENDOR_GUID_BYTES)
+    return header + encoded + data
+
+
+def vss_auth_variable(name='AuthVar', data=b'\xBB' * 8, attributes=0x27):
+    encoded = utf16(name)
+    header = struct.pack(varstore.HDR_FMT_VSS_AUTH, varstore.VARIABLE_DATA, VAR_ADDED_STATE, 0,
+                         attributes, 1, 0, 0, 0, len(encoded), len(data), VENDOR_GUID_BYTES)
+    return header + encoded + data
+
+
+def vss_apple_variable(name='AppleVar', data=b'\xCC' * 8, attributes=0x7):
+    encoded = utf16(name)
+    header = struct.pack(varstore.HDR_FMT_VSS_APPLE, varstore.VARIABLE_DATA, VAR_ADDED_STATE, 0,
+                         attributes, len(encoded), len(data), VENDOR_GUID_BYTES, 0)
+    return header + encoded + data
+
+
+def vss_store(*variables):
+    body = b''.join(variables) or vss_variable()
+    size = struct.calcsize(varstore.VARIABLE_STORE_HEADER_FMT_VSS) + len(body)
+    signature = struct.unpack('=I', varstore.VARIABLE_STORE_SIGNATURE_VSS)[0]
+    header = struct.pack(varstore.VARIABLE_STORE_HEADER_FMT_VSS, signature, size,
+                         varstore.VARIABLE_STORE_FORMATTED, varstore.VARIABLE_STORE_HEALTHY, 0, 0)
+    return header + body
+
+
+def vss2_store(signature=varstore.VARIABLE_STORE_SIGNATURE_VSS2, *variables):
+    body = b''.join(variables) or vss_variable()
+    size = struct.calcsize(varstore.VARIABLE_STORE_HEADER_FMT_VSS2) + len(body)
+    header = struct.pack(varstore.VARIABLE_STORE_HEADER_FMT_VSS2, signature, size,
+                         varstore.VARIABLE_STORE_FORMATTED, varstore.VARIABLE_STORE_HEALTHY, 0, 0)
+    return header + body
+
+
+def tlv(tag0: int, payload: bytes, tag1: int = 0) -> bytes:
+    return struct.pack(varstore.TLV_HEADER, tag0, tag1, len(payload) + varstore.tlv_h_size) + payload
+
+
+def evsa_store(name='TestVar', data=b'\xDE\xAD\xBE\xEF', attributes=0x7, guid_id=1, var_id=5):
+    guid_record = tlv(0xED, struct.pack('<H16s', guid_id, VENDOR_GUID_BYTES))
+    name_record = tlv(0xEE, struct.pack('<H16s', var_id, utf16(name)))
+    value_record = tlv(0xEF, struct.pack(f'<HHI{len(data)}s', guid_id, var_id, attributes, data))
+    length = varstore.tlv_h_size + 16 + len(guid_record) + len(name_record) + len(value_record)
+    store_header = tlv(0xEC, varstore.VARIABLE_STORE_SIGNATURE_EVSA +
+                       struct.pack('<III', 0, length, 0))
+    return store_header + guid_record + name_record + value_record
+
+
+class TestVSSStoreDiscovery(unittest.TestCase):
+    """The VSS store is located by scanning for its signature."""
+
+    def test_a_vss_store_is_located_by_offset_and_size(self):
+        store = vss_store()
+
+        offset, size, header = varstore.getNVstore_VSS(b'\xFF' * 32 + store)
+
+        self.assertEqual(offset, 32)
+        self.assertEqual(size, len(store))
+        self.assertEqual(header.Format, varstore.VARIABLE_STORE_FORMATTED)
+
+    def test_a_buffer_without_a_signature_has_no_store(self):
+        self.assertEqual(varstore.getNVstore_VSS(b'\xFF' * 128), (-1, 0, None))
+
+    def test_a_signature_without_a_valid_variable_is_rejected(self):
+        signature = struct.unpack('=I', varstore.VARIABLE_STORE_SIGNATURE_VSS)[0]
+        header = struct.pack(varstore.VARIABLE_STORE_HEADER_FMT_VSS, signature, 16, 0x5A, 0xFE, 0, 0)
+
+        self.assertEqual(varstore.getNVstore_VSS(header + b'\xFF' * 64), (-1, 0, None))
+
+    def test_a_vss2_store_is_located_by_its_guid_signature(self):
+        store = vss2_store()
+
+        offset, size, header = varstore.getNVstore_VSS2(store)
+
+        self.assertEqual(offset, 0)
+        self.assertEqual(size, len(store))
+        self.assertEqual(header.Signature, varstore.VARIABLE_STORE_SIGNATURE_VSS2)
+
+    def test_a_vss2_auth_store_uses_a_different_guid(self):
+        store = vss2_store(varstore.VARIABLE_STORE_SIGNATURE_VSS2_AUTH, vss_auth_variable())
+
+        offset, _size, _header = varstore.getNVstore_VSS2_AUTH(store)
+
+        self.assertEqual(offset, 0)
+
+    def test_a_vss_auth_store_is_located(self):
+        store = vss_store(vss_auth_variable())
+
+        offset, _size, _header = varstore.getNVstore_VSS_AUTH(store)
+
+        self.assertEqual(offset, 0)
+
+    def test_an_apple_store_is_located(self):
+        store = vss_store(vss_apple_variable())
+
+        offset, _size, _header = varstore.getNVstore_VSS_APPLE(store)
+
+        self.assertEqual(offset, 0)
+
+    def test_store_headers_render_their_signature(self):
+        _off, _size, vss = varstore.getNVstore_VSS(vss_store())
+        _off2, _size2, vss2 = varstore.getNVstore_VSS2(vss2_store())
+
+        self.assertIn('$VSS', str(vss))
+        self.assertIn(str(UUID(bytes_le=varstore.VARIABLE_STORE_SIGNATURE_VSS2)).upper(), str(vss2).upper())
+
+
+class TestVSSTypeDetection(unittest.TestCase):
+
+    def test_a_well_formed_vss_variable_confirms_the_type(self):
+        self.assertTrue(varstore.isCorrectVSStype(vss_store(), FWType.EFI_FW_TYPE_VSS))
+
+    def test_an_unknown_firmware_type_is_rejected(self):
+        self.assertFalse(varstore.isCorrectVSStype(vss_store(), 'not-a-type'))
+
+    def test_a_buffer_without_a_variable_signature_is_rejected(self):
+        self.assertFalse(varstore.isCorrectVSStype(b'\x00' * 128, FWType.EFI_FW_TYPE_VSS))
+
+    def test_a_variable_with_an_unprintable_name_is_rejected(self):
+        header = struct.pack(varstore.HDR_FMT_VSS, varstore.VARIABLE_DATA, VAR_ADDED_STATE, 0,
+                             0x7, 8, 8, VENDOR_GUID_BYTES)
+        buf = header + b'\x01\x00' * 4 + b'\xAA' * 8
+
+        self.assertFalse(varstore.isCorrectVSStype(buf, FWType.EFI_FW_TYPE_VSS))
+
+    def test_padding_between_variables_is_tolerated(self):
+        store = vss_store(vss_variable(), b'\xFF' * 4, vss_variable(name='Second'))
+
+        self.assertTrue(varstore.isCorrectVSStype(store, FWType.EFI_FW_TYPE_VSS))
+
+
+class TestVSSVariableExtraction(unittest.TestCase):
+
+    def test_a_variable_name_and_data_are_recovered(self):
+        variables = varstore.getEFIvariables_VSS(vss_store(vss_variable(data=b'\x01\x02\x03\x04')))
+
+        self.assertIn('TestVar', variables)
+        offset, _buf, header, data, guid, attrs = variables['TestVar'][0]
+        self.assertEqual(data, b'\x01\x02\x03\x04')
+        self.assertEqual(guid.upper(), str(VENDOR_GUID).upper())
+        self.assertEqual(attrs, 0x7)
+        self.assertEqual(header.StartId, varstore.VARIABLE_DATA)
+        self.assertGreater(offset, 0)
+
+    def test_consecutive_variables_are_all_recovered(self):
+        store = vss_store(vss_variable(name='First'), vss_variable(name='Second'))
+
+        variables = varstore.getEFIvariables_VSS(store)
+
+        self.assertEqual(set(variables), {'First', 'Second'})
+
+    def test_repeated_names_are_grouped_together(self):
+        store = vss_store(vss_variable(data=b'\x01' * 8), vss_variable(data=b'\x02' * 8))
+
+        variables = varstore.getEFIvariables_VSS(store)
+
+        self.assertEqual(len(variables['TestVar']), 2)
+
+    def test_a_buffer_without_variables_yields_nothing(self):
+        self.assertEqual(varstore.getEFIvariables_VSS(b'\x00' * 128), {})
+
+    def test_an_unknown_firmware_type_yields_nothing(self):
+        self.assertEqual(varstore._getEFIvariables_VSS(vss_store(), 'not-a-type'), {})
+
+    def test_auth_variables_expose_their_extra_header_fields(self):
+        store = vss_store(vss_auth_variable(name='AuthVar', attributes=0x27))
+
+        variables = varstore.getEFIvariables_VSS_AUTH(store)
+
+        self.assertIn('AuthVar', variables)
+        header = variables['AuthVar'][0][2]
+        self.assertEqual(header.MonotonicCount, 1)
+        self.assertEqual(variables['AuthVar'][0][5], 0x27)
+
+    def test_apple_variables_expose_their_extra_field(self):
+        store = vss_store(vss_apple_variable(name='AppleVar'))
+
+        variables = varstore.getEFIvariables_VSS_APPLE(store)
+
+        self.assertIn('AppleVar', variables)
+        self.assertEqual(variables['AppleVar'][0][2].unknown, 0)
+
+    def test_vss2_variables_use_the_plain_variable_header(self):
+        store = vss2_store(varstore.VARIABLE_STORE_SIGNATURE_VSS2, vss_variable(name='Vss2Var'))
+
+        variables = varstore.getEFIvariables_VSS2(store)
+
+        self.assertIn('Vss2Var', variables)
+
+    def test_headers_render_their_decoded_fields(self):
+        store = vss_store(vss_variable())
+        header = varstore.getEFIvariables_VSS(store)['TestVar'][0][2]
+
+        self.assertIn('Header (VSS)', str(header))
+        self.assertIn('Header (VSS_AUTH)', str(varstore.getEFIvariables_VSS_AUTH(
+            vss_store(vss_auth_variable()))['AuthVar'][0][2]))
+        self.assertIn('Header (VSS_APPLE)', str(varstore.getEFIvariables_VSS_APPLE(
+            vss_store(vss_apple_variable()))['AppleVar'][0][2]))
+
+
+class TestEVSAVariableExtraction(unittest.TestCase):
+
+    def test_a_variable_is_recovered_from_an_evsa_store(self):
+        variables = varstore.EFIvar_EVSA(evsa_store(data=b'\x01\x02\x03\x04'))
+
+        self.assertIn('TestVar', variables)
+        _off, _buf, _hdr, data, guid, attrs = variables['TestVar'][0]
+        self.assertEqual(data, b'\x01\x02\x03\x04')
+        self.assertEqual(guid.upper(), str(VENDOR_GUID).upper())
+        self.assertEqual(attrs, 0x7)
+
+    def test_the_store_can_be_found_after_other_content(self):
+        variables = varstore.EFIvar_EVSA(b'\x00' * 64 + evsa_store())
+
+        self.assertIn('TestVar', variables)
+
+    def test_a_buffer_without_a_signature_yields_nothing(self):
+        self.assertEqual(varstore.EFIvar_EVSA(b'\x00' * 128), {})
+
+    def test_a_block_with_the_wrong_tag_is_skipped(self):
+        store = bytearray(evsa_store())
+        store[0] = 0xAA
+
+        self.assertEqual(varstore.EFIvar_EVSA(bytes(store)), {})
+
+    def test_a_value_without_a_matching_name_is_skipped(self):
+        store = evsa_store(var_id=5)
+        broken = bytearray(store)
+        name_offset = store.find(utf16('TestVar')) - 2
+        broken[name_offset] = 0x63  # different variable id
+
+        self.assertEqual(varstore.EFIvar_EVSA(bytes(broken)), {})
+
+
+class TestNVARVariableExtraction(unittest.TestCase):
+
+    def test_the_simple_format_locates_the_store(self):
+        buf = b'\xFF' * 16 + varstore.NVAR_EFIvar_signature + b'\x00' * 64
+
+        self.assertEqual(varstore.getNVstore_NVAR_simple(buf), (16, -1, None))
+
+    def test_a_buffer_without_the_signature_has_no_store(self):
+        self.assertEqual(varstore.getNVstore_NVAR_simple(b'\x00' * 32), (-1, -1, None))
+
+    def test_the_simple_format_recovers_names_and_data(self):
+        data = b'\x01\x02\x03\x04'
+        name = b'TestVar\x00'
+        total = varstore.NVAR_HDR_SIZE + len(name) + len(data)
+        signature = struct.unpack('=I', varstore.NVAR_EFIvar_signature)[0]
+        entry = struct.pack(varstore.NVAR_HDR_FMT, signature, total, 0, 0, 0, 0x7, 0x7F)
+
+        variables = varstore.getEFIvariables_NVAR_simple(entry + name + data)
+
+        self.assertIn('TestVar', variables)
+        _off, buf, header, parsed, _guid, attrs = variables['TestVar'][0]
+        self.assertEqual(header.TotalSize, total)
+        self.assertEqual(attrs, 0x7)
+        self.assertEqual(len(buf), total)
+        self.assertTrue(parsed.endswith(data))
+
+    def test_an_empty_buffer_yields_nothing(self):
+        self.assertEqual(varstore.getEFIvariables_NVAR_simple(b'\x00' * 32), {})
+
+    def test_the_nvar_header_renders_its_fields(self):
+        header = varstore.EFI_HDR_NVAR1(0x5241564E, 0x20, 0, 0, 0, 0x7, 0x7F)
+
+        self.assertIn('Header (NVAR)', str(header))
+
+    def test_invalid_nvar_entries_stop_the_walk(self):
+        self.assertEqual(varstore.getEFIvariables_NVAR(b'\x00' * 64), {})
+
+
+class TestNVRAMIdentification(unittest.TestCase):
+
+    def test_a_vss_store_is_identified(self):
+        self.assertEqual(varstore.identify_EFI_NVRAM(vss_store()), FWType.EFI_FW_TYPE_VSS)
+
+    def test_a_vss2_store_is_identified(self):
+        self.assertEqual(varstore.identify_EFI_NVRAM(vss2_store()), FWType.EFI_FW_TYPE_VSS2)
+
+    def test_an_unrecognized_buffer_is_not_identified(self):
+        self.assertEqual(varstore.identify_EFI_NVRAM(b'\x00' * 256), '')
+
+
+class TestVariableStoreLookup(unittest.TestCase):
+
+    def test_the_store_is_carved_out_of_the_rom_image(self):
+        store = vss_store()
+        rom = b'\xFF' * 64 + store + b'\xFF' * 64
+
+        self.assertEqual(varstore.find_EFI_variable_store(rom, FWType.EFI_FW_TYPE_VSS), store)
+
+    def test_a_missing_rom_image_yields_nothing(self):
+        self.assertEqual(varstore.find_EFI_variable_store(None, FWType.EFI_FW_TYPE_VSS), b'')
+
+    def test_a_missing_firmware_type_yields_nothing(self):
+        self.assertEqual(varstore.find_EFI_variable_store(vss_store(), None), b'')
+
+    def test_a_rom_image_without_a_store_yields_nothing(self):
+        self.assertEqual(varstore.find_EFI_variable_store(b'\xFF' * 256, FWType.EFI_FW_TYPE_VSS), b'')
+
+
+class TestVariableStateFlags(unittest.TestCase):
+
+    def test_an_added_variable_reports_the_added_state(self):
+        self.assertTrue(varstore.IS_VARIABLE_STATE(0x3F, varstore.VAR_ADDED))
+
+    def test_a_fully_erased_variable_reports_no_state(self):
+        self.assertFalse(varstore.IS_VARIABLE_STATE(0xFF, varstore.VAR_ADDED))
+
+    def test_a_deleted_variable_reports_the_deleted_state(self):
+        self.assertTrue(varstore.IS_VARIABLE_STATE(0x3D, varstore.VAR_DELETED))
+
+
+class TestVariableReporting(unittest.TestCase):
+
+    def setUp(self):
+        self.variables = varstore.getEFIvariables_VSS(vss_store(vss_variable(name='ZVar'),
+                                                                vss_variable(name='AVar')))
+
+    def test_printing_a_variable_does_not_raise(self):
+        offset, buf, header, data, guid, attrs = self.variables['AVar'][0]
+
+        varstore.print_efi_variable(offset, buf, header, 'AVar', data, guid, attrs)
+
+    def test_printing_a_variable_without_a_header_does_not_raise(self):
+        varstore.print_efi_variable(0, b'', None, 'AVar', b'\x00', str(VENDOR_GUID), 0x7)
+
+    def test_printing_every_variable_does_not_raise(self):
+        varstore.print_sorted_EFI_variables(self.variables)
+
+    def test_decoding_writes_one_file_per_variable(self):
+        with tempfile.TemporaryDirectory() as path:
+            varstore.decode_EFI_variables(self.variables, path)
+
+            self.assertEqual(len(os.listdir(path)), 2)
+
+    def test_decoded_file_names_include_the_variable_name_and_guid(self):
+        with tempfile.TemporaryDirectory() as path:
+            varstore.decode_EFI_variables(self.variables, path)
+
+            names = os.listdir(path)
+            self.assertTrue(any(n.startswith('AVar_') for n in names))
+            self.assertTrue(all(str(VENDOR_GUID).upper() in n.upper() for n in names))
+
+
+class TestEndToEndParsing(unittest.TestCase):
+
+    def test_a_rom_image_is_parsed_into_variable_files(self):
+        rom = b'\xFF' * 32 + vss_store(vss_variable(name='TestVar'))
+        with tempfile.TemporaryDirectory() as path:
+            fname = os.path.join(path, 'rom.bin')
+
+            self.assertTrue(varstore.parse_EFI_variables(fname, rom, False, FWType.EFI_FW_TYPE_VSS))
+
+            self.assertTrue(os.path.exists(f'{fname}.nvram.bin'))
+            self.assertTrue(os.path.isdir(f'{fname}.nvram.dir'))
+            self.assertEqual(len(os.listdir(f'{fname}.nvram.dir')), 1)
+
+    def test_an_unknown_firmware_type_is_rejected(self):
+        with tempfile.TemporaryDirectory() as path:
+            fname = os.path.join(path, 'rom.bin')
+
+            self.assertFalse(varstore.parse_EFI_variables(fname, vss_store(), False, 'not-a-type'))
+
+    def test_a_rom_image_without_nvram_is_reported(self):
+        with tempfile.TemporaryDirectory() as path:
+            fname = os.path.join(path, 'rom.bin')
+
+            self.assertFalse(varstore.parse_EFI_variables(fname, b'\xFF' * 256, False,
+                                                          FWType.EFI_FW_TYPE_VSS))
+
+
+class TestCertificateDatabases(unittest.TestCase):
+
+    def test_an_auth_certificate_list_is_split_into_entries(self):
+        cert = b'\xAB' * 16
+        name = utf16('certdb')
+        node = struct.pack(varstore.AUTH_CERT_DB_DATA, VENDOR_GUID_BYTES,
+                           varstore.AUTH_CERT_DB_DATA_size + len(name) + len(cert),
+                           len(name) // 2, len(cert)) + name + cert
+        db = struct.pack(varstore.AUTH_CERT_DB_LIST_HEAD,
+                         varstore.AUTH_CERT_DB_LIST_HEAD_size + len(node)) + node
+
+        with tempfile.TemporaryDirectory() as path:
+            entries = varstore.parse_auth_var(db, path)
+
+            self.assertEqual(entries, [cert])
+            self.assertEqual(len(os.listdir(path)), 1)
+
+    def test_an_empty_auth_list_yields_no_entries(self):
+        with tempfile.TemporaryDirectory() as path:
+            self.assertEqual(varstore.parse_auth_var(b'\x00\x00', path), [])
+
+    def test_an_auth_list_with_a_wrong_size_is_rejected(self):
+        with tempfile.TemporaryDirectory() as path:
+            db = struct.pack(varstore.AUTH_CERT_DB_LIST_HEAD, 0x100) + b'\x00' * 32
+
+            self.assertEqual(varstore.parse_auth_var(db, path), [])
+
+    def test_an_esal_database_is_split_into_fixed_size_keys(self):
+        db = b'\x01' * varstore.ESAL_SIG_SIZE + b'\x02' * varstore.ESAL_SIG_SIZE
+
+        with tempfile.TemporaryDirectory() as path:
+            entries = varstore.parse_esal_var(db, path)
+
+            self.assertEqual(len(entries), 2)
+            self.assertEqual(entries[0], b'\x01' * varstore.ESAL_SIG_SIZE)
+            self.assertEqual(len(os.listdir(path)), 2)
+
+    def test_an_esal_database_smaller_than_one_key_yields_nothing(self):
+        with tempfile.TemporaryDirectory() as path:
+            self.assertEqual(varstore.parse_esal_var(b'\x01' * 8, path), [])
+
+    def test_an_unsupported_variable_type_is_reported(self):
+        with tempfile.TemporaryDirectory() as path:
+            fname = os.path.join(path, 'var.bin')
+
+            varstore.parse_efivar_file(fname, b'\x00' * 16, var_type=99)
+
+            self.assertTrue(os.path.isdir(f'{fname}.dir'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/library/uefi/test_varstore_nvram.py
+++ b/tests/library/uefi/test_varstore_nvram.py
@@ -298,7 +298,16 @@ class TestNVARVariableExtraction(unittest.TestCase):
         self.assertEqual(header.TotalSize, total)
         self.assertEqual(attrs, 0x7)
         self.assertEqual(len(buf), total)
-        self.assertTrue(parsed.endswith(data))
+        self.assertEqual(parsed, data)
+
+    def test_a_name_without_a_terminator_is_rejected(self):
+        signature = struct.unpack('=I', varstore.NVAR_EFIvar_signature)[0]
+        total = varstore.NVAR_HDR_SIZE + 8
+        entry = struct.pack(
+            varstore.NVAR_HDR_FMT, signature, total, 0, 0, 0, 0x7, 0x7F)
+
+        self.assertEqual(
+            varstore.getEFIvariables_NVAR_simple(entry + b'NoNull!!'), {})
 
     def test_an_empty_buffer_yields_nothing(self):
         self.assertEqual(varstore.getEFIvariables_NVAR_simple(b'\x00' * 32), {})
@@ -428,7 +437,27 @@ class TestCertificateDatabases(unittest.TestCase):
             entries = varstore.parse_auth_var(db, path)
 
             self.assertEqual(entries, [cert])
-            self.assertEqual(len(os.listdir(path)), 1)
+            expected_name = f'{str(VENDOR_GUID).upper()}-certdb-00.bin'
+            self.assertEqual(os.listdir(path), [expected_name])
+            with open(os.path.join(path, expected_name), 'rb') as cert_file:
+                self.assertEqual(cert_file.read(), cert)
+
+    def test_auth_certificate_filename_replaces_unsafe_characters(self):
+        cert = b'\xAB' * 16
+        name = utf16('cert:db/name')
+        node = struct.pack(
+            varstore.AUTH_CERT_DB_DATA, VENDOR_GUID_BYTES,
+            varstore.AUTH_CERT_DB_DATA_size + len(name) + len(cert),
+            len(name) // 2, len(cert)) + name + cert
+        db = struct.pack(
+            varstore.AUTH_CERT_DB_LIST_HEAD,
+            varstore.AUTH_CERT_DB_LIST_HEAD_size + len(node)) + node
+
+        with tempfile.TemporaryDirectory() as path:
+            varstore.parse_auth_var(db, path)
+
+            expected_name = f'{str(VENDOR_GUID).upper()}-cert_db_name-00.bin'
+            self.assertEqual(os.listdir(path), [expected_name])
 
     def test_an_empty_auth_list_yields_no_entries(self):
         with tempfile.TemporaryDirectory() as path:

--- a/tests/library/uefi/test_varstore_nvram.py
+++ b/tests/library/uefi/test_varstore_nvram.py
@@ -309,6 +309,22 @@ class TestNVARVariableExtraction(unittest.TestCase):
         self.assertEqual(
             varstore.getEFIvariables_NVAR_simple(entry + b'NoNull!!'), {})
 
+    def test_name_terminator_search_does_not_cross_entry_boundary(self):
+        signature = struct.unpack('=I', varstore.NVAR_EFIvar_signature)[0]
+        malformed_size = varstore.NVAR_HDR_SIZE + 8
+        malformed = struct.pack(
+            varstore.NVAR_HDR_FMT, signature, malformed_size,
+            0, 0, 0, 0x7, 0x7F) + b'NoNull!!'
+        valid_name = b'Valid\x00'
+        valid_data = b'\x01\x02'
+        valid_size = varstore.NVAR_HDR_SIZE + len(valid_name) + len(valid_data)
+        valid = struct.pack(
+            varstore.NVAR_HDR_FMT, signature, valid_size,
+            0, 0, 0, 0x7, 0x7F) + valid_name + valid_data
+
+        self.assertEqual(
+            varstore.getEFIvariables_NVAR_simple(malformed + valid), {})
+
     def test_an_empty_buffer_yields_nothing(self):
         self.assertEqual(varstore.getEFIvariables_NVAR_simple(b'\x00' * 32), {})
 

--- a/tests/modules/run_chipsec_module.py
+++ b/tests/modules/run_chipsec_module.py
@@ -19,7 +19,7 @@
 #
 
 
-from typing import List
+from typing import List, Sequence, Tuple
 from unittest.mock import Mock
 
 import chipsec.helper.replay.replayhelper as rph
@@ -56,6 +56,64 @@ def setup_run_destroy_module_with_mock_logger_output(init_replay_file: str, modu
 def setup_run_destroy_module_with_mock_logger(init_replay_file: str, module_str: str, module_args: str = "", module_replay_file: str = "") -> int:
     retval, _ = setup_run_destroy_module_with_mock_logger_output(init_replay_file, module_str, module_args, module_replay_file)
     return retval
+
+
+def setup_run_destroy_modules_with_mock_logger_output(
+        init_replay_file: str,
+        module_runs: List[Tuple[str, str, str]],
+    logging_functions_to_capture: Sequence[str] = ('log', 'log_error')
+) -> List[Tuple[int, str]]:
+    if not module_runs:
+        return []
+
+    chipsec.library.logger._logger.remove_chipsec_logger()
+    chipsec.library.logger._logger = Mock()
+    chipsec.library.logger._logger.VERBOSE = False
+    chipsec.library.logger._logger.DEBUG = False
+    chipsec.library.logger._logger.HAL = False
+    results = []
+
+    try:
+        module_str, module_args, _ = module_runs[0]
+        arg_str = f" {module_args}" if module_args else ""
+        cli_cmds = f"-m {module_str}{arg_str}".strip().split(' ')
+        cs._chipset = None
+        seed = ChipsecMain(parse_args(cli_cmds), cli_cmds)
+        replay_helper = rph.ReplayHelper(init_replay_file)
+        seed._helper = replay_helper
+        seed._cs.init(
+            seed._platform, seed._pch, replay_helper, not seed._no_driver,
+            seed._load_config, seed._ignore_platform)
+
+        for module_str, module_args, module_replay_file in module_runs:
+            arg_str = f" {module_args}" if module_args else ""
+            cli_cmds = f"-m {module_str}{arg_str}".strip().split(' ')
+            csm = ChipsecMain(parse_args(cli_cmds), cli_cmds)
+            csm._helper = replay_helper
+
+            if module_replay_file:
+                replay_helper.config_file = module_replay_file
+                replay_helper._load()
+
+            csm.load_module(module_str, csm._module_argv)
+            call_offsets = {
+                name: len(getattr(chipsec.library.logger._logger, name).mock_calls)
+                for name in logging_functions_to_capture
+                if hasattr(chipsec.library.logger._logger, name)
+            }
+            retval = csm.run_loaded_modules()
+            logger_calls = []
+            for name, offset in call_offsets.items():
+                logger_calls.extend(
+                    getattr(chipsec.library.logger._logger, name).mock_calls[offset:])
+            results.append((
+                retval,
+                "\n ---".join(str(call.args[0]) for call in logger_calls)))
+    finally:
+        clear_cs()
+        chipsec.library.logger._logger = chipsec.library.logger.Logger()
+
+    return results
 
 def setup_run_destroy_module(init_replay_file: str, module_str: str, module_args: str = "", module_replay_file: str = "") -> int:
     arg_str = f" {module_args}" if module_args else ""

--- a/tests/modules/run_chipsec_module.py
+++ b/tests/modules/run_chipsec_module.py
@@ -24,7 +24,6 @@ from unittest.mock import Mock
 
 import chipsec.helper.replay.replayhelper as rph
 from chipsec_main import ChipsecMain, parse_args
-from chipsec.chipset import clear_cs
 import chipsec.chipset as cs
 import chipsec.library.logger
 
@@ -49,7 +48,7 @@ def setup_run_destroy_module_with_mock_logger_output(init_replay_file: str, modu
     for func in logging_fucntions_to_capture:
         if hasattr(chipsec.library.logger._logger, func):
             logger_calls += getattr(chipsec.library.logger._logger, func).mock_calls
-    clear_cs()
+    cs.clear_cs()
     chipsec.library.logger._logger = chipsec.library.logger.Logger()
     return retval, "\n ---".join([str(call.args[0]) for call in logger_calls])
 
@@ -110,7 +109,7 @@ def setup_run_destroy_modules_with_mock_logger_output(
                 retval,
                 "\n ---".join(str(call.args[0]) for call in logger_calls)))
     finally:
-        clear_cs()
+        cs.clear_cs()
         chipsec.library.logger._logger = chipsec.library.logger.Logger()
 
     return results
@@ -124,5 +123,5 @@ def setup_run_destroy_module(init_replay_file: str, module_str: str, module_args
     replayHelper = rph.ReplayHelper(init_replay_file)
     csm._helper = replayHelper
     chipsec_return = run_chipsec_module(csm, module_replay_file)
-    clear_cs()
+    cs.clear_cs()
     return chipsec_return

--- a/tests/modules/test_tgl_modules.py
+++ b/tests/modules/test_tgl_modules.py
@@ -25,7 +25,7 @@ import os
 
 from chipsec.library.file import get_main_dir
 from chipsec.testcase import ExitCode
-from tests.modules.run_chipsec_module import setup_run_destroy_module_with_mock_logger_output as run_util
+from tests.modules.run_chipsec_module import setup_run_destroy_modules_with_mock_logger_output as runmodules
 
 class TestTglModules(unittest.TestCase):
     def setUp(self) -> None:
@@ -35,86 +35,49 @@ class TestTglModules(unittest.TestCase):
     def derive_filename(self, module_name:str) -> str:
         return f"{module_name.replace('.', '-')}_test.json"
 
-    def run_and_test_module(self, module_name:str, expected_returncode:int) -> None:
-        test_recording = self.derive_filename(module_name)
-        replay_file = os.path.join(self.folder_path, test_recording)
-        retval, logstr = run_util(self.init_replay_file, module_name, module_replay_file=replay_file)
-        self.assertEqual(retval, expected_returncode, f"Module: {module_name} Expected: {expected_returncode} but got: {retval}\n{logstr}")
-                   
-    def test_tgl_module_bios_smi(self):
-        self.run_and_test_module("common.bios_smi", ExitCode.OK)
-    
-    def test_tgl_module_bios_ts(self):
-        self.run_and_test_module("common.bios_ts", ExitCode.OK)
-    
-    def test_tgl_module_bios_wp(self):
-        self.run_and_test_module("common.bios_wp", ExitCode.OK)
-        
-    def test_tgl_module_cpu_cpu_info(self):
-        self.run_and_test_module("common.cpu.cpu_info", ExitCode.INFORMATION)
-    
-    def test_tgl_module_cpu_ia_untrusted(self):
-        self.run_and_test_module("common.cpu.ia_untrusted", ExitCode.OK)
-        
-    def test_tgl_module_cpu_spectre_v2(self):
-        self.run_and_test_module("common.cpu.spectre_v2", ExitCode.OK)
-        
-    def test_tgl_module_debugenabled(self):
-        self.run_and_test_module("common.debugenabled", ExitCode.OK)
-        
-    def test_tgl_module_ia32cfg(self):
-        self.run_and_test_module("common.ia32cfg", ExitCode.OK)
-        
-    def test_tgl_module_memconfig(self):
-        self.run_and_test_module("common.memconfig", ExitCode.OK)
-        
-    def test_tgl_module_memlock(self):
-        self.run_and_test_module("common.memlock", ExitCode.NOTAPPLICABLE)
-    
-    def test_tgl_module_me_mfg_mode(self):
-        self.run_and_test_module("common.me_mfg_mode", ExitCode.OK)
-    
-    def test_tgl_module_remap(self):
-        self.run_and_test_module("common.remap", ExitCode.OK)
+    modules_results = [
+        ("common.bios_smi", ExitCode.OK),
+        ("common.bios_ts", ExitCode.OK),
+        ("common.bios_wp", ExitCode.OK),
+        ("common.cpu.cpu_info", ExitCode.INFORMATION),
+        ("common.cpu.ia_untrusted", ExitCode.OK),
+        ("common.cpu.spectre_v2", ExitCode.OK),
+        ("common.debugenabled", ExitCode.OK),
+        ("common.ia32cfg", ExitCode.OK),
+        ("common.memconfig", ExitCode.OK),
+        ("common.memlock", ExitCode.NOTAPPLICABLE),
+        ("common.me_mfg_mode", ExitCode.OK),
+        ("common.remap", ExitCode.OK),
+        ("common.rtclock", ExitCode.WARNING),
+        ("common.secureboot.variables", ExitCode.OK),
+        ("common.sgx_check", ExitCode.NOTAPPLICABLE),
+        ("common.smm_code_chk", ExitCode.OK),
+        ("common.smm_dma", ExitCode.OK),
+        ("common.smm", ExitCode.NOTAPPLICABLE),
+        ("common.smrr", ExitCode.OK),
+        ("common.spd_wd", ExitCode.OK),
+        ("common.spi_access", ExitCode.FAIL),
+        ("common.spi_desc", ExitCode.OK),
+        ("common.spi_fdopss", ExitCode.OK),
+        ("common.spi_lock", ExitCode.OK),
+        ("common.uefi.access_uefispec", ExitCode.OK),
+    ]
 
-    def test_tgl_module_rtclock(self):
-        self.run_and_test_module("common.rtclock", ExitCode.WARNING)
-        
-    def test_tgl_module_secureboot_variables(self):
-        self.run_and_test_module("common.secureboot.variables", ExitCode.OK)
-        
-    def test_tgl_module_sgx_check(self):
-        self.run_and_test_module("common.sgx_check", ExitCode.NOTAPPLICABLE)
-        
-    def test_tgl_module_smm_code_chk(self):
-        self.run_and_test_module("common.smm_code_chk", ExitCode.OK)
-    
-    def test_tgl_module_smm_dma(self):
-        self.run_and_test_module("common.smm_dma", ExitCode.OK)
-    
-    def test_tgl_module_smm(self):
-        self.run_and_test_module("common.smm", ExitCode.NOTAPPLICABLE)
-    
-    def test_tgl_module_smrr(self):
-        self.run_and_test_module("common.smrr", ExitCode.OK)
-    
-    def test_tgl_module_spd_wd(self):
-        self.run_and_test_module("common.spd_wd", ExitCode.OK)
-    
-    def test_tgl_module_spi_access(self):
-        self.run_and_test_module("common.spi_access", ExitCode.FAIL)
-    
-    def test_tgl_module_spi_desc(self):
-        self.run_and_test_module("common.spi_desc", ExitCode.OK)
-    
-    def test_tgl_module_spi_fdopss(self):
-        self.run_and_test_module("common.spi_fdopss", ExitCode.OK)
-    
-    def test_tgl_module_spi_lock(self):
-        self.run_and_test_module("common.spi_lock", ExitCode.OK)
-    
-    def test_tgl_module_uefi_access_uefispec(self):
-        self.run_and_test_module("common.uefi.access_uefispec", ExitCode.OK)
+    def test_tgl_modules(self):
+        module_runs = [
+            (module, '', os.path.join(
+                self.folder_path, self.derive_filename(module)))
+            for module, _ in self.modules_results
+        ]
+        results = runmodules(self.init_replay_file, module_runs)
+        failed = []
+        for (module, expected), (retval, module_output) in zip(
+                self.modules_results, results):
+            if retval != expected:
+                failed.append(
+                    f"{module}: expected {expected}, got {retval}\n{module_output}")
+
+        self.assertFalse(failed, "\n\n".join(failed))
 
     @unittest.skip("S3bootscript module was archived")
     def test_tgl_module_uefi_s3bootscript(self):

--- a/tests/software/mock_helper.py
+++ b/tests/software/mock_helper.py
@@ -19,6 +19,7 @@ import struct
 
 from chipsec.helper.basehelper import Helper
 from chipsec.library.exceptions import UnimplementedAPIError
+from tests.helpers.acpi_utils import build_rsdp
 from typing import Optional, TYPE_CHECKING
 if TYPE_CHECKING:
     from ctypes import Array
@@ -232,26 +233,11 @@ class ACPIHelper(TestHelper):
     RSDT_ADDRESS = 0x200
 
     def _create_rsdp(self):
-        rsdp = b""
-        if self.USE_RSDP_REV_0:
-            # Emulate initial version of RSDP described in ACPI v1.0
-            rsdp = (b"RSD PTR " +                            # Signature
-                    struct.pack("<B", 0x1) +                # Checksum
-                    b"TEST00" +                              # OEMID
-                    struct.pack("<B", 0x0) +                # Revision
-                    struct.pack("<I", self.RSDT_ADDRESS))   # RSDT Address
-        else:
-            # Emulate RSDP described in ACPI v2.0 onwards
-            rsdp = (b"RSD PTR " +                            # Signature
-                    struct.pack("<B", 0x1) +                # Checksum
-                    b"TEST00" +                              # OEMID
-                    struct.pack("<B", 0x2) +                # Revision
-                    struct.pack("<I", self.RSDT_ADDRESS) +  # RSDT Address
-                    struct.pack("<I", 0x24) +               # Length
-                    struct.pack("<Q", self.XSDT_ADDRESS) +  # XSDT Address
-                    struct.pack("<B", 0x0) +                # Extended Checksum
-                    b"AAA")                                  # Reserved
-        return rsdp
+        return build_rsdp(
+            revision=0 if self.USE_RSDP_REV_0 else 2,
+            rsdt_address=self.RSDT_ADDRESS,
+            xsdt_address=None if self.USE_RSDP_REV_0 else self.XSDT_ADDRESS,
+            oem_id=b'TEST00')
 
     def _create_generic_acpi_table_header(self, signature, length):
         return (signature +                  # Signature

--- a/tests/utilcmd/ec_cmd/test_ec_cmd.py
+++ b/tests/utilcmd/ec_cmd/test_ec_cmd.py
@@ -24,6 +24,7 @@ To execute: python[3] -m unittest tests.utilcmd.ec_cmd.test_ec_cmd
 
 import unittest
 import os
+from unittest.mock import patch
 
 from chipsec.library.file import get_main_dir
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
@@ -54,6 +55,8 @@ class TestEcUtilcmd(unittest.TestCase):
         retval = setup_run_destroy_util(init_replay_file, "ec", "write 0x2f 0x00", util_replay_file=ec_cmd_write_2f_0_replay_file)
         self.assertEqual(retval, ExitCode.OK)
 
+    @patch('chipsec.hal.common.ec.EC.read_idx',
+           new=lambda _ec, offset: offset & 0xFF)
     def test_index(self) -> None:
         init_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "adlenumerate.json")
         ec_cmd_index_replay_file = os.path.join(get_main_dir(), "tests", "utilcmd", "ec_cmd", "ec_cmd_index_1.json")

--- a/tests/utilcmd/iommu_cmd/test_iommu_cmd.py
+++ b/tests/utilcmd/iommu_cmd/test_iommu_cmd.py
@@ -29,6 +29,7 @@ from unittest.mock import patch
 from chipsec.library.acpi_tables import RSDP
 from chipsec.library.file import get_main_dir
 from chipsec.testcase import ExitCode
+from tests.helpers.acpi_utils import build_rsdp
 from tests.utilcmd.run_chipsec_util import setup_run_destroy_util
 
 class TestIommuUtilcmd(unittest.TestCase):
@@ -41,7 +42,10 @@ class TestIommuUtilcmd(unittest.TestCase):
     def mock_find_rsdp(self) -> None:
         # Mock the return value of _find_RSDP_in_EFI_config_table
         rsdp_pa = 0x56fa3014
-        rsdp_buf = b'RSD PTR \x93INTEL\x00\x02\x94\xf3\xf3V$\x00\x00\x00(\xf7\xf3V\x00\x00\x00\x00t\x00\x00\x00'
+        rsdp_buf = build_rsdp(
+            revision=2,
+            rsdt_address=0x56F3F394,
+            xsdt_address=0x56F3F728)
         rsdp = RSDP()
         rsdp.parse(rsdp_buf)
         return rsdp, rsdp_pa


### PR DESCRIPTION
Summary
Expanded behavior-focused unit coverage for several previously under-tested CHIPSEC components and fixed issues uncovered by those tests.

Changes

- Added comprehensive tests for:
  - ACPI table and AML parsing
  - Paging and address translation
  - SMBIOS discovery and decoding
  - UEFI variable stores and NVAR parsing
  - S3 boot-script parsing and encoding
  - Fuzzing primitives

- Fixed page expansion:
  - Avoids modifying the translation dictionary during iteration.
  - Correctly expands 1GB pages into 512 2MB pages.
  - Correctly expands 2MB pages into 512 4KB pages.
  - Rejects unsupported expansion sizes.

- Fixed simple NVAR parsing:
  - Excludes the variable name’s NUL terminator from returned data.
  - Rejects malformed entries without a name terminator.
  - Preserves the separate hardware-error-record path.

- Fixed APIC Platform Interrupt Sources parsing:
  - Corrected the binary format to include the I/O SAPIC vector field.

- Improved S3 boot-script handling:
  - Uses the bytes-aware buffer renderer for malformed payloads.
  - Added encoding support for PCI configuration read/write, SMBus execution, STALL, and TERMINATE operations.
  - Added semantic round-trip coverage for supported operations.

- Fixed fuzzing string corpus reuse:
  - String primitives now use the shared fuzz library rather than rebuilding or shadowing it per instance.
  - Per-instance `max_len` filtering does not alter the shared corpus.

Test optimization:
- Added batched CHIPSEC module execution
  - Added setup_run_destroy_modules_with_mock_logger_output() to tests/modules/run_chipsec_module.py.
  - Initializes CHIPSEC platform configuration once for a batch of modules.
  - Loads each module’s replay recording independently.
  - Creates a fresh ChipsecMain command context for each module.
  - Captures return codes and log output separately for each module.
  - Restores global CHIPSEC and logger state after the batch completes.
  - Retains the existing single-module runner APIs.

- Batched the public TGL module tests
  - Replaced 25 separate test methods with a declarative modules_results table.
  - Runs all active TGL modules through one shared platform initialization.
  - Continues to validate every module’s expected exit code.
  - Preserves module-specific log output in failure messages.
  - Keeps the archived S3 boot-script test explicitly skipped.
  - Reduced test_tgl_modules.py execution from approximately 2.05 seconds to 0.26 seconds.

- Optimized the EC index command test
  - Replaced 65,536 replay-helper and MagicMock I/O operations with a deterministic patched EC.read_idx().
  - Preserves the complete 64KB index iteration and output path.
  - Reduced the EC index test from approximately 4.47 seconds to 0.04 seconds.