### PR TITLE
Merged codeql updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,6 +53,6 @@ jobs:
           make
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get install -qqy nasm
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality


### PR DESCRIPTION
Unified pull request combining the changes from:

- #2860 — Bump github/codeql-action/analyze from 4.37.8 to 4.37.9 (@dependabot[bot]) — https://github.com/chipsec/chipsec/pull/2860
- #2862 — Bump github/codeql-action/init from 4.37.8 to 4.37.9 (@dependabot[bot]) — https://github.com/chipsec/chipsec/pull/2862

Base branch: `chipsec2`

## Commits included

### From #2860
- `7cca0690` Bump github/codeql-action/analyze from 4.37.8 to 4.37.9

### From #2862
- `f1f0ef87` Bump github/codeql-action/init from 4.37.8 to 4.37.9

_Generated by `merge_prs.py`._